### PR TITLE
Collabora import/export integration

### DIFF
--- a/modules/api/internal/convert-routes.ts
+++ b/modules/api/internal/convert-routes.ts
@@ -1,0 +1,139 @@
+/** Contract: contracts/api/rules.md */
+
+/**
+ * API routes for document import/export via Collabora.
+ * Mounted at /api/documents/:id/convert-*.
+ */
+
+import { Router, raw, type Request, type Response } from 'express';
+import {
+  convertViaCollabora,
+  importViaCollabora,
+  detectImportFormat,
+  isValidExportFormat,
+  getExportMimeType,
+  getExportExtension,
+  CollaboraError,
+  ImportError,
+} from '../../convert/index.ts';
+import { getDocument } from '../../storage/internal/pg.ts';
+
+const MAX_UPLOAD_SIZE = 50 * 1024 * 1024; // 50 MB
+
+export function createConvertRoutes(): Router {
+  const router = Router();
+
+  router.post(
+    '/api/documents/:id/convert-import',
+    raw({ type: '*/*', limit: MAX_UPLOAD_SIZE }),
+    handleImport
+  );
+
+  router.post('/api/documents/:id/convert-export', handleExport);
+
+  return router;
+}
+
+async function handleImport(req: Request, res: Response): Promise<void> {
+  const documentId = String(req.params.id);
+  const doc = await getDocument(documentId);
+  if (!doc) {
+    res.status(404).json({ error: 'Document not found' });
+    return;
+  }
+
+  const fileBuffer = Buffer.isBuffer(req.body)
+    ? req.body
+    : Buffer.from(req.body as ArrayBuffer);
+
+  if (fileBuffer.length === 0) {
+    res.status(400).json({ error: 'No file content received' });
+    return;
+  }
+
+  const rawFilename = req.headers['x-filename'];
+  const filename = (Array.isArray(rawFilename) ? rawFilename[0] : rawFilename) || 'upload.docx';
+  const rawMime = req.headers['content-type'];
+  const mimeType = Array.isArray(rawMime) ? rawMime[0] : rawMime;
+  const format = detectImportFormat(mimeType, filename);
+
+  if (!format) {
+    res.status(400).json({
+      error: 'Unsupported file format. Accepted: .docx, .odt, .pdf',
+    });
+    return;
+  }
+
+  try {
+    const result = await importViaCollabora(
+      fileBuffer, format, documentId, filename
+    );
+    res.json({
+      ok: true,
+      documentId: result.documentId,
+      snapshot: result.snapshot,
+    });
+  } catch (err) {
+    handleConvertError(res, err);
+  }
+}
+
+async function handleExport(req: Request, res: Response): Promise<void> {
+  const documentId = String(req.params.id);
+  const { format, content, requestedBy } = (req.body || {}) as Record<string, string>;
+
+  if (!format || !isValidExportFormat(format)) {
+    res.status(400).json({
+      error: 'format must be "docx", "odt", or "pdf"',
+    });
+    return;
+  }
+
+  if (!content && content !== '') {
+    res.status(400).json({ error: 'content (HTML) is required' });
+    return;
+  }
+
+  const doc = await getDocument(documentId);
+  if (!doc) {
+    res.status(404).json({ error: 'Document not found' });
+    return;
+  }
+
+  try {
+    const result = await convertViaCollabora(
+      content, format, documentId, requestedBy || 'anonymous'
+    );
+    const title = doc.title || 'document';
+    const ext = getExportExtension(format);
+    const mime = getExportMimeType(format);
+    const fname = `${title}.${ext}`;
+
+    res.setHeader('Content-Type', mime);
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="${encodeURIComponent(fname)}"`
+    );
+    res.setHeader('X-Export-Stale', String(result.stale));
+    res.setHeader('X-Export-At', result.exportedAt);
+    res.send(result.fileBuffer);
+  } catch (err) {
+    handleConvertError(res, err);
+  }
+}
+
+function handleConvertError(res: Response, err: unknown): void {
+  if (err instanceof CollaboraError) {
+    res.status(502).json({
+      error: 'Conversion service unavailable',
+      detail: err.message,
+    });
+    return;
+  }
+  if (err instanceof ImportError) {
+    res.status(400).json({ error: err.message, code: err.code });
+    return;
+  }
+  console.error('[convert] unexpected error:', err);
+  res.status(500).json({ error: 'Internal conversion error' });
+}

--- a/modules/api/internal/server.ts
+++ b/modules/api/internal/server.ts
@@ -13,6 +13,7 @@ import {
   updateDocumentTitle,
 } from '../../storage/internal/pg.ts';
 import { getDocumentForExport } from '../../convert/internal/converter.ts';
+import { createConvertRoutes } from './convert-routes.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -21,6 +22,9 @@ export function startServer(port = 3000) {
   const { handleUpgrade } = createCollabServer();
 
   app.use(express.json());
+
+  // Collabora convert routes (import/export binary formats)
+  app.use(createConvertRoutes());
 
   // Serve static frontend
   const publicDir = resolve(__dirname, '../../app/internal/public');

--- a/modules/convert/index.ts
+++ b/modules/convert/index.ts
@@ -22,13 +22,43 @@ export type {
   FlushConfig,
 } from './contract.ts';
 
-// MVP converter
+// Converter (public API)
 export {
   getDocumentForExport,
   convertViaCollabora,
+  importViaCollabora,
+  buildSnapshot,
+  toConversionResult,
 } from './internal/converter.ts';
 
 export type {
   MvpExportFormat,
   MvpExportResult,
+  ExportResult,
 } from './internal/converter.ts';
+
+// Format utilities
+export {
+  detectImportFormat,
+  isValidImportFormat,
+  isValidExportFormat,
+  getExportMimeType,
+  getExportExtension,
+} from './internal/formats.ts';
+
+// Collabora client
+export {
+  convertFile,
+  convertToHtml,
+  CollaboraError,
+} from './internal/libreoffice.ts';
+
+export type { CollaboraConfig } from './internal/libreoffice.ts';
+
+// HTML parsing/rendering
+export { htmlToProseMirrorJson } from './internal/html-parser.ts';
+export { snapshotToHtml, contentToHtml } from './internal/html-renderer.ts';
+
+// Import/Export pipelines
+export { importFile, ImportError } from './internal/importer.ts';
+export { exportDocument, ExportError } from './internal/exporter.ts';

--- a/modules/convert/internal/converter.ts
+++ b/modules/convert/internal/converter.ts
@@ -1,19 +1,23 @@
 /** Contract: contracts/convert/rules.md */
 
 /**
- * MVP converter — client-side HTML/text export via TipTap editor methods.
- *
- * The full Collabora pipeline (flush -> read snapshot -> LibreOffice convert)
- * is stubbed here and will be wired up when the convert container is running.
- * For now, the actual export happens client-side using editor.getHTML() and
- * editor.getText(), with the API endpoints provided as a future hook.
+ * Unified converter facade — wires import and export pipelines
+ * and provides the public API surface for the convert module.
  */
 
-import type { ExportFormat } from '../contract.ts';
+import type { ExportFormat, ImportFormat } from '../contract.ts';
+import { importFile, buildSnapshot } from './importer.ts';
+import {
+  exportDocument,
+  toConversionResult,
+  type ExportResult,
+} from './exporter.ts';
+import { contentToHtml } from './html-renderer.ts';
 import { getDocument } from '../../storage/internal/pg.ts';
 
-// --- MVP Export Formats (no Collabora needed) ---
+export type { ExportResult };
 
+// Re-export for backward compat with existing server.ts
 export type MvpExportFormat = 'html' | 'text';
 
 export interface MvpExportResult {
@@ -26,7 +30,6 @@ export interface MvpExportResult {
 
 /**
  * Get document metadata for export (title, existence check).
- * Actual content export happens client-side for MVP.
  */
 export async function getDocumentForExport(
   documentId: string
@@ -36,20 +39,30 @@ export async function getDocumentForExport(
   return { title: doc.title };
 }
 
-// --- Collabora Integration (future) ---
-
-const COLLABORA_URL = process.env.COLLABORA_URL || 'http://localhost:9980';
-
 /**
- * Placeholder: convert HTML to a binary format via Collabora's REST API.
- * Not yet implemented — requires the convert container to be running.
+ * Convert HTML content to a binary format via Collabora.
+ * This is the main export path used by the API.
  */
 export async function convertViaCollabora(
   html: string,
-  targetFormat: ExportFormat
-): Promise<Buffer> {
-  throw new Error(
-    `Collabora conversion to ${targetFormat} not yet implemented. ` +
-    `Ensure the convert container is running at ${COLLABORA_URL}.`
-  );
+  targetFormat: ExportFormat,
+  documentId: string,
+  requestedBy: string = 'system'
+): Promise<ExportResult> {
+  const wrappedHtml = contentToHtml(html);
+  return exportDocument(documentId, targetFormat, requestedBy, wrappedHtml);
 }
+
+/**
+ * Import a file and return a DocumentSnapshot.
+ */
+export async function importViaCollabora(
+  fileBuffer: Buffer,
+  format: ImportFormat,
+  documentId: string,
+  filename: string
+) {
+  return importFile(fileBuffer, format, documentId, filename);
+}
+
+export { buildSnapshot, toConversionResult };

--- a/modules/convert/internal/exporter.ts
+++ b/modules/convert/internal/exporter.ts
@@ -1,0 +1,141 @@
+/** Contract: contracts/convert/rules.md */
+
+/**
+ * Export pipeline: flush -> wait -> read snapshot -> render HTML -> Collabora convert.
+ *
+ * Per contract invariants:
+ * - Always emits ConversionRequested before reading snapshot
+ * - Waits for StateFlushed with timeout (default 10s)
+ * - Sets stale flag honestly
+ * - Always emits ExportReady when done
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { ExportFormat, ConversionResult } from '../contract.ts';
+import { EventType, type DomainEvent, type EventBus } from '../../events/contract.ts';
+import { convertFile } from './libreoffice.ts';
+import { getDocument } from '../../storage/internal/pg.ts';
+
+const FLUSH_TIMEOUT_MS = parseInt(
+  process.env.FLUSH_TIMEOUT_MS || '10000',
+  10
+);
+
+export class ExportError extends Error {
+  constructor(message: string, public readonly code: string) {
+    super(message);
+    this.name = 'ExportError';
+  }
+}
+
+export interface ExportResult {
+  documentId: string;
+  format: ExportFormat;
+  stale: boolean;
+  fileBuffer: Buffer;
+  exportedAt: string;
+}
+
+/**
+ * Full export pipeline with flush coordination.
+ *
+ * When no EventBus is available (MVP), falls back to reading
+ * the current snapshot directly (stale=true).
+ */
+export async function exportDocument(
+  documentId: string,
+  format: ExportFormat,
+  requestedBy: string,
+  html: string,
+  eventBus?: EventBus
+): Promise<ExportResult> {
+  let stale = true;
+
+  if (eventBus) {
+    stale = await flushAndWait(documentId, format, requestedBy, eventBus);
+  }
+
+  const doc = await getDocument(documentId);
+  const title = doc?.title || 'document';
+  const filename = `${title}.html`;
+
+  const htmlBuffer = Buffer.from(html, 'utf-8');
+  const fileBuffer = await convertFile(htmlBuffer, filename, format);
+
+  const exportedAt = new Date().toISOString();
+
+  const result: ExportResult = {
+    documentId,
+    format,
+    stale,
+    fileBuffer,
+    exportedAt,
+  };
+
+  if (eventBus) {
+    await emitExportReady(eventBus, result);
+  }
+
+  return result;
+}
+
+/** Emit ConversionRequested and wait for StateFlushed */
+async function flushAndWait(
+  documentId: string,
+  _format: ExportFormat,
+  requestedBy: string,
+  eventBus: EventBus
+): Promise<boolean> {
+  const conversionEvent: DomainEvent = {
+    id: randomUUID(),
+    type: EventType.ConversionRequested,
+    aggregateId: documentId,
+    actorId: requestedBy,
+    actorType: 'system',
+    occurredAt: new Date().toISOString(),
+  };
+  await eventBus.emit(conversionEvent, null);
+
+  return new Promise<boolean>((resolve) => {
+    const timeout = setTimeout(() => resolve(true), FLUSH_TIMEOUT_MS);
+
+    const group = `convert-flush-${documentId}-${Date.now()}`;
+    eventBus.subscribe(group, [EventType.StateFlushed]).then(() => {
+      clearTimeout(timeout);
+      resolve(false);
+    }).catch(() => {
+      clearTimeout(timeout);
+      resolve(true);
+    });
+  });
+}
+
+/** Emit ExportReady event */
+async function emitExportReady(
+  eventBus: EventBus,
+  result: ExportResult
+): Promise<void> {
+  const event: DomainEvent = {
+    id: randomUUID(),
+    type: EventType.ExportReady,
+    aggregateId: result.documentId,
+    actorId: 'convert',
+    actorType: 'system',
+    occurredAt: result.exportedAt,
+  };
+  await eventBus.emit(event, null).catch(() => {
+    console.error('[convert] failed to emit ExportReady event');
+  });
+}
+
+/**
+ * Build a ConversionResult metadata object (without file bytes).
+ */
+export function toConversionResult(result: ExportResult): ConversionResult {
+  return {
+    documentId: result.documentId,
+    format: result.format,
+    stale: result.stale,
+    exportedAt: result.exportedAt,
+  };
+}

--- a/modules/convert/internal/formats.test.ts
+++ b/modules/convert/internal/formats.test.ts
@@ -1,0 +1,96 @@
+/** Contract: contracts/convert/rules.md */
+
+import { describe, it, expect } from 'vitest';
+import {
+  detectImportFormat,
+  isValidImportFormat,
+  isValidExportFormat,
+  getExportMimeType,
+  getExportExtension,
+  getCollaboraFilter,
+} from './formats.ts';
+
+describe('detectImportFormat', () => {
+  it('detects docx from MIME type', () => {
+    const mime = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+    expect(detectImportFormat(mime)).toBe('docx');
+  });
+
+  it('detects odt from MIME type', () => {
+    expect(detectImportFormat('application/vnd.oasis.opendocument.text'))
+      .toBe('odt');
+  });
+
+  it('detects pdf from MIME type', () => {
+    expect(detectImportFormat('application/pdf')).toBe('pdf');
+  });
+
+  it('detects format from filename extension', () => {
+    expect(detectImportFormat(undefined, 'report.docx')).toBe('docx');
+    expect(detectImportFormat(undefined, 'report.odt')).toBe('odt');
+    expect(detectImportFormat(undefined, 'report.pdf')).toBe('pdf');
+  });
+
+  it('returns null for unsupported formats', () => {
+    expect(detectImportFormat('text/plain')).toBeNull();
+    expect(detectImportFormat(undefined, 'file.txt')).toBeNull();
+  });
+
+  it('prefers MIME type over filename', () => {
+    expect(detectImportFormat('application/pdf', 'file.docx')).toBe('pdf');
+  });
+
+  it('falls back to filename when MIME is unknown', () => {
+    expect(detectImportFormat('application/octet-stream', 'file.odt'))
+      .toBe('odt');
+  });
+});
+
+describe('isValidImportFormat', () => {
+  it('accepts valid formats', () => {
+    expect(isValidImportFormat('docx')).toBe(true);
+    expect(isValidImportFormat('odt')).toBe(true);
+    expect(isValidImportFormat('pdf')).toBe(true);
+  });
+
+  it('rejects invalid formats', () => {
+    expect(isValidImportFormat('txt')).toBe(false);
+    expect(isValidImportFormat('html')).toBe(false);
+  });
+});
+
+describe('isValidExportFormat', () => {
+  it('accepts valid formats', () => {
+    expect(isValidExportFormat('docx')).toBe(true);
+    expect(isValidExportFormat('odt')).toBe(true);
+    expect(isValidExportFormat('pdf')).toBe(true);
+  });
+
+  it('rejects invalid formats', () => {
+    expect(isValidExportFormat('html')).toBe(false);
+  });
+});
+
+describe('getExportMimeType', () => {
+  it('returns correct MIME types', () => {
+    expect(getExportMimeType('pdf')).toBe('application/pdf');
+    expect(getExportMimeType('docx')).toContain('wordprocessingml');
+    expect(getExportMimeType('odt')).toContain('opendocument');
+  });
+});
+
+describe('getExportExtension', () => {
+  it('returns correct extensions', () => {
+    expect(getExportExtension('pdf')).toBe('pdf');
+    expect(getExportExtension('docx')).toBe('docx');
+    expect(getExportExtension('odt')).toBe('odt');
+  });
+});
+
+describe('getCollaboraFilter', () => {
+  it('returns filter names', () => {
+    expect(getCollaboraFilter('pdf')).toBe('pdf');
+    expect(getCollaboraFilter('docx')).toBe('docx');
+    expect(getCollaboraFilter('odt')).toBe('odt');
+  });
+});

--- a/modules/convert/internal/formats.ts
+++ b/modules/convert/internal/formats.ts
@@ -1,0 +1,74 @@
+/** Contract: contracts/convert/rules.md */
+
+import type { ImportFormat, ExportFormat } from '../contract.ts';
+
+/** MIME types accepted for import */
+const IMPORT_MIME_MAP: Record<string, ImportFormat> = {
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+  'application/vnd.oasis.opendocument.text': 'odt',
+  'application/pdf': 'pdf',
+};
+
+/** File extensions to ImportFormat */
+const IMPORT_EXT_MAP: Record<string, ImportFormat> = {
+  '.docx': 'docx',
+  '.odt': 'odt',
+  '.pdf': 'pdf',
+};
+
+/** ExportFormat to MIME type */
+const EXPORT_MIME_MAP: Record<ExportFormat, string> = {
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  odt: 'application/vnd.oasis.opendocument.text',
+  pdf: 'application/pdf',
+};
+
+/** ExportFormat to file extension (without dot) */
+const EXPORT_EXT_MAP: Record<ExportFormat, string> = {
+  docx: 'docx',
+  odt: 'odt',
+  pdf: 'pdf',
+};
+
+/** Collabora filter names for export conversion */
+const COLLABORA_FILTER_MAP: Record<ExportFormat, string> = {
+  pdf: 'pdf',
+  docx: 'docx',
+  odt: 'odt',
+};
+
+export function detectImportFormat(
+  mimeType?: string,
+  filename?: string
+): ImportFormat | null {
+  if (mimeType) {
+    const fromMime = IMPORT_MIME_MAP[mimeType];
+    if (fromMime) return fromMime;
+  }
+  if (filename) {
+    const ext = filename.slice(filename.lastIndexOf('.')).toLowerCase();
+    const fromExt = IMPORT_EXT_MAP[ext];
+    if (fromExt) return fromExt;
+  }
+  return null;
+}
+
+export function isValidImportFormat(format: string): format is ImportFormat {
+  return format === 'docx' || format === 'odt' || format === 'pdf';
+}
+
+export function isValidExportFormat(format: string): format is ExportFormat {
+  return format === 'docx' || format === 'odt' || format === 'pdf';
+}
+
+export function getExportMimeType(format: ExportFormat): string {
+  return EXPORT_MIME_MAP[format];
+}
+
+export function getExportExtension(format: ExportFormat): string {
+  return EXPORT_EXT_MAP[format];
+}
+
+export function getCollaboraFilter(format: ExportFormat): string {
+  return COLLABORA_FILTER_MAP[format];
+}

--- a/modules/convert/internal/html-parser.test.ts
+++ b/modules/convert/internal/html-parser.test.ts
@@ -1,0 +1,94 @@
+/** Contract: contracts/convert/rules.md */
+
+import { describe, it, expect } from 'vitest';
+import { htmlToProseMirrorJson, stripTags, decodeEntities } from './html-parser.ts';
+
+describe('htmlToProseMirrorJson', () => {
+  it('parses a single paragraph', () => {
+    const result = htmlToProseMirrorJson('<p>Hello world</p>');
+    expect(result.type).toBe('doc');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('paragraph');
+    expect(result.content[0].content?.[0].text).toBe('Hello world');
+  });
+
+  it('parses multiple paragraphs', () => {
+    const html = '<p>First</p><p>Second</p><p>Third</p>';
+    const result = htmlToProseMirrorJson(html);
+    expect(result.content).toHaveLength(3);
+    expect(result.content[0].content?.[0].text).toBe('First');
+    expect(result.content[2].content?.[0].text).toBe('Third');
+  });
+
+  it('parses headings with correct level', () => {
+    const html = '<h1>Title</h1><h2>Subtitle</h2>';
+    const result = htmlToProseMirrorJson(html);
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0].type).toBe('heading');
+    expect(result.content[0].attrs?.level).toBe(1);
+    expect(result.content[1].attrs?.level).toBe(2);
+  });
+
+  it('parses bold text', () => {
+    const html = '<p><strong>bold</strong> normal</p>';
+    const result = htmlToProseMirrorJson(html);
+    const content = result.content[0].content!;
+    expect(content[0].marks).toEqual([{ type: 'bold' }]);
+    expect(content[0].text).toBe('bold');
+    expect(content[1].text).toBe(' normal');
+    expect(content[1].marks).toBeUndefined();
+  });
+
+  it('parses italic text', () => {
+    const html = '<p><em>italic</em></p>';
+    const result = htmlToProseMirrorJson(html);
+    const content = result.content[0].content!;
+    expect(content[0].marks).toEqual([{ type: 'italic' }]);
+  });
+
+  it('generates unique blockIds for each block', () => {
+    const html = '<p>One</p><p>Two</p>';
+    const result = htmlToProseMirrorJson(html);
+    const id1 = result.content[0].attrs?.blockId;
+    const id2 = result.content[1].attrs?.blockId;
+    expect(id1).toBeDefined();
+    expect(id2).toBeDefined();
+    expect(id1).not.toBe(id2);
+  });
+
+  it('returns a default paragraph for empty input', () => {
+    const result = htmlToProseMirrorJson('');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('paragraph');
+  });
+
+  it('handles plain text without block tags', () => {
+    const result = htmlToProseMirrorJson('Just some text');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('paragraph');
+    expect(result.content[0].content?.[0].text).toBe('Just some text');
+  });
+
+  it('decodes HTML entities', () => {
+    const html = '<p>A &amp; B &lt; C &gt; D</p>';
+    const result = htmlToProseMirrorJson(html);
+    expect(result.content[0].content?.[0].text).toBe('A & B < C > D');
+  });
+});
+
+describe('stripTags', () => {
+  it('removes HTML tags', () => {
+    expect(stripTags('<p>hello <b>world</b></p>')).toBe('hello world');
+  });
+
+  it('handles empty string', () => {
+    expect(stripTags('')).toBe('');
+  });
+});
+
+describe('decodeEntities', () => {
+  it('decodes common entities', () => {
+    expect(decodeEntities('&amp;&lt;&gt;&quot;&#39;&nbsp;'))
+      .toBe('&<>"\' ');
+  });
+});

--- a/modules/convert/internal/html-parser.ts
+++ b/modules/convert/internal/html-parser.ts
@@ -1,0 +1,164 @@
+/** Contract: contracts/convert/rules.md */
+
+/**
+ * Parses HTML into ProseMirror JSON for document import.
+ *
+ * Server-side parser that converts Collabora's HTML output
+ * into a valid ProseMirror document structure with blockIds.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { ProseMirrorNode } from '../../document/contract.ts';
+
+/** Inline mark types we extract from HTML */
+const INLINE_TAG_MARKS: Record<string, string> = {
+  STRONG: 'bold',
+  B: 'bold',
+  EM: 'italic',
+  I: 'italic',
+  U: 'underline',
+  S: 'strike',
+  STRIKE: 'strike',
+  CODE: 'code',
+};
+
+/** Block-level tag to ProseMirror node type */
+const BLOCK_TAG_MAP: Record<string, string> = {
+  P: 'paragraph',
+  H1: 'heading',
+  H2: 'heading',
+  H3: 'heading',
+  H4: 'heading',
+  H5: 'heading',
+  H6: 'heading',
+  BLOCKQUOTE: 'blockquote',
+  PRE: 'codeBlock',
+  LI: 'listItem',
+};
+
+function headingLevel(tag: string): number | null {
+  const match = /^H([1-6])$/.exec(tag);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+/** Create a text node with optional marks */
+function textNode(
+  text: string,
+  marks?: Array<{ type: string }>
+): ProseMirrorNode {
+  const node: ProseMirrorNode = { type: 'text', text };
+  if (marks && marks.length > 0) {
+    node.marks = marks;
+  }
+  return node;
+}
+
+/** Create a block node with a blockId */
+function blockNode(
+  type: string,
+  content: ProseMirrorNode[],
+  attrs?: Record<string, unknown>
+): ProseMirrorNode {
+  return {
+    type,
+    attrs: { blockId: randomUUID(), ...attrs },
+    content: content.length > 0 ? content : undefined,
+  };
+}
+
+/**
+ * Parse raw HTML string into a ProseMirror JSON document.
+ * Uses regex-based parsing for server-side use (no DOM).
+ */
+export function htmlToProseMirrorJson(html: string): {
+  type: 'doc';
+  content: ProseMirrorNode[];
+} {
+  const blocks = extractBlocks(html);
+
+  if (blocks.length === 0) {
+    return {
+      type: 'doc',
+      content: [blockNode('paragraph', [textNode('')])],
+    };
+  }
+
+  return { type: 'doc', content: blocks };
+}
+
+/** Extract block-level elements from HTML */
+function extractBlocks(html: string): ProseMirrorNode[] {
+  const blocks: ProseMirrorNode[] = [];
+  const blockPattern =
+    /<(p|h[1-6]|blockquote|pre|li)\b[^>]*>([\s\S]*?)<\/\1>/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = blockPattern.exec(html)) !== null) {
+    const tag = match[1].toUpperCase();
+    const inner = match[2];
+    const nodeType = BLOCK_TAG_MAP[tag] || 'paragraph';
+    const inlineContent = parseInlineContent(inner);
+
+    const attrs: Record<string, unknown> = {};
+    const level = headingLevel(tag);
+    if (level !== null) {
+      attrs.level = level;
+    }
+
+    blocks.push(blockNode(nodeType, inlineContent, attrs));
+  }
+
+  if (blocks.length === 0) {
+    const stripped = stripTags(html).trim();
+    if (stripped) {
+      blocks.push(blockNode('paragraph', [textNode(stripped)]));
+    }
+  }
+
+  return blocks;
+}
+
+/** Parse inline content (bold, italic, etc.) within a block */
+function parseInlineContent(html: string): ProseMirrorNode[] {
+  const nodes: ProseMirrorNode[] = [];
+  const inlinePattern =
+    /<(strong|b|em|i|u|s|strike|code)\b[^>]*>([\s\S]*?)<\/\1>|([^<]+)/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = inlinePattern.exec(html)) !== null) {
+    if (match[3]) {
+      const text = decodeEntities(match[3]);
+      if (text) nodes.push(textNode(text));
+    } else if (match[1] && match[2]) {
+      const tag = match[1].toUpperCase();
+      const markType = INLINE_TAG_MARKS[tag];
+      const text = decodeEntities(stripTags(match[2]));
+      if (text && markType) {
+        nodes.push(textNode(text, [{ type: markType }]));
+      }
+    }
+  }
+
+  if (nodes.length === 0) {
+    const plain = decodeEntities(stripTags(html)).trim();
+    if (plain) nodes.push(textNode(plain));
+  }
+
+  return nodes;
+}
+
+/** Strip HTML tags */
+export function stripTags(html: string): string {
+  return html.replace(/<[^>]*>/g, '');
+}
+
+/** Decode basic HTML entities */
+export function decodeEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ');
+}

--- a/modules/convert/internal/html-renderer.test.ts
+++ b/modules/convert/internal/html-renderer.test.ts
@@ -1,0 +1,113 @@
+/** Contract: contracts/convert/rules.md */
+
+import { describe, it, expect } from 'vitest';
+import {
+  escapeHtml,
+  renderNode,
+  wrapHtmlDocument,
+  snapshotToHtml,
+  contentToHtml,
+} from './html-renderer.ts';
+import type { ProseMirrorNode } from '../../document/contract.ts';
+
+describe('escapeHtml', () => {
+  it('escapes special characters', () => {
+    expect(escapeHtml('<script>alert("xss")</script>'))
+      .toBe('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;');
+  });
+
+  it('escapes ampersands', () => {
+    expect(escapeHtml('A & B')).toBe('A &amp; B');
+  });
+});
+
+describe('renderNode', () => {
+  it('renders a paragraph', () => {
+    const node: ProseMirrorNode = {
+      type: 'paragraph',
+      content: [{ type: 'text', text: 'Hello' }],
+    };
+    expect(renderNode(node)).toBe('<p>Hello</p>');
+  });
+
+  it('renders a heading with level', () => {
+    const node: ProseMirrorNode = {
+      type: 'heading',
+      attrs: { level: 2 },
+      content: [{ type: 'text', text: 'Title' }],
+    };
+    expect(renderNode(node)).toBe('<h2>Title</h2>');
+  });
+
+  it('renders bold text', () => {
+    const node: ProseMirrorNode = {
+      type: 'text',
+      text: 'bold',
+      marks: [{ type: 'bold' }],
+    };
+    expect(renderNode(node)).toBe('<strong>bold</strong>');
+  });
+
+  it('renders italic text', () => {
+    const node: ProseMirrorNode = {
+      type: 'text',
+      text: 'italic',
+      marks: [{ type: 'italic' }],
+    };
+    expect(renderNode(node)).toBe('<em>italic</em>');
+  });
+
+  it('renders nested marks', () => {
+    const node: ProseMirrorNode = {
+      type: 'text',
+      text: 'both',
+      marks: [{ type: 'bold' }, { type: 'italic' }],
+    };
+    expect(renderNode(node)).toBe('<em><strong>both</strong></em>');
+  });
+});
+
+describe('wrapHtmlDocument', () => {
+  it('wraps body in a full HTML document', () => {
+    const result = wrapHtmlDocument('<p>Hello</p>');
+    expect(result).toContain('<!DOCTYPE html>');
+    expect(result).toContain('<body><p>Hello</p></body>');
+    expect(result).toContain('<meta charset="utf-8">');
+  });
+});
+
+describe('contentToHtml', () => {
+  it('wraps HTML content in a document', () => {
+    const result = contentToHtml('<p>Test</p>');
+    expect(result).toContain('<!DOCTYPE html>');
+    expect(result).toContain('<p>Test</p>');
+  });
+
+  it('converts plain text to paragraphs', () => {
+    const result = contentToHtml('Line one\nLine two');
+    expect(result).toContain('<p>Line one</p>');
+    expect(result).toContain('<p>Line two</p>');
+  });
+});
+
+describe('snapshotToHtml', () => {
+  it('renders a full document snapshot', () => {
+    const snapshot = {
+      documentType: 'text' as const,
+      schemaVersion: '1.0.0' as const,
+      content: {
+        type: 'doc' as const,
+        content: [
+          {
+            type: 'paragraph',
+            attrs: { blockId: '00000000-0000-4000-8000-000000000001' },
+            content: [{ type: 'text', text: 'Hello world' }],
+          },
+        ],
+      },
+    };
+    const html = snapshotToHtml(snapshot);
+    expect(html).toContain('<p>Hello world</p>');
+    expect(html).toContain('<!DOCTYPE html>');
+  });
+});

--- a/modules/convert/internal/html-renderer.ts
+++ b/modules/convert/internal/html-renderer.ts
@@ -1,0 +1,113 @@
+/** Contract: contracts/convert/rules.md */
+
+/**
+ * Renders a DocumentSnapshot (ProseMirror JSON) to HTML.
+ * Used for export: snapshot -> HTML -> Collabora -> target format.
+ */
+
+import type { ProseMirrorNode, DocumentSnapshot } from '../../document/contract.ts';
+
+/** Render a full DocumentSnapshot to an HTML document string */
+export function snapshotToHtml(snapshot: DocumentSnapshot): string {
+  const bodyHtml = renderNodes(snapshot.content.content);
+  return wrapHtmlDocument(bodyHtml);
+}
+
+/** Render a ProseMirror JSON content string to HTML (for client-sent HTML) */
+export function contentToHtml(content: string): string {
+  if (content.trim().startsWith('<')) {
+    return wrapHtmlDocument(content);
+  }
+  const paragraphs = content
+    .split('\n')
+    .map((line) => `<p>${escapeHtml(line)}</p>`)
+    .join('\n');
+  return wrapHtmlDocument(paragraphs);
+}
+
+/** Render an array of ProseMirror nodes to HTML */
+function renderNodes(nodes: ProseMirrorNode[] | undefined): string {
+  if (!nodes || nodes.length === 0) return '';
+  return nodes.map(renderNode).join('\n');
+}
+
+/** Render a single ProseMirror node to HTML */
+export function renderNode(node: ProseMirrorNode): string {
+  switch (node.type) {
+    case 'doc':
+      return renderNodes(node.content);
+    case 'paragraph':
+      return `<p>${renderInline(node.content)}</p>`;
+    case 'heading': {
+      const level = (node.attrs?.level as number) || 1;
+      const tag = `h${Math.min(Math.max(level, 1), 6)}`;
+      return `<${tag}>${renderInline(node.content)}</${tag}>`;
+    }
+    case 'blockquote':
+      return `<blockquote>${renderNodes(node.content)}</blockquote>`;
+    case 'codeBlock':
+      return `<pre><code>${renderInline(node.content)}</code></pre>`;
+    case 'bulletList':
+      return `<ul>${renderNodes(node.content)}</ul>`;
+    case 'orderedList':
+      return `<ol>${renderNodes(node.content)}</ol>`;
+    case 'listItem':
+      return `<li>${renderNodes(node.content)}</li>`;
+    case 'horizontalRule':
+      return '<hr>';
+    case 'text':
+      return renderTextNode(node);
+    default:
+      return renderNodes(node.content);
+  }
+}
+
+/** Render inline content within a block */
+function renderInline(nodes: ProseMirrorNode[] | undefined): string {
+  if (!nodes || nodes.length === 0) return '';
+  return nodes.map(renderNode).join('');
+}
+
+/** Render a text node with its marks */
+function renderTextNode(node: ProseMirrorNode): string {
+  let html = escapeHtml(node.text || '');
+
+  if (node.marks) {
+    for (const mark of node.marks) {
+      html = wrapMark(html, mark.type);
+    }
+  }
+
+  return html;
+}
+
+/** Wrap text in the appropriate HTML tag for a mark */
+function wrapMark(html: string, markType: string): string {
+  switch (markType) {
+    case 'bold': return `<strong>${html}</strong>`;
+    case 'italic': return `<em>${html}</em>`;
+    case 'underline': return `<u>${html}</u>`;
+    case 'strike': return `<s>${html}</s>`;
+    case 'code': return `<code>${html}</code>`;
+    default: return html;
+  }
+}
+
+/** Escape HTML special characters */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** Wrap body HTML in a full document */
+export function wrapHtmlDocument(body: string): string {
+  return [
+    '<!DOCTYPE html>',
+    '<html><head><meta charset="utf-8"></head>',
+    `<body>${body}</body>`,
+    '</html>',
+  ].join('\n');
+}

--- a/modules/convert/internal/importer.test.ts
+++ b/modules/convert/internal/importer.test.ts
@@ -1,0 +1,85 @@
+/** Contract: contracts/convert/rules.md */
+
+import { describe, it, expect } from 'vitest';
+import { buildSnapshot, ImportError } from './importer.ts';
+
+describe('buildSnapshot', () => {
+  it('produces a valid DocumentSnapshot from simple HTML', () => {
+    const html = '<p>Hello world</p>';
+    const snapshot = buildSnapshot(html);
+
+    expect(snapshot.documentType).toBe('text');
+    expect(snapshot.schemaVersion).toBe('1.0.0');
+    expect(snapshot.content.type).toBe('doc');
+    expect(snapshot.content.content.length).toBeGreaterThan(0);
+  });
+
+  it('produces a snapshot with correct paragraph content', () => {
+    const html = '<p>Test content</p>';
+    const snapshot = buildSnapshot(html);
+    const firstBlock = snapshot.content.content[0];
+
+    expect(firstBlock.type).toBe('paragraph');
+    expect(firstBlock.attrs?.blockId).toBeDefined();
+    expect(firstBlock.content?.[0].text).toBe('Test content');
+  });
+
+  it('handles multiple paragraphs', () => {
+    const html = '<p>First</p><p>Second</p>';
+    const snapshot = buildSnapshot(html);
+
+    expect(snapshot.content.content).toHaveLength(2);
+  });
+
+  it('handles headings', () => {
+    const html = '<h1>Title</h1><p>Body text</p>';
+    const snapshot = buildSnapshot(html);
+
+    expect(snapshot.content.content[0].type).toBe('heading');
+    expect(snapshot.content.content[0].attrs?.level).toBe(1);
+    expect(snapshot.content.content[1].type).toBe('paragraph');
+  });
+
+  it('produces a default paragraph for empty HTML', () => {
+    const snapshot = buildSnapshot('');
+    expect(snapshot.content.content).toHaveLength(1);
+    expect(snapshot.content.content[0].type).toBe('paragraph');
+  });
+
+  it('handles inline formatting (bold)', () => {
+    const html = '<p><strong>bold text</strong></p>';
+    const snapshot = buildSnapshot(html);
+    const textNode = snapshot.content.content[0].content?.[0];
+
+    expect(textNode?.text).toBe('bold text');
+    expect(textNode?.marks).toEqual([{ type: 'bold' }]);
+  });
+
+  it('each block has a unique UUIDv4 blockId', () => {
+    const html = '<p>A</p><p>B</p><p>C</p>';
+    const snapshot = buildSnapshot(html);
+    const ids = snapshot.content.content.map((n) => n.attrs?.blockId);
+
+    ids.forEach((id) => expect(id).toBeDefined());
+
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    ids.forEach((id) => expect(String(id)).toMatch(uuidRegex));
+  });
+
+  it('snapshot passes DocumentSnapshotSchema validation', () => {
+    const html = '<h2>Heading</h2><p>Paragraph with <em>italic</em></p>';
+    expect(() => buildSnapshot(html)).not.toThrow();
+  });
+});
+
+describe('ImportError', () => {
+  it('has correct name and code', () => {
+    const err = new ImportError('test', 'TEST_CODE');
+    expect(err.name).toBe('ImportError');
+    expect(err.code).toBe('TEST_CODE');
+    expect(err.message).toBe('test');
+  });
+});

--- a/modules/convert/internal/importer.ts
+++ b/modules/convert/internal/importer.ts
@@ -1,0 +1,69 @@
+/** Contract: contracts/convert/rules.md */
+
+/**
+ * Import pipeline: file -> Collabora HTML -> ProseMirror JSON -> DocumentSnapshot.
+ *
+ * 1. Validate file format
+ * 2. Send to Collabora for HTML conversion
+ * 3. Parse HTML into ProseMirror JSON
+ * 4. Build and validate DocumentSnapshot
+ */
+
+import { TextSchemaVersion, DocumentSnapshotSchema, type DocumentSnapshot } from '../../document/contract.ts';
+import { convertToHtml } from './libreoffice.ts';
+import { htmlToProseMirrorJson } from './html-parser.ts';
+import { isValidImportFormat } from './formats.ts';
+
+export class ImportError extends Error {
+  constructor(message: string, public readonly code: string) {
+    super(message);
+    this.name = 'ImportError';
+  }
+}
+
+export interface ImportResult {
+  documentId: string;
+  snapshot: DocumentSnapshot;
+}
+
+/**
+ * Import a file into a DocumentSnapshot.
+ */
+export async function importFile(
+  fileBuffer: Buffer,
+  format: string,
+  documentId: string,
+  filename: string
+): Promise<ImportResult> {
+  if (!isValidImportFormat(format)) {
+    throw new ImportError(
+      `Unsupported import format: ${format}`,
+      'INVALID_FORMAT'
+    );
+  }
+
+  if (fileBuffer.length === 0) {
+    throw new ImportError('File is empty', 'EMPTY_FILE');
+  }
+
+  const html = await convertToHtml(fileBuffer, filename);
+  const snapshot = buildSnapshot(html);
+
+  return { documentId, snapshot };
+}
+
+/**
+ * Build a DocumentSnapshot from HTML content.
+ * Exported for testing without requiring Collabora.
+ */
+export function buildSnapshot(html: string): DocumentSnapshot {
+  const content = htmlToProseMirrorJson(html);
+
+  const snapshot = {
+    documentType: 'text' as const,
+    schemaVersion: TextSchemaVersion.current,
+    content,
+  };
+
+  return DocumentSnapshotSchema.parse(snapshot);
+}

--- a/modules/convert/internal/libreoffice.test.ts
+++ b/modules/convert/internal/libreoffice.test.ts
@@ -1,0 +1,28 @@
+/** Contract: contracts/convert/rules.md */
+
+import { describe, it, expect } from 'vitest';
+import { CollaboraError } from './libreoffice.ts';
+
+describe('CollaboraError', () => {
+  it('has correct name', () => {
+    const err = new CollaboraError('test message');
+    expect(err.name).toBe('CollaboraError');
+    expect(err.message).toBe('test message');
+  });
+
+  it('stores statusCode', () => {
+    const err = new CollaboraError('not found', 404);
+    expect(err.statusCode).toBe(404);
+  });
+
+  it('stores cause', () => {
+    const cause = new Error('original');
+    const err = new CollaboraError('wrapped', undefined, cause);
+    expect(err.cause).toBe(cause);
+  });
+
+  it('is an instance of Error', () => {
+    const err = new CollaboraError('test');
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/modules/convert/internal/libreoffice.ts
+++ b/modules/convert/internal/libreoffice.ts
@@ -1,0 +1,136 @@
+/** Contract: contracts/convert/rules.md */
+
+/**
+ * Collabora Online REST API client.
+ *
+ * Uses the /cool/convert-to endpoint:
+ *   POST /cool/convert-to/<format>
+ *   Body: multipart/form-data with file in "data" field
+ *   Returns: converted file bytes
+ */
+
+import type { ExportFormat } from '../contract.ts';
+import { getCollaboraFilter } from './formats.ts';
+
+export interface CollaboraConfig {
+  baseUrl: string;
+  timeoutMs: number;
+}
+
+const DEFAULT_CONFIG: CollaboraConfig = {
+  baseUrl: process.env.COLLABORA_URL || 'http://localhost:9980',
+  timeoutMs: parseInt(process.env.COLLABORA_TIMEOUT_MS || '30000', 10),
+};
+
+export class CollaboraError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = 'CollaboraError';
+  }
+}
+
+/**
+ * Convert a file buffer to the target format via Collabora's REST API.
+ * POST /cool/convert-to/<format> with multipart form data.
+ */
+export async function convertFile(
+  fileBuffer: Buffer,
+  filename: string,
+  targetFormat: ExportFormat,
+  config: CollaboraConfig = DEFAULT_CONFIG
+): Promise<Buffer> {
+  const filter = getCollaboraFilter(targetFormat);
+  const url = `${config.baseUrl}/cool/convert-to/${filter}`;
+
+  const formData = new FormData();
+  const blob = new Blob([new Uint8Array(fileBuffer)]);
+  formData.append('data', blob, filename);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), config.timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      body: formData,
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new CollaboraError(
+        `Collabora conversion failed: ${response.status} ${response.statusText}`,
+        response.status
+      );
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    return Buffer.from(arrayBuffer);
+  } catch (err: unknown) {
+    if (err instanceof CollaboraError) throw err;
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes('abort')) {
+      throw new CollaboraError(
+        `Collabora conversion timed out after ${config.timeoutMs}ms`,
+        undefined,
+        err
+      );
+    }
+    throw new CollaboraError(
+      `Collabora conversion error: ${msg}`,
+      undefined,
+      err
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Convert an uploaded file to HTML via Collabora.
+ * Used for import: file -> HTML -> ProseMirror JSON.
+ */
+export async function convertToHtml(
+  fileBuffer: Buffer,
+  filename: string,
+  config: CollaboraConfig = DEFAULT_CONFIG
+): Promise<string> {
+  const url = `${config.baseUrl}/cool/convert-to/html`;
+
+  const formData = new FormData();
+  const blob = new Blob([new Uint8Array(fileBuffer)]);
+  formData.append('data', blob, filename);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), config.timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      body: formData,
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new CollaboraError(
+        `Collabora HTML conversion failed: ${response.status} ${response.statusText}`,
+        response.status
+      );
+    }
+
+    return await response.text();
+  } catch (err: unknown) {
+    if (err instanceof CollaboraError) throw err;
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new CollaboraError(
+      `Collabora HTML conversion error: ${msg}`,
+      undefined,
+      err
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## Summary
- Collabora REST API client using `/cool/convert-to/<format>` (stateless, no WOPI)
- Import pipeline: file → Collabora HTML → ProseMirror JSON → validated DocumentSnapshot
- Export pipeline: HTML → Collabora binary → streamed response with stale flag
- Server-side HTML↔ProseMirror round-trip parsers (no DOM dependency)
- Two new endpoints: `POST /api/documents/:id/convert-import` and `convert-export`

## Test plan
- [ ] 50 new tests (formats, HTML parsing, rendering, import, Collabora errors)
- [ ] `npm run lint` clean
- [ ] `npm test` passes
- [ ] Manual test with Collabora container running

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)