### PR TITLE
Redis caching + idempotency keys

### DIFF
--- a/modules/api/internal/idempotency.test.ts
+++ b/modules/api/internal/idempotency.test.ts
@@ -1,0 +1,170 @@
+/** Contract: contracts/api/rules.md — Idempotency middleware tests */
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { NextFunction } from 'express';
+import type { CacheClient } from './redis.ts';
+import {
+  buildCacheKey,
+  serializeResponse,
+  deserializeResponse,
+  idempotencyMiddleware,
+  IDEMPOTENCY_TTL_SECONDS,
+  IDEMPOTENCY_KEY_PREFIX,
+} from './idempotency.ts';
+import { InMemoryCache, makeReq, makeRes } from './test-helpers.ts';
+
+// --- Unit tests: cache key generation ---
+
+describe('buildCacheKey', () => {
+  it('builds a deterministic key from method, path, and idempotency key', () => {
+    const key = buildCacheKey('POST', '/api/documents', 'abc-123');
+    expect(key).toBe(`${IDEMPOTENCY_KEY_PREFIX}POST:/api/documents:abc-123`);
+  });
+
+  it('different methods produce different keys', () => {
+    const a = buildCacheKey('POST', '/api/documents', 'key-1');
+    const b = buildCacheKey('DELETE', '/api/documents', 'key-1');
+    expect(a).not.toBe(b);
+  });
+
+  it('different paths produce different keys', () => {
+    const a = buildCacheKey('POST', '/api/documents', 'key-1');
+    const b = buildCacheKey('POST', '/api/documents/123', 'key-1');
+    expect(a).not.toBe(b);
+  });
+});
+
+// --- Unit tests: response serialization ---
+
+describe('serializeResponse / deserializeResponse', () => {
+  it('round-trips correctly', () => {
+    const serialized = serializeResponse(201, { 'content-type': 'application/json' }, '{"id":"123"}');
+    const deserialized = deserializeResponse(serialized);
+    expect(deserialized.statusCode).toBe(201);
+    expect(deserialized.headers['content-type']).toBe('application/json');
+    expect(deserialized.body).toBe('{"id":"123"}');
+  });
+
+  it('handles empty body', () => {
+    const serialized = serializeResponse(204, {}, '');
+    const deserialized = deserializeResponse(serialized);
+    expect(deserialized.statusCode).toBe(204);
+    expect(deserialized.body).toBe('');
+  });
+});
+
+// --- TTL configuration ---
+
+describe('IDEMPOTENCY_TTL_SECONDS', () => {
+  it('is 24 hours per collab contract', () => {
+    expect(IDEMPOTENCY_TTL_SECONDS).toBe(24 * 60 * 60);
+  });
+});
+
+// --- Middleware behavior ---
+
+describe('idempotencyMiddleware', () => {
+  let cache: InMemoryCache;
+
+  beforeEach(() => {
+    cache = new InMemoryCache();
+  });
+
+  it('passes through GET requests without requiring header', async () => {
+    const middleware = idempotencyMiddleware({ cache });
+    const req = makeReq({ method: 'GET' });
+    const res = makeRes();
+    let nextCalled = false;
+    const next: NextFunction = () => { nextCalled = true; };
+    await middleware(req, res, next);
+    expect(nextCalled).toBe(true);
+  });
+
+  it('returns 400 when Idempotency-Key header is missing on POST', async () => {
+    const middleware = idempotencyMiddleware({ cache });
+    const req = makeReq({ method: 'POST', headers: {} });
+    const res = makeRes();
+    await middleware(req, res, () => {});
+    expect(res._status).toBe(400);
+    expect((res._body as { code: string }).code).toBe('MISSING_IDEMPOTENCY_KEY');
+  });
+
+  it('returns 400 when Idempotency-Key header is missing on DELETE', async () => {
+    const middleware = idempotencyMiddleware({ cache });
+    const req = makeReq({ method: 'DELETE', headers: {} });
+    const res = makeRes();
+    await middleware(req, res, () => {});
+    expect(res._status).toBe(400);
+  });
+
+  it('calls next() on first request with a new idempotency key', async () => {
+    const middleware = idempotencyMiddleware({ cache });
+    const req = makeReq({ method: 'POST', headers: { 'idempotency-key': 'unique-key-1' } });
+    const res = makeRes();
+    let nextCalled = false;
+    await middleware(req, res, () => { nextCalled = true; });
+    expect(nextCalled).toBe(true);
+  });
+
+  it('returns cached response on duplicate idempotency key', async () => {
+    const middleware = idempotencyMiddleware({ cache });
+
+    const req1 = makeReq({ method: 'POST', path: '/api/documents', headers: { 'idempotency-key': 'dup-key' } });
+    const res1 = makeRes();
+    res1.setHeader('content-type', 'application/json');
+    await middleware(req1, res1, () => {});
+
+    res1.status(201);
+    res1.json({ id: 'doc-42' });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const req2 = makeReq({ method: 'POST', path: '/api/documents', headers: { 'idempotency-key': 'dup-key' } });
+    const res2 = makeRes();
+    let next2Called = false;
+    await middleware(req2, res2, () => { next2Called = true; });
+
+    expect(next2Called).toBe(false);
+    expect(res2._status).toBe(201);
+    expect(res2._body).toBe('{"id":"doc-42"}');
+    expect(res2._headers['X-Idempotent-Replayed']).toBe('true');
+  });
+
+  it('does not cache 5xx responses', async () => {
+    const middleware = idempotencyMiddleware({ cache });
+    const req = makeReq({ method: 'POST', path: '/api/docs', headers: { 'idempotency-key': 'err-key' } });
+    const res1 = makeRes();
+    await middleware(req, res1, () => {});
+    res1.status(500);
+    res1.json({ error: 'internal' });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const req2 = makeReq({ method: 'POST', path: '/api/docs', headers: { 'idempotency-key': 'err-key' } });
+    const res2 = makeRes();
+    let nextCalled = false;
+    await middleware(req2, res2, () => { nextCalled = true; });
+    expect(nextCalled).toBe(true);
+  });
+
+  it('survives cache read errors gracefully', async () => {
+    const failingCache: CacheClient = {
+      get: async () => { throw new Error('connection lost'); },
+      set: async () => 'OK',
+      quit: async () => 'OK',
+      status: 'ready',
+    };
+    const middleware = idempotencyMiddleware({ cache: failingCache });
+    const req = makeReq({ method: 'POST', headers: { 'idempotency-key': 'fail-key' } });
+    const res = makeRes();
+    let nextCalled = false;
+    await middleware(req, res, () => { nextCalled = true; });
+    expect(nextCalled).toBe(true);
+  });
+
+  it('respects custom methods configuration', async () => {
+    const middleware = idempotencyMiddleware({ cache, methods: ['POST'] });
+    const req = makeReq({ method: 'DELETE', headers: {} });
+    const res = makeRes();
+    let nextCalled = false;
+    await middleware(req, res, () => { nextCalled = true; });
+    expect(nextCalled).toBe(true);
+  });
+});

--- a/modules/api/internal/idempotency.ts
+++ b/modules/api/internal/idempotency.ts
@@ -1,0 +1,146 @@
+/** Contract: contracts/api/rules.md */
+import type { Request, Response, NextFunction } from 'express';
+import type { CacheClient } from './redis.ts';
+
+/** 24 hours in seconds, per collab contract idempotency cache requirement. */
+export const IDEMPOTENCY_TTL_SECONDS = 86_400;
+
+/** Prefix for idempotency cache keys. */
+export const IDEMPOTENCY_KEY_PREFIX = 'idem:';
+
+export interface CachedResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+/** Build the cache key from the request method, path, and idempotency key header. */
+export function buildCacheKey(method: string, path: string, idempotencyKey: string): string {
+  return `${IDEMPOTENCY_KEY_PREFIX}${method}:${path}:${idempotencyKey}`;
+}
+
+/** Serialize a response for caching. */
+export function serializeResponse(statusCode: number, headers: Record<string, string>, body: string): string {
+  const cached: CachedResponse = { statusCode, headers, body };
+  return JSON.stringify(cached);
+}
+
+/** Deserialize a cached response. */
+export function deserializeResponse(raw: string): CachedResponse {
+  return JSON.parse(raw) as CachedResponse;
+}
+
+export interface IdempotencyOptions {
+  cache: CacheClient;
+  ttlSeconds?: number;
+  /** HTTP methods to apply idempotency to. Default: POST, PUT, DELETE */
+  methods?: string[];
+  headerName?: string;
+}
+
+/**
+ * Express middleware that enforces idempotency via `Idempotency-Key` header.
+ *
+ * For mutating requests (POST/PUT/DELETE by default):
+ * - If the header is present and a cached response exists, returns the cached response immediately.
+ * - If the header is present and no cache exists, intercepts the response, caches it, then sends it.
+ * - If the header is missing on a mutating request, returns 400.
+ */
+export function idempotencyMiddleware(options: IdempotencyOptions) {
+  const {
+    cache,
+    ttlSeconds = IDEMPOTENCY_TTL_SECONDS,
+    methods = ['POST', 'PUT', 'DELETE'],
+    headerName = 'idempotency-key',
+  } = options;
+
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const method = req.method.toUpperCase();
+
+    // Only apply to configured methods
+    if (!methods.includes(method)) {
+      next();
+      return;
+    }
+
+    const idempotencyKey = req.headers[headerName] as string | undefined;
+
+    // Require header on mutating endpoints
+    if (!idempotencyKey) {
+      res.status(400).json({
+        code: 'MISSING_IDEMPOTENCY_KEY',
+        message: `${headerName} header is required for ${method} requests`,
+      });
+      return;
+    }
+
+    const cacheKey = buildCacheKey(method, req.path, idempotencyKey);
+
+    // Check cache for existing response
+    try {
+      const cached = await cache.get(cacheKey);
+      if (cached) {
+        const { statusCode, headers, body } = deserializeResponse(cached);
+        for (const [key, value] of Object.entries(headers)) {
+          res.setHeader(key, value);
+        }
+        res.setHeader('X-Idempotent-Replayed', 'true');
+        res.status(statusCode).send(body);
+        return;
+      }
+    } catch (err) {
+      // Cache read failure is non-fatal — proceed without idempotency
+      console.error('[idempotency] cache read error:', err);
+    }
+
+    // Intercept the response to cache it
+    interceptResponse(res, cache, cacheKey, ttlSeconds);
+    next();
+  };
+}
+
+/**
+ * Monkey-patches res.json and res.send to capture the response for caching.
+ * After the first response is sent, it's stored in Redis with the configured TTL.
+ */
+function interceptResponse(
+  res: Response,
+  cache: CacheClient,
+  cacheKey: string,
+  ttlSeconds: number,
+): void {
+  const originalJson = res.json.bind(res);
+  const originalSend = res.send.bind(res);
+
+  let captured = false;
+
+  const captureAndCache = (body: string) => {
+    if (captured) return;
+    captured = true;
+
+    // Only cache successful or expected error responses (2xx, 4xx)
+    const status = res.statusCode;
+    if (status >= 200 && status < 500) {
+      const headers: Record<string, string> = {};
+      const contentType = res.getHeader('content-type');
+      if (contentType) headers['content-type'] = String(contentType);
+
+      const serialized = serializeResponse(status, headers, body);
+      cache.set(cacheKey, serialized, 'EX', ttlSeconds).catch((err) => {
+        console.error('[idempotency] cache write error:', err);
+      });
+    }
+  };
+
+  res.json = function patchedJson(data: unknown) {
+    const body = JSON.stringify(data);
+    captureAndCache(body);
+    return originalJson(data);
+  } as typeof res.json;
+
+  res.send = function patchedSend(data: unknown) {
+    const body = typeof data === 'string' ? data : JSON.stringify(data);
+    captureAndCache(body);
+    return originalSend(data);
+  } as typeof res.send;
+}

--- a/modules/api/internal/redis.ts
+++ b/modules/api/internal/redis.ts
@@ -1,0 +1,79 @@
+/** Contract: contracts/api/rules.md */
+import { Redis as IORedis } from 'ioredis';
+
+type RedisInstance = IORedis;
+
+export interface RedisConfig {
+  url: string;
+  /** Key prefix for all operations (default: 'opendesk:') */
+  keyPrefix?: string;
+  /** Max reconnection attempts before giving up (default: 20) */
+  maxRetriesPerRequest?: number;
+  /** Connection timeout in ms (default: 5000) */
+  connectTimeout?: number;
+}
+
+/** Minimal interface for cache operations — allows in-memory substitution in tests. */
+export interface CacheClient {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, mode: 'EX', ttl: number): Promise<string | null>;
+  quit(): Promise<string>;
+  status: string;
+}
+
+const DEFAULT_CONFIG: Partial<RedisConfig> = {
+  keyPrefix: 'opendesk:',
+  maxRetriesPerRequest: 20,
+  connectTimeout: 5000,
+};
+
+let sharedClient: RedisInstance | null = null;
+
+/**
+ * Creates and returns a Redis client with graceful reconnection handling.
+ * Re-uses the same connection across the process.
+ */
+export function getRedisClient(config?: Partial<RedisConfig>): RedisInstance {
+  if (sharedClient && sharedClient.status !== 'end') {
+    return sharedClient;
+  }
+
+  const url = config?.url ?? process.env.REDIS_URL ?? 'redis://localhost:6379';
+  const merged = { ...DEFAULT_CONFIG, ...config, url };
+
+  const client = new IORedis(merged.url, {
+    keyPrefix: merged.keyPrefix,
+    maxRetriesPerRequest: merged.maxRetriesPerRequest,
+    connectTimeout: merged.connectTimeout,
+    retryStrategy(times: number) {
+      if (times > (merged.maxRetriesPerRequest ?? 20)) {
+        console.error(`[redis] giving up after ${times} retries`);
+        return null; // stop retrying
+      }
+      const delay = Math.min(times * 200, 5000);
+      console.warn(`[redis] reconnecting in ${delay}ms (attempt ${times})`);
+      return delay;
+    },
+    lazyConnect: false,
+  });
+
+  client.on('connect', () => console.log('[redis] connected'));
+  client.on('error', (err: Error) => console.error('[redis] error:', err.message));
+  client.on('close', () => console.warn('[redis] connection closed'));
+
+  sharedClient = client;
+  return client;
+}
+
+/** Disconnect the shared client (for graceful shutdown). */
+export async function disconnectRedis(): Promise<void> {
+  if (sharedClient) {
+    await sharedClient.quit();
+    sharedClient = null;
+  }
+}
+
+/** Reset shared client reference (for tests). */
+export function resetRedisClient(): void {
+  sharedClient = null;
+}

--- a/modules/api/internal/server.ts
+++ b/modules/api/internal/server.ts
@@ -13,6 +13,8 @@ import {
   updateDocumentTitle,
 } from '../../storage/internal/pg.ts';
 import { getDocumentForExport } from '../../convert/internal/converter.ts';
+import { getRedisClient, disconnectRedis } from './redis.ts';
+import { idempotencyMiddleware } from './idempotency.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -21,6 +23,10 @@ export function startServer(port = 3000) {
   const { handleUpgrade } = createCollabServer();
 
   app.use(express.json());
+
+  // Idempotency middleware for mutating endpoints (POST, PUT, DELETE)
+  const redisClient = getRedisClient();
+  app.use('/api', idempotencyMiddleware({ cache: redisClient }));
 
   // Serve static frontend
   const publicDir = resolve(__dirname, '../../app/internal/public');
@@ -132,6 +138,15 @@ export function startServer(port = 3000) {
     console.log(`[opendesk] server running at http://localhost:${port}`);
     console.log(`[opendesk] WebSocket collab at ws://localhost:${port}/collab`);
   });
+
+  // Graceful shutdown: disconnect Redis on process exit
+  const shutdown = async () => {
+    console.log('[opendesk] shutting down...');
+    await disconnectRedis();
+    httpServer.close();
+  };
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
 
   return httpServer;
 }

--- a/modules/api/internal/test-helpers.ts
+++ b/modules/api/internal/test-helpers.ts
@@ -1,0 +1,79 @@
+/** Shared test helpers for api module tests. */
+import type { Request, Response } from 'express';
+import type { CacheClient } from './redis.ts';
+
+/** In-memory cache implementing CacheClient — a real Map-backed store, not a mock. */
+export class InMemoryCache implements CacheClient {
+  private store = new Map<string, { value: string; expiresAt: number }>();
+  status = 'ready';
+
+  async get(key: string): Promise<string | null> {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  async set(key: string, value: string, _mode: 'EX', ttl: number): Promise<string | null> {
+    this.store.set(key, { value, expiresAt: Date.now() + ttl * 1000 });
+    return 'OK';
+  }
+
+  async quit(): Promise<string> {
+    this.store.clear();
+    return 'OK';
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+export type TestResponse = Response & {
+  _status: number;
+  _body: unknown;
+  _headers: Record<string, string>;
+};
+
+export function makeReq(overrides: Partial<Request> = {}): Request {
+  return {
+    method: 'POST',
+    path: '/api/documents',
+    headers: {},
+    ...overrides,
+  } as unknown as Request;
+}
+
+export function makeRes(): TestResponse {
+  const res = {
+    _status: 200,
+    _body: undefined as unknown,
+    _headers: {} as Record<string, string>,
+    statusCode: 200,
+
+    status(code: number) {
+      res._status = code;
+      res.statusCode = code;
+      return res;
+    },
+    json(data: unknown) {
+      res._body = data;
+      return res;
+    },
+    send(data: unknown) {
+      res._body = data;
+      return res;
+    },
+    setHeader(key: string, value: string) {
+      res._headers[key] = value;
+      return res;
+    },
+    getHeader(key: string) {
+      return res._headers[key];
+    },
+  };
+  return res as unknown as TestResponse;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@tiptap/pm": "^3.22.2",
         "@tiptap/starter-kit": "^3.22.2",
         "express": "^5.2.1",
+        "ioredis": "^5.10.1",
         "pg": "^8.20.0",
         "y-prosemirror": "^1.3.7",
         "yjs": "^13.6.30",
@@ -725,6 +726,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
@@ -2314,6 +2321,15 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2435,6 +2451,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -3176,6 +3201,30 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ioredis": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+      "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.5.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -3356,6 +3405,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -4124,6 +4185,27 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4407,6 +4489,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
     "node_modules/statuses": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@tiptap/pm": "^3.22.2",
     "@tiptap/starter-kit": "^3.22.2",
     "express": "^5.2.1",
+    "ioredis": "^5.10.1",
     "pg": "^8.20.0",
     "y-prosemirror": "^1.3.7",
     "yjs": "^13.6.30",


### PR DESCRIPTION
## Summary
- Redis client helper (`ioredis`, singleton, exponential backoff reconnect)
- Idempotency middleware: caches by `Idempotency-Key` header for 24h, skips 5xx, graceful degradation
- Wired into Express for all mutating endpoints (POST/PUT/DELETE)
- Graceful Redis shutdown on SIGTERM/SIGINT

## Test plan
- [ ] 14 new tests (cache hit/miss, TTL, 5xx exclusion, resilience, key generation)
- [ ] `npm run lint` clean
- [ ] `npm test` passes

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)