### PR TITLE
Auth: wire OIDC/OAuth2 provider

### DIFF
--- a/modules/auth/index.ts
+++ b/modules/auth/index.ts
@@ -21,3 +21,13 @@ export {
   type ApiKeyVerifier,
   type ServiceAccountManager,
 } from './contract.ts';
+
+export { createAuth, type AuthModule, type AuthDependencies } from './internal/create-auth.ts';
+export { createAuthMiddleware, type AuthMiddlewareOptions } from './internal/middleware.ts';
+export { createSystemPrincipal } from './internal/system.ts';
+export { loadAuthConfig, type AuthConfig, type AuthMode } from './internal/config.ts';
+export { createOidcVerifier } from './internal/oidc-verifier.ts';
+export { createDevTokenVerifier, createDevApiKeyVerifier } from './internal/dev-verifier.ts';
+export { createApiKeyVerifier, type ServiceAccountStore, type ServiceAccountRecord } from './internal/apikey-verifier.ts';
+export { createServiceAccountManager, type ServiceAccountStorage } from './internal/service-accounts.ts';
+export { hashApiKey, generateApiKey } from './internal/hash.ts';

--- a/modules/auth/internal/apikey-verifier.test.ts
+++ b/modules/auth/internal/apikey-verifier.test.ts
@@ -1,0 +1,78 @@
+/** Contract: contracts/auth/rules.md */
+
+import { describe, it, expect } from 'vitest';
+import { createApiKeyVerifier, type ServiceAccountStore, type ServiceAccountRecord } from './apikey-verifier.ts';
+import { hashApiKey } from './hash.ts';
+
+function makeStore(records: ServiceAccountRecord[]): ServiceAccountStore {
+  return {
+    async findByKeyHash(keyHash: string) {
+      return records.find((r) => r.keyHash === keyHash) || null;
+    },
+  };
+}
+
+describe('API Key Verifier', () => {
+  const rawKey = 'test-api-key-abc123';
+  const keyHash = hashApiKey(rawKey);
+
+  const activeRecord: ServiceAccountRecord = {
+    id: 'sa-1',
+    keyHash,
+    displayName: 'Test Agent',
+    scopes: ['documents.read'],
+    revoked: false,
+  };
+
+  const revokedRecord: ServiceAccountRecord = {
+    ...activeRecord,
+    id: 'sa-2',
+    keyHash: hashApiKey('revoked-key'),
+    revoked: true,
+  };
+
+  it('resolves valid key to agent principal', async () => {
+    const verifier = createApiKeyVerifier(makeStore([activeRecord]));
+    const result = await verifier.verifyApiKey(rawKey);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.principal.actorType).toBe('agent');
+    expect(result.principal.id).toBe('sa-1');
+    expect(result.principal.displayName).toBe('Test Agent');
+    expect(result.principal.scopes).toEqual(['documents.read']);
+  });
+
+  it('rejects unknown key', async () => {
+    const verifier = createApiKeyVerifier(makeStore([activeRecord]));
+    const result = await verifier.verifyApiKey('unknown-key');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('KEY_INVALID');
+  });
+
+  it('rejects revoked key', async () => {
+    const verifier = createApiKeyVerifier(makeStore([revokedRecord]));
+    const result = await verifier.verifyApiKey('revoked-key');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('KEY_REVOKED');
+  });
+
+  it('rejects empty key', async () => {
+    const verifier = createApiKeyVerifier(makeStore([]));
+    const result = await verifier.verifyApiKey('');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('KEY_INVALID');
+  });
+
+  it('same key resolves to same id (stable identity)', async () => {
+    const verifier = createApiKeyVerifier(makeStore([activeRecord]));
+    const r1 = await verifier.verifyApiKey(rawKey);
+    const r2 = await verifier.verifyApiKey(rawKey);
+    expect(r1.ok && r2.ok).toBe(true);
+    if (r1.ok && r2.ok) {
+      expect(r1.principal.id).toBe(r2.principal.id);
+    }
+  });
+});

--- a/modules/auth/internal/apikey-verifier.ts
+++ b/modules/auth/internal/apikey-verifier.ts
@@ -1,0 +1,55 @@
+/** Contract: contracts/auth/rules.md */
+
+import type { ApiKeyVerifier, VerificationResult } from '../contract.ts';
+import { hashApiKey } from './hash.ts';
+
+/**
+ * Storage interface for service account lookups.
+ * Decoupled from the actual storage module to avoid circular deps.
+ */
+export type ServiceAccountRecord = {
+  id: string;
+  keyHash: string;
+  displayName: string;
+  scopes: string[];
+  revoked: boolean;
+};
+
+export type ServiceAccountStore = {
+  findByKeyHash(keyHash: string): Promise<ServiceAccountRecord | null>;
+};
+
+/**
+ * API key verifier. Hashes the incoming key and looks it up
+ * in the service account store. Resolved principals have actorType 'agent'.
+ */
+export function createApiKeyVerifier(store: ServiceAccountStore): ApiKeyVerifier {
+  return {
+    async verifyApiKey(apiKey: string): Promise<VerificationResult> {
+      if (!apiKey || typeof apiKey !== 'string') {
+        return { ok: false, error: { code: 'KEY_INVALID', message: 'API key is empty' } };
+      }
+
+      const keyHash = hashApiKey(apiKey);
+      const record = await store.findByKeyHash(keyHash);
+
+      if (!record) {
+        return { ok: false, error: { code: 'KEY_INVALID', message: 'API key not recognized' } };
+      }
+
+      if (record.revoked) {
+        return { ok: false, error: { code: 'KEY_REVOKED', message: 'API key has been revoked' } };
+      }
+
+      return {
+        ok: true,
+        principal: {
+          id: record.id,
+          actorType: 'agent',
+          displayName: record.displayName,
+          scopes: record.scopes,
+        },
+      };
+    },
+  };
+}

--- a/modules/auth/internal/config.test.ts
+++ b/modules/auth/internal/config.test.ts
@@ -1,0 +1,51 @@
+/** Contract: contracts/auth/rules.md */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { loadAuthConfig } from './config.ts';
+
+describe('loadAuthConfig', () => {
+  const origEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.AUTH_MODE;
+    delete process.env.OIDC_ISSUER;
+    delete process.env.OIDC_CLIENT_ID;
+    delete process.env.OIDC_AUDIENCE;
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, origEnv);
+  });
+
+  it('defaults to oidc mode', () => {
+    const cfg = loadAuthConfig();
+    expect(cfg.mode).toBe('oidc');
+  });
+
+  it('reads dev mode from AUTH_MODE', () => {
+    process.env.AUTH_MODE = 'dev';
+    const cfg = loadAuthConfig();
+    expect(cfg.mode).toBe('dev');
+  });
+
+  it('reads OIDC settings from env', () => {
+    process.env.OIDC_ISSUER = 'https://auth.example.com';
+    process.env.OIDC_CLIENT_ID = 'my-client';
+    process.env.OIDC_AUDIENCE = 'my-audience';
+    const cfg = loadAuthConfig();
+    expect(cfg.oidcIssuer).toBe('https://auth.example.com');
+    expect(cfg.oidcClientId).toBe('my-client');
+    expect(cfg.oidcAudience).toBe('my-audience');
+  });
+
+  it('defaults audience to clientId', () => {
+    process.env.OIDC_CLIENT_ID = 'client-x';
+    const cfg = loadAuthConfig();
+    expect(cfg.oidcAudience).toBe('client-x');
+  });
+
+  it('throws on invalid AUTH_MODE', () => {
+    process.env.AUTH_MODE = 'invalid';
+    expect(() => loadAuthConfig()).toThrow('Invalid AUTH_MODE');
+  });
+});

--- a/modules/auth/internal/config.ts
+++ b/modules/auth/internal/config.ts
@@ -1,0 +1,32 @@
+/** Contract: contracts/auth/rules.md */
+
+/**
+ * Auth module configuration, driven entirely by environment variables.
+ * AUTH_MODE controls which verification strategy is active.
+ */
+
+export type AuthMode = 'oidc' | 'dev';
+
+export type AuthConfig = {
+  mode: AuthMode;
+  /** OIDC issuer URL (e.g. https://keycloak.example.com/realms/opendesk) */
+  oidcIssuer: string;
+  /** OIDC client ID used for audience validation */
+  oidcClientId: string;
+  /** Optional: OIDC audience (defaults to clientId) */
+  oidcAudience: string;
+};
+
+export function loadAuthConfig(): AuthConfig {
+  const mode = (process.env.AUTH_MODE || 'oidc') as AuthMode;
+  if (mode !== 'oidc' && mode !== 'dev') {
+    throw new Error(`Invalid AUTH_MODE: ${mode}. Must be 'oidc' or 'dev'.`);
+  }
+
+  return {
+    mode,
+    oidcIssuer: process.env.OIDC_ISSUER || '',
+    oidcClientId: process.env.OIDC_CLIENT_ID || '',
+    oidcAudience: process.env.OIDC_AUDIENCE || process.env.OIDC_CLIENT_ID || '',
+  };
+}

--- a/modules/auth/internal/contract-compliance.test.ts
+++ b/modules/auth/internal/contract-compliance.test.ts
@@ -1,0 +1,63 @@
+/** Contract: contracts/auth/rules.md */
+
+/**
+ * Contract compliance tests — verify structural invariants
+ * that are testable via code-level audit.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const authModuleRoot = join(__dirname, '..');
+
+function getAllTsFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...getAllTsFiles(full));
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+describe('Contract Compliance', () => {
+  const sourceFiles = getAllTsFiles(authModuleRoot);
+
+  it('every source file has a contract header', () => {
+    for (const file of sourceFiles) {
+      const content = readFileSync(file, 'utf-8');
+      expect(content).toContain('Contract: contracts/auth/rules.md');
+    }
+  });
+
+  it('no source file imports from permissions module', () => {
+    for (const file of sourceFiles) {
+      const content = readFileSync(file, 'utf-8');
+      expect(content).not.toMatch(/from\s+['"].*permissions/);
+      expect(content).not.toMatch(/import.*permissions/);
+    }
+  });
+
+  it('no source file contains in-memory cache or session store', () => {
+    for (const file of sourceFiles) {
+      const content = readFileSync(file, 'utf-8');
+      // Should not have Map/WeakMap used for caching principals
+      expect(content).not.toMatch(/new Map<.*Principal/);
+      expect(content).not.toMatch(/sessionStore/i);
+      expect(content).not.toMatch(/cookie/i);
+    }
+  });
+
+  it('no source file exceeds 200 lines', () => {
+    for (const file of sourceFiles) {
+      const lines = readFileSync(file, 'utf-8').split('\n').length;
+      expect(lines, `${file} has ${lines} lines`).toBeLessThanOrEqual(200);
+    }
+  });
+});

--- a/modules/auth/internal/create-auth.ts
+++ b/modules/auth/internal/create-auth.ts
@@ -1,0 +1,69 @@
+/** Contract: contracts/auth/rules.md */
+
+import type { TokenVerifier, ApiKeyVerifier, ServiceAccountManager } from '../contract.ts';
+import { loadAuthConfig, type AuthConfig } from './config.ts';
+import { createOidcVerifier } from './oidc-verifier.ts';
+import { createDevTokenVerifier, createDevApiKeyVerifier } from './dev-verifier.ts';
+import { createApiKeyVerifier, type ServiceAccountStore } from './apikey-verifier.ts';
+import { createServiceAccountManager, type ServiceAccountStorage } from './service-accounts.ts';
+import { createAuthMiddleware, type AuthMiddlewareOptions } from './middleware.ts';
+import { createSystemPrincipal } from './system.ts';
+
+export type AuthModule = {
+  tokenVerifier: TokenVerifier;
+  apiKeyVerifier: ApiKeyVerifier;
+  serviceAccounts: ServiceAccountManager;
+  middleware: ReturnType<typeof createAuthMiddleware>;
+  systemPrincipal: ReturnType<typeof createSystemPrincipal>;
+  config: AuthConfig;
+};
+
+export type AuthDependencies = {
+  serviceAccountStore: ServiceAccountStore;
+  serviceAccountStorage: ServiceAccountStorage;
+  /** Paths that skip authentication */
+  publicPaths?: string[];
+};
+
+/**
+ * Factory function that wires up the entire auth module.
+ * Call once at application startup.
+ */
+export function createAuth(deps: AuthDependencies): AuthModule {
+  const config = loadAuthConfig();
+
+  let tokenVerifier: TokenVerifier;
+  let apiKeyVerifier: ApiKeyVerifier;
+
+  if (config.mode === 'dev') {
+    console.warn('[auth] Running in DEV mode — no real token verification');
+    tokenVerifier = createDevTokenVerifier();
+    apiKeyVerifier = createDevApiKeyVerifier();
+  } else {
+    if (!config.oidcIssuer) {
+      throw new Error('OIDC_ISSUER is required when AUTH_MODE is not "dev"');
+    }
+    if (!config.oidcClientId) {
+      throw new Error('OIDC_CLIENT_ID is required when AUTH_MODE is not "dev"');
+    }
+    tokenVerifier = createOidcVerifier(config);
+    apiKeyVerifier = createApiKeyVerifier(deps.serviceAccountStore);
+  }
+
+  const serviceAccounts = createServiceAccountManager(deps.serviceAccountStorage);
+
+  const middlewareOpts: AuthMiddlewareOptions = {
+    tokenVerifier,
+    apiKeyVerifier,
+    publicPaths: deps.publicPaths,
+  };
+
+  return {
+    tokenVerifier,
+    apiKeyVerifier,
+    serviceAccounts,
+    middleware: createAuthMiddleware(middlewareOpts),
+    systemPrincipal: createSystemPrincipal(),
+    config,
+  };
+}

--- a/modules/auth/internal/dev-verifier.test.ts
+++ b/modules/auth/internal/dev-verifier.test.ts
@@ -1,0 +1,91 @@
+/** Contract: contracts/auth/rules.md */
+
+import { describe, it, expect } from 'vitest';
+import { createDevTokenVerifier, createDevApiKeyVerifier } from './dev-verifier.ts';
+
+describe('Dev Token Verifier', () => {
+  const verifier = createDevTokenVerifier();
+
+  it('accepts bare "dev" token as default user', async () => {
+    const result = await verifier.verifyToken('dev');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.principal.actorType).toBe('human');
+    expect(result.principal.id).toBe('dev-user');
+    expect(result.principal.scopes).toContain('*');
+  });
+
+  it('accepts dev:<id>:<name>:<scopes> format', async () => {
+    const result = await verifier.verifyToken('dev:u42:Alice:read,write');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.principal.id).toBe('u42');
+    expect(result.principal.actorType).toBe('human');
+    expect(result.principal.displayName).toBe('Alice');
+    expect(result.principal.scopes).toEqual(['read', 'write']);
+  });
+
+  it('accepts dev:<id>:<name> without scopes, defaults to *', async () => {
+    const result = await verifier.verifyToken('dev:u1:Bob');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.principal.scopes).toEqual(['*']);
+  });
+
+  it('rejects empty token', async () => {
+    const result = await verifier.verifyToken('');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('TOKEN_MALFORMED');
+  });
+
+  it('rejects non-dev-prefixed token', async () => {
+    const result = await verifier.verifyToken('some.jwt.token');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('TOKEN_MALFORMED');
+  });
+
+  it('rejects dev: with too few parts', async () => {
+    const result = await verifier.verifyToken('dev:onlyid');
+    expect(result.ok).toBe(false);
+  });
+
+  it('always produces actorType "human"', async () => {
+    const tokens = ['dev', 'dev:a:A', 'dev:b:B:read'];
+    for (const t of tokens) {
+      const result = await verifier.verifyToken(t);
+      if (result.ok) {
+        expect(result.principal.actorType).toBe('human');
+      }
+    }
+  });
+
+  it('same token always resolves to same id (stable identity)', async () => {
+    const r1 = await verifier.verifyToken('dev:x:X');
+    const r2 = await verifier.verifyToken('dev:x:X');
+    expect(r1.ok && r2.ok).toBe(true);
+    if (r1.ok && r2.ok) {
+      expect(r1.principal.id).toBe(r2.principal.id);
+    }
+  });
+});
+
+describe('Dev API Key Verifier', () => {
+  const verifier = createDevApiKeyVerifier();
+
+  it('accepts devkey:<id> format', async () => {
+    const result = await verifier.verifyApiKey('devkey:bot1');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.principal.actorType).toBe('agent');
+    expect(result.principal.id).toBe('agent-bot1');
+  });
+
+  it('rejects non-devkey-prefixed key', async () => {
+    const result = await verifier.verifyApiKey('randomkey123');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('KEY_INVALID');
+  });
+});

--- a/modules/auth/internal/dev-verifier.ts
+++ b/modules/auth/internal/dev-verifier.ts
@@ -1,0 +1,82 @@
+/** Contract: contracts/auth/rules.md */
+
+import type { TokenVerifier, VerificationResult, ApiKeyVerifier } from '../contract.ts';
+
+/**
+ * Dev-mode token verifier. When AUTH_MODE=dev, this accepts
+ * bearer tokens in the format "dev:<id>:<displayName>:<scopes>"
+ * (e.g., "dev:user1:Alice:read,write") and resolves them
+ * without cryptographic verification.
+ *
+ * Also accepts a simple "dev" token that creates a default user.
+ * NEVER use in production.
+ */
+export function createDevTokenVerifier(): TokenVerifier {
+  return {
+    async verifyToken(token: string): Promise<VerificationResult> {
+      if (!token || typeof token !== 'string') {
+        return { ok: false, error: { code: 'TOKEN_MALFORMED', message: 'Token is empty' } };
+      }
+
+      if (token === 'dev') {
+        return {
+          ok: true,
+          principal: {
+            id: 'dev-user',
+            actorType: 'human',
+            displayName: 'Dev User',
+            email: 'dev@opendesk.local',
+            scopes: ['*'],
+          },
+        };
+      }
+
+      if (!token.startsWith('dev:')) {
+        return { ok: false, error: { code: 'TOKEN_MALFORMED', message: 'Dev token must start with "dev:"' } };
+      }
+
+      const parts = token.split(':');
+      if (parts.length < 3) {
+        return { ok: false, error: { code: 'TOKEN_MALFORMED', message: 'Dev token format: dev:<id>:<name>[:<scopes>]' } };
+      }
+
+      const [, id, displayName, scopeStr] = parts;
+      const scopes = scopeStr ? scopeStr.split(',').filter(Boolean) : ['*'];
+
+      return {
+        ok: true,
+        principal: {
+          id: id!,
+          actorType: 'human',
+          displayName: displayName!,
+          email: `${id}@opendesk.local`,
+          scopes,
+        },
+      };
+    },
+  };
+}
+
+/**
+ * Dev-mode API key verifier. Accepts any key prefixed with "devkey:".
+ */
+export function createDevApiKeyVerifier(): ApiKeyVerifier {
+  return {
+    async verifyApiKey(apiKey: string): Promise<VerificationResult> {
+      if (!apiKey.startsWith('devkey:')) {
+        return { ok: false, error: { code: 'KEY_INVALID', message: 'Invalid dev API key' } };
+      }
+
+      const id = apiKey.slice('devkey:'.length);
+      return {
+        ok: true,
+        principal: {
+          id: `agent-${id}`,
+          actorType: 'agent',
+          displayName: `Dev Agent ${id}`,
+          scopes: ['*'],
+        },
+      };
+    },
+  };
+}

--- a/modules/auth/internal/hash.test.ts
+++ b/modules/auth/internal/hash.test.ts
@@ -1,0 +1,37 @@
+/** Contract: contracts/auth/rules.md */
+
+import { describe, it, expect } from 'vitest';
+import { generateApiKey, hashApiKey } from './hash.ts';
+
+describe('generateApiKey', () => {
+  it('produces a 64-char hex string', () => {
+    const key = generateApiKey();
+    expect(key).toHaveLength(64);
+    expect(key).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('produces unique keys', () => {
+    const keys = new Set(Array.from({ length: 20 }, () => generateApiKey()));
+    expect(keys.size).toBe(20);
+  });
+});
+
+describe('hashApiKey', () => {
+  it('produces a 64-char hex string (SHA-256)', () => {
+    const hash = hashApiKey('test-key');
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('is deterministic', () => {
+    const h1 = hashApiKey('same-key');
+    const h2 = hashApiKey('same-key');
+    expect(h1).toBe(h2);
+  });
+
+  it('hash differs from raw key', () => {
+    const raw = generateApiKey();
+    const hash = hashApiKey(raw);
+    expect(hash).not.toBe(raw);
+  });
+});

--- a/modules/auth/internal/hash.ts
+++ b/modules/auth/internal/hash.ts
@@ -1,0 +1,19 @@
+/** Contract: contracts/auth/rules.md */
+
+import { createHash, randomBytes } from 'node:crypto';
+
+/**
+ * Generate a cryptographically random API key.
+ * Returns the raw key string (hex-encoded).
+ */
+export function generateApiKey(): string {
+  return randomBytes(32).toString('hex');
+}
+
+/**
+ * Hash an API key using SHA-256.
+ * Used before storing — raw keys are never persisted.
+ */
+export function hashApiKey(rawKey: string): string {
+  return createHash('sha256').update(rawKey).digest('hex');
+}

--- a/modules/auth/internal/middleware.test.ts
+++ b/modules/auth/internal/middleware.test.ts
@@ -1,0 +1,101 @@
+/** Contract: contracts/auth/rules.md */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createAuthMiddleware } from './middleware.ts';
+import type { TokenVerifier, ApiKeyVerifier, Principal } from '../contract.ts';
+import type { Request, Response, NextFunction } from 'express';
+
+function mockReq(headers: Record<string, string> = {}, path = '/api/test'): Partial<Request> {
+  return { headers, path };
+}
+
+function mockRes(): Partial<Response> & { statusCode: number; body: unknown } {
+  const res = {
+    statusCode: 200,
+    body: null as unknown,
+    status(code: number) { res.statusCode = code; return res as unknown as Response; },
+    json(data: unknown) { res.body = data; return res as unknown as Response; },
+  };
+  return res;
+}
+
+const humanPrincipal: Principal = {
+  id: 'u1', actorType: 'human', displayName: 'Test', scopes: ['read'],
+};
+
+const agentPrincipal: Principal = {
+  id: 'a1', actorType: 'agent', displayName: 'Bot', scopes: ['*'],
+};
+
+const okToken: TokenVerifier = {
+  async verifyToken() { return { ok: true, principal: humanPrincipal }; },
+};
+
+const failToken: TokenVerifier = {
+  async verifyToken() { return { ok: false, error: { code: 'TOKEN_INVALID', message: 'bad' } }; },
+};
+
+const okKey: ApiKeyVerifier = {
+  async verifyApiKey() { return { ok: true, principal: agentPrincipal }; },
+};
+
+const failKey: ApiKeyVerifier = {
+  async verifyApiKey() { return { ok: false, error: { code: 'KEY_INVALID', message: 'bad' } }; },
+};
+
+describe('Auth Middleware', () => {
+  it('passes through public paths without auth', async () => {
+    const mw = createAuthMiddleware({ tokenVerifier: failToken, apiKeyVerifier: failKey, publicPaths: ['/api/health'] });
+    const req = mockReq({}, '/api/health');
+    const res = mockRes();
+    const next = vi.fn();
+    await mw(req as Request, res as unknown as Response, next as NextFunction);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('resolves API key via X-Api-Key header', async () => {
+    const mw = createAuthMiddleware({ tokenVerifier: failToken, apiKeyVerifier: okKey });
+    const req = mockReq({ 'x-api-key': 'some-key' });
+    const next = vi.fn();
+    await mw(req as Request, mockRes() as unknown as Response, next as NextFunction);
+    expect(next).toHaveBeenCalled();
+    expect((req as Request).principal).toEqual(agentPrincipal);
+  });
+
+  it('resolves Bearer token', async () => {
+    const mw = createAuthMiddleware({ tokenVerifier: okToken, apiKeyVerifier: failKey });
+    const req = mockReq({ authorization: 'Bearer tok123' });
+    const next = vi.fn();
+    await mw(req as Request, mockRes() as unknown as Response, next as NextFunction);
+    expect(next).toHaveBeenCalled();
+    expect((req as Request).principal).toEqual(humanPrincipal);
+  });
+
+  it('returns 401 for invalid Bearer token', async () => {
+    const mw = createAuthMiddleware({ tokenVerifier: failToken, apiKeyVerifier: failKey });
+    const req = mockReq({ authorization: 'Bearer bad' });
+    const res = mockRes();
+    const next = vi.fn();
+    await mw(req as Request, res as unknown as Response, next as NextFunction);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 when no credentials provided', async () => {
+    const mw = createAuthMiddleware({ tokenVerifier: okToken, apiKeyVerifier: okKey });
+    const req = mockReq({});
+    const res = mockRes();
+    const next = vi.fn();
+    await mw(req as Request, res as unknown as Response, next as NextFunction);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('prefers API key over Bearer token', async () => {
+    const mw = createAuthMiddleware({ tokenVerifier: okToken, apiKeyVerifier: okKey });
+    const req = mockReq({ 'x-api-key': 'key', authorization: 'Bearer tok' });
+    const next = vi.fn();
+    await mw(req as Request, mockRes() as unknown as Response, next as NextFunction);
+    expect((req as Request).principal?.actorType).toBe('agent');
+  });
+});

--- a/modules/auth/internal/middleware.ts
+++ b/modules/auth/internal/middleware.ts
@@ -1,0 +1,72 @@
+/** Contract: contracts/auth/rules.md */
+
+import type { Request, Response, NextFunction } from 'express';
+import type { Principal, TokenVerifier, ApiKeyVerifier } from '../contract.ts';
+
+/**
+ * Extend Express Request to carry the resolved Principal.
+ */
+declare global {
+  namespace Express {
+    interface Request {
+      principal?: Principal;
+    }
+  }
+}
+
+export type AuthMiddlewareOptions = {
+  tokenVerifier: TokenVerifier;
+  apiKeyVerifier: ApiKeyVerifier;
+  /** Paths that skip authentication (e.g. /api/health) */
+  publicPaths?: string[];
+};
+
+/**
+ * Express middleware that extracts credentials from the request,
+ * verifies them, and populates req.principal.
+ *
+ * Credentials are checked in order:
+ * 1. X-Api-Key header -> API key verification
+ * 2. Authorization: Bearer <token> -> Token verification
+ *
+ * No caching — each request re-verifies (contract invariant).
+ */
+export function createAuthMiddleware(opts: AuthMiddlewareOptions) {
+  const publicPaths = new Set(opts.publicPaths || []);
+
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    if (publicPaths.has(req.path)) {
+      next();
+      return;
+    }
+
+    const apiKey = req.headers['x-api-key'];
+    if (typeof apiKey === 'string' && apiKey.length > 0) {
+      const result = await opts.apiKeyVerifier.verifyApiKey(apiKey);
+      if (result.ok) {
+        req.principal = result.principal;
+        next();
+        return;
+      }
+      res.status(401).json({ error: result.error });
+      return;
+    }
+
+    const authHeader = req.headers.authorization;
+    if (typeof authHeader === 'string' && authHeader.startsWith('Bearer ')) {
+      const token = authHeader.slice(7);
+      const result = await opts.tokenVerifier.verifyToken(token);
+      if (result.ok) {
+        req.principal = result.principal;
+        next();
+        return;
+      }
+      res.status(401).json({ error: result.error });
+      return;
+    }
+
+    res.status(401).json({
+      error: { code: 'TOKEN_INVALID', message: 'No credentials provided' },
+    });
+  };
+}

--- a/modules/auth/internal/oidc-verifier.ts
+++ b/modules/auth/internal/oidc-verifier.ts
@@ -1,0 +1,107 @@
+/** Contract: contracts/auth/rules.md */
+
+import * as jose from 'jose';
+import type { TokenVerifier, VerificationResult } from '../contract.ts';
+import type { AuthConfig } from './config.ts';
+
+/**
+ * OIDC token verifier. Discovers the provider's JWKS and validates
+ * JWT bearer tokens. Resolved principals always have actorType 'human'.
+ *
+ * No caching of principals across requests (contract invariant).
+ * JWKS caching is handled internally by jose.
+ */
+export function createOidcVerifier(config: AuthConfig): TokenVerifier {
+  let jwks: ReturnType<typeof jose.createRemoteJWKSet> | null = null;
+
+  async function getJwks(): Promise<ReturnType<typeof jose.createRemoteJWKSet>> {
+    if (jwks) return jwks;
+    const issuerUrl = config.oidcIssuer.replace(/\/$/, '');
+    const discoveryUrl = `${issuerUrl}/.well-known/openid-configuration`;
+
+    let discovery: { jwks_uri: string };
+    try {
+      const res = await fetch(discoveryUrl);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      discovery = (await res.json()) as { jwks_uri: string };
+    } catch {
+      throw new ProviderUnreachableError(issuerUrl);
+    }
+
+    jwks = jose.createRemoteJWKSet(new URL(discovery.jwks_uri));
+    return jwks;
+  }
+
+  return {
+    async verifyToken(token: string): Promise<VerificationResult> {
+      if (!token || typeof token !== 'string') {
+        return { ok: false, error: { code: 'TOKEN_MALFORMED', message: 'Token is empty or not a string' } };
+      }
+
+      let keySet: ReturnType<typeof jose.createRemoteJWKSet>;
+      try {
+        keySet = await getJwks();
+      } catch (err) {
+        if (err instanceof ProviderUnreachableError) {
+          return { ok: false, error: { code: 'PROVIDER_UNREACHABLE', message: err.message } };
+        }
+        return { ok: false, error: { code: 'PROVIDER_UNREACHABLE', message: 'Failed to fetch JWKS' } };
+      }
+
+      try {
+        const { payload } = await jose.jwtVerify(token, keySet, {
+          issuer: config.oidcIssuer,
+          audience: config.oidcAudience,
+        });
+
+        const id = (payload.sub as string) || '';
+        if (!id) {
+          return { ok: false, error: { code: 'TOKEN_INVALID', message: 'Token missing sub claim' } };
+        }
+
+        return {
+          ok: true,
+          principal: {
+            id,
+            actorType: 'human',
+            displayName: (payload.name as string) || (payload.preferred_username as string) || id,
+            email: (payload.email as string) || undefined,
+            scopes: parseScopeClaim(payload),
+          },
+        };
+      } catch (err) {
+        return { ok: false, error: classifyJoseError(err) };
+      }
+    },
+  };
+}
+
+function parseScopeClaim(payload: jose.JWTPayload): string[] {
+  if (typeof payload.scope === 'string') {
+    return payload.scope.split(' ').filter(Boolean);
+  }
+  if (Array.isArray(payload.scope)) {
+    return payload.scope.filter((s): s is string => typeof s === 'string');
+  }
+  return [];
+}
+
+function classifyJoseError(err: unknown): { code: 'TOKEN_EXPIRED' | 'TOKEN_INVALID' | 'TOKEN_MALFORMED'; message: string } {
+  if (err instanceof jose.errors.JWTExpired) {
+    return { code: 'TOKEN_EXPIRED', message: 'Token has expired' };
+  }
+  if (err instanceof jose.errors.JWTClaimValidationFailed) {
+    return { code: 'TOKEN_INVALID', message: `Claim validation failed: ${err.message}` };
+  }
+  if (err instanceof jose.errors.JWSSignatureVerificationFailed) {
+    return { code: 'TOKEN_INVALID', message: 'Signature verification failed' };
+  }
+  return { code: 'TOKEN_MALFORMED', message: `Invalid token: ${err instanceof Error ? err.message : 'unknown'}` };
+}
+
+class ProviderUnreachableError extends Error {
+  constructor(issuer: string) {
+    super(`OIDC provider unreachable: ${issuer}`);
+    this.name = 'ProviderUnreachableError';
+  }
+}

--- a/modules/auth/internal/service-accounts.test.ts
+++ b/modules/auth/internal/service-accounts.test.ts
@@ -1,0 +1,77 @@
+/** Contract: contracts/auth/rules.md */
+
+import { describe, it, expect } from 'vitest';
+import { createServiceAccountManager, type ServiceAccountStorage } from './service-accounts.ts';
+import { hashApiKey } from './hash.ts';
+import type { ServiceAccountRecord } from './apikey-verifier.ts';
+
+function makeStorage(): ServiceAccountStorage & { records: Map<string, ServiceAccountRecord & { createdAt: string }> } {
+  const records = new Map<string, ServiceAccountRecord & { createdAt: string }>();
+  return {
+    records,
+    async insertServiceAccount(record) {
+      records.set(record.id, record);
+    },
+    async findServiceAccountById(id) {
+      return records.get(id) || null;
+    },
+    async revokeServiceAccount(id) {
+      const record = records.get(id);
+      if (record) record.revoked = true;
+    },
+  };
+}
+
+describe('Service Account Manager', () => {
+  it('creates a service account and returns raw key', async () => {
+    const storage = makeStorage();
+    const manager = createServiceAccountManager(storage);
+
+    const sa = await manager.create({ displayName: 'Bot', scopes: ['read'] });
+    expect(sa.id).toBeTruthy();
+    expect(sa.apiKey).toHaveLength(64); // hex-encoded 32 bytes
+    expect(sa.displayName).toBe('Bot');
+    expect(sa.scopes).toEqual(['read']);
+    expect(sa.createdAt).toBeTruthy();
+  });
+
+  it('stores hashed key, not raw key', async () => {
+    const storage = makeStorage();
+    const manager = createServiceAccountManager(storage);
+
+    const sa = await manager.create({ displayName: 'Bot', scopes: [] });
+    const stored = storage.records.get(sa.id);
+    expect(stored).toBeTruthy();
+    expect(stored!.keyHash).toBe(hashApiKey(sa.apiKey));
+    expect(stored!.keyHash).not.toBe(sa.apiKey);
+  });
+
+  it('read returns masked key', async () => {
+    const storage = makeStorage();
+    const manager = createServiceAccountManager(storage);
+
+    const sa = await manager.create({ displayName: 'Bot', scopes: ['write'] });
+    const read = await manager.read(sa.id);
+    expect(read).toBeTruthy();
+    expect(read!.apiKey).toBe('***');
+    expect(read!.displayName).toBe('Bot');
+  });
+
+  it('read returns null for unknown id', async () => {
+    const storage = makeStorage();
+    const manager = createServiceAccountManager(storage);
+    const read = await manager.read('nonexistent');
+    expect(read).toBeNull();
+  });
+
+  it('revoke marks account as revoked', async () => {
+    const storage = makeStorage();
+    const manager = createServiceAccountManager(storage);
+
+    const sa = await manager.create({ displayName: 'Bot', scopes: [] });
+    await manager.revoke(sa.id);
+
+    const stored = storage.records.get(sa.id);
+    expect(stored!.revoked).toBe(true);
+  });
+});

--- a/modules/auth/internal/service-accounts.ts
+++ b/modules/auth/internal/service-accounts.ts
@@ -1,0 +1,63 @@
+/** Contract: contracts/auth/rules.md */
+
+import { randomUUID } from 'node:crypto';
+import type { ServiceAccountDef, ServiceAccount, ServiceAccountManager } from '../contract.ts';
+import { generateApiKey, hashApiKey } from './hash.ts';
+import type { ServiceAccountRecord } from './apikey-verifier.ts';
+
+/**
+ * Storage interface for service account persistence.
+ * Auth does not manage its own persistence (contract rule).
+ */
+export type ServiceAccountStorage = {
+  insertServiceAccount(record: ServiceAccountRecord & { createdAt: string }): Promise<void>;
+  findServiceAccountById(id: string): Promise<(ServiceAccountRecord & { createdAt: string }) | null>;
+  revokeServiceAccount(id: string): Promise<void>;
+};
+
+/**
+ * Service account manager. Handles create, read, revoke.
+ * API keys are hashed before storage; raw keys returned only at creation.
+ */
+export function createServiceAccountManager(
+  storage: ServiceAccountStorage,
+): ServiceAccountManager {
+  return {
+    async create(def: ServiceAccountDef): Promise<ServiceAccount> {
+      const id = randomUUID();
+      const rawKey = generateApiKey();
+      const keyHash = hashApiKey(rawKey);
+      const createdAt = new Date().toISOString();
+
+      await storage.insertServiceAccount({
+        id,
+        keyHash,
+        displayName: def.displayName,
+        scopes: def.scopes,
+        revoked: false,
+        createdAt,
+      });
+
+      // Raw key is returned exactly once — never stored or retrievable again
+      return { id, apiKey: rawKey, displayName: def.displayName, scopes: def.scopes, createdAt };
+    },
+
+    async read(id: string): Promise<ServiceAccount | null> {
+      const record = await storage.findServiceAccountById(id);
+      if (!record) return null;
+
+      // Never return the raw key after creation — return hash placeholder
+      return {
+        id: record.id,
+        apiKey: '***',
+        displayName: record.displayName,
+        scopes: record.scopes,
+        createdAt: record.createdAt,
+      };
+    },
+
+    async revoke(id: string): Promise<void> {
+      await storage.revokeServiceAccount(id);
+    },
+  };
+}

--- a/modules/auth/internal/system.test.ts
+++ b/modules/auth/internal/system.test.ts
@@ -1,0 +1,26 @@
+/** Contract: contracts/auth/rules.md */
+
+import { describe, it, expect } from 'vitest';
+import { createSystemPrincipal } from './system.ts';
+
+describe('createSystemPrincipal', () => {
+  it('creates a principal with actorType "system"', () => {
+    const p = createSystemPrincipal();
+    expect(p.actorType).toBe('system');
+    expect(p.id).toBe('system');
+    expect(p.displayName).toBe('System');
+    expect(p.scopes).toContain('*');
+  });
+
+  it('accepts custom id and scopes', () => {
+    const p = createSystemPrincipal('cron-job', ['documents.read']);
+    expect(p.id).toBe('cron-job');
+    expect(p.actorType).toBe('system');
+    expect(p.scopes).toEqual(['documents.read']);
+  });
+
+  it('principal is frozen (immutable)', () => {
+    const p = createSystemPrincipal();
+    expect(Object.isFrozen(p)).toBe(true);
+  });
+});

--- a/modules/auth/internal/system.ts
+++ b/modules/auth/internal/system.ts
@@ -1,0 +1,19 @@
+/** Contract: contracts/auth/rules.md */
+
+import type { Principal } from '../contract.ts';
+
+/**
+ * Creates a system principal for internal/automated operations.
+ * actorType is always 'system' per the contract.
+ */
+export function createSystemPrincipal(
+  id = 'system',
+  scopes: string[] = ['*'],
+): Principal {
+  return Object.freeze({
+    id,
+    actorType: 'system' as const,
+    displayName: 'System',
+    scopes: Object.freeze([...scopes]) as unknown as string[],
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@tiptap/starter-kit": "^3.22.2",
         "express": "^5.2.1",
         "ioredis": "^5.10.1",
+        "jose": "^6.2.2",
         "pg": "^8.20.0",
         "y-prosemirror": "^1.3.7",
         "yjs": "^13.6.30",
@@ -3278,6 +3279,15 @@
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@tiptap/starter-kit": "^3.22.2",
     "express": "^5.2.1",
     "ioredis": "^5.10.1",
+    "jose": "^6.2.2",
     "pg": "^8.20.0",
     "y-prosemirror": "^1.3.7",
     "yjs": "^13.6.30",


### PR DESCRIPTION
## Summary
- OIDC discovery + JWT verification via `jose` library
- `Principal` type with actorType (human/agent/system) and scopes
- API key support with SHA-256 hashed storage
- Express middleware populating `req.principal`
- Dev mode (`AUTH_MODE=dev`) for testing without a running OIDC provider
- 9 files, all under 200 lines, all with contract headers

## Test plan
- [ ] 43 new unit tests (verifier, middleware, service accounts, hashing, config, contract compliance)
- [ ] `npm run lint` clean
- [ ] `npm test` passes
- [ ] Review restricted zone: `modules/auth/`

⚠️ **Restricted zone** — requires human maintainer approval

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)