### PR TITLE
CRDT compaction in worker threads

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,50 @@
+import js from '@eslint/js';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['modules/**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+      },
+      globals: {
+        console: 'readonly',
+        process: 'readonly',
+        Buffer: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        setInterval: 'readonly',
+        clearInterval: 'readonly',
+        URL: 'readonly',
+        Uint8Array: 'readonly',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      // TypeScript handles these
+      'no-unused-vars': 'off',
+      'no-undef': 'off',
+
+      // Code quality
+      'no-redeclare': 'off',
+      'no-console': 'off',
+      'no-debugger': 'error',
+      'no-duplicate-imports': 'error',
+      'prefer-const': 'error',
+      'no-var': 'error',
+
+      // Contract enforcement
+      'max-lines': ['warn', { max: 200, skipBlankLines: true, skipComments: true }],
+    },
+  },
+  {
+    ignores: ['node_modules/', 'dist/', '**/*.bundle.js', '**/*.js', '!eslint.config.js'],
+  },
+];

--- a/modules/collab/internal/compaction-manager.test.ts
+++ b/modules/collab/internal/compaction-manager.test.ts
@@ -1,0 +1,148 @@
+/** Contract: contracts/collab/rules.md */
+import { describe, it, expect } from 'vitest';
+import * as Y from 'yjs';
+import { CompactionManager, type StorageAdapter } from './compaction-manager.ts';
+
+/** In-memory storage adapter for testing (real Yjs state, no mocks). */
+function createMemoryStorage(): StorageAdapter & {
+  states: Map<string, Uint8Array>;
+} {
+  const states = new Map<string, Uint8Array>();
+  return {
+    states,
+    async saveYjsState(docId: string, state: Uint8Array) {
+      states.set(docId, state);
+    },
+    async loadYjsState(docId: string) {
+      return states.get(docId) ?? null;
+    },
+  };
+}
+
+/** Build a Yjs doc with many edits that produce a bloated state. */
+function buildBloatedDoc(editCount: number): {
+  doc: Y.Doc;
+  state: Uint8Array;
+} {
+  const doc = new Y.Doc();
+  const text = doc.getText('content');
+
+  for (let i = 0; i < editCount; i++) {
+    text.insert(text.length, `edit-${i} `);
+  }
+  // Delete half the content to create tombstones
+  const len = text.toString().length;
+  text.delete(0, Math.floor(len / 2));
+
+  const state = Y.encodeStateAsUpdate(doc);
+  return { doc, state };
+}
+
+describe('CompactionManager', () => {
+  it('skips compaction when state is below threshold', async () => {
+    const storage = createMemoryStorage();
+    const manager = new CompactionManager(1_000_000, storage);
+
+    const doc = new Y.Doc();
+    doc.getText('content').insert(0, 'small');
+    const state = Y.encodeStateAsUpdate(doc);
+
+    const result = await manager.maybeCompact('doc-1', state);
+    expect(result).toBeNull();
+    expect(storage.states.size).toBe(0);
+
+    doc.destroy();
+  });
+
+  it('triggers compaction when state exceeds threshold', async () => {
+    const storage = createMemoryStorage();
+    // Set a very low threshold so compaction triggers
+    const manager = new CompactionManager(100, storage);
+
+    const { doc, state } = buildBloatedDoc(200);
+
+    const result = await manager.maybeCompact('doc-1', state);
+    expect(result).not.toBeNull();
+    expect(result!.documentId).toBe('doc-1');
+    expect(result!.originalSize).toBe(state.byteLength);
+    expect(result!.compactedSize).toBeGreaterThan(0);
+    expect(result!.durationMs).toBeGreaterThanOrEqual(0);
+
+    // Verify compacted state was persisted
+    const persisted = storage.states.get('doc-1');
+    expect(persisted).toBeDefined();
+
+    // Verify persisted state produces identical content
+    const verifyDoc = new Y.Doc();
+    Y.applyUpdate(verifyDoc, persisted!);
+    expect(verifyDoc.getText('content').toString()).toBe(
+      doc.getText('content').toString(),
+    );
+
+    doc.destroy();
+    verifyDoc.destroy();
+  }, 15_000);
+
+  it('compaction reduces state size for edit-heavy documents', async () => {
+    const storage = createMemoryStorage();
+    const manager = new CompactionManager(100, storage);
+
+    const { doc, state } = buildBloatedDoc(500);
+
+    const result = await manager.maybeCompact('doc-2', state);
+    expect(result).not.toBeNull();
+
+    // After heavy edits + deletes, compacted should be smaller
+    // (tombstones get cleaned up in re-encoding)
+    expect(result!.compactedSize).toBeLessThanOrEqual(
+      result!.originalSize,
+    );
+
+    doc.destroy();
+  }, 15_000);
+
+  it('prevents concurrent compaction of the same document', async () => {
+    const storage = createMemoryStorage();
+    const manager = new CompactionManager(100, storage);
+
+    const { doc, state } = buildBloatedDoc(200);
+
+    // Fire two compactions simultaneously
+    const [result1, result2] = await Promise.all([
+      manager.maybeCompact('doc-3', state),
+      manager.maybeCompact('doc-3', state),
+    ]);
+
+    // Exactly one should have run, the other skipped
+    const results = [result1, result2].filter((r) => r !== null);
+    expect(results.length).toBe(1);
+
+    doc.destroy();
+  }, 15_000);
+
+  it('allows compaction of different documents concurrently', async () => {
+    const storage = createMemoryStorage();
+    const manager = new CompactionManager(100, storage);
+
+    const doc1 = buildBloatedDoc(200);
+    const doc2 = buildBloatedDoc(200);
+
+    const [result1, result2] = await Promise.all([
+      manager.maybeCompact('doc-a', doc1.state),
+      manager.maybeCompact('doc-b', doc2.state),
+    ]);
+
+    expect(result1).not.toBeNull();
+    expect(result2).not.toBeNull();
+
+    doc1.doc.destroy();
+    doc2.doc.destroy();
+  }, 15_000);
+
+  it('exposes active compaction set', async () => {
+    const storage = createMemoryStorage();
+    const manager = new CompactionManager(100, storage);
+
+    expect(manager.activeCompactions.size).toBe(0);
+  });
+});

--- a/modules/collab/internal/compaction-manager.ts
+++ b/modules/collab/internal/compaction-manager.ts
@@ -1,0 +1,128 @@
+/** Contract: contracts/collab/rules.md */
+import { Worker } from 'node:worker_threads';
+
+export interface CompactionResult {
+  documentId: string;
+  originalSize: number;
+  compactedSize: number;
+  durationMs: number;
+}
+
+export interface StorageAdapter {
+  saveYjsState(docId: string, state: Uint8Array): Promise<void>;
+  loadYjsState(docId: string): Promise<Uint8Array | null>;
+}
+
+/**
+ * Inline ESM worker code for CRDT compaction.
+ * Uses eval mode to avoid .ts extension loader issues in worker_threads.
+ * The logic is minimal: apply update to fresh doc, re-encode.
+ */
+const WORKER_CODE = `
+import { workerData, parentPort } from 'node:worker_threads';
+import * as Y from 'yjs';
+
+try {
+  const doc = new Y.Doc();
+  Y.applyUpdate(doc, workerData.state);
+  const compacted = Y.encodeStateAsUpdate(doc);
+  doc.destroy();
+  parentPort.postMessage({ compacted }, [compacted.buffer]);
+} catch (err) {
+  parentPort.postMessage({
+    error: err instanceof Error ? err.message : String(err),
+  });
+}
+`;
+
+/**
+ * Monitors document state size and triggers off-thread compaction
+ * when the byte threshold is exceeded.
+ */
+export class CompactionManager {
+  private readonly thresholdBytes: number;
+  private readonly storage: StorageAdapter;
+  private readonly active = new Set<string>();
+
+  constructor(thresholdBytes: number, storage: StorageAdapter) {
+    this.thresholdBytes = thresholdBytes;
+    this.storage = storage;
+  }
+
+  /**
+   * Check whether a document's state exceeds the compaction threshold.
+   * If so, spawn a worker to compact it and atomically swap in storage.
+   * Returns null if compaction was not needed or already in progress.
+   */
+  async maybeCompact(
+    documentId: string,
+    currentState: Uint8Array,
+  ): Promise<CompactionResult | null> {
+    if (currentState.byteLength < this.thresholdBytes) {
+      return null;
+    }
+
+    if (this.active.has(documentId)) {
+      return null;
+    }
+
+    this.active.add(documentId);
+    try {
+      return await this.runCompaction(documentId, currentState);
+    } finally {
+      this.active.delete(documentId);
+    }
+  }
+
+  /** Returns the set of document IDs currently being compacted. */
+  get activeCompactions(): ReadonlySet<string> {
+    return this.active;
+  }
+
+  private runCompaction(
+    documentId: string,
+    state: Uint8Array,
+  ): Promise<CompactionResult> {
+    const startMs = Date.now();
+    const originalSize = state.byteLength;
+
+    return new Promise<CompactionResult>((resolve, reject) => {
+      const worker = new Worker(WORKER_CODE, {
+        workerData: { state },
+        eval: true,
+      });
+
+      worker.on('message', async (msg) => {
+        if (msg.error) {
+          reject(new Error(`Compaction worker error: ${msg.error}`));
+          return;
+        }
+
+        const compacted = new Uint8Array(msg.compacted);
+        try {
+          await this.storage.saveYjsState(documentId, compacted);
+          resolve({
+            documentId,
+            originalSize,
+            compactedSize: compacted.byteLength,
+            durationMs: Date.now() - startMs,
+          });
+        } catch (err) {
+          reject(
+            err instanceof Error ? err : new Error(String(err)),
+          );
+        }
+      });
+
+      worker.on('error', (err) => {
+        reject(new Error(`Compaction worker crashed: ${err.message}`));
+      });
+
+      worker.on('exit', (code) => {
+        if (code !== 0) {
+          reject(new Error(`Compaction worker exited with code ${code}`));
+        }
+      });
+    });
+  }
+}

--- a/modules/collab/internal/compaction-worker.test.ts
+++ b/modules/collab/internal/compaction-worker.test.ts
@@ -1,0 +1,98 @@
+/** Contract: contracts/collab/rules.md */
+import { describe, it, expect } from 'vitest';
+import * as Y from 'yjs';
+import { compact } from './compaction-worker.ts';
+
+describe('compaction-worker: compact()', () => {
+  it('preserves document content after compaction', () => {
+    const doc = new Y.Doc();
+    const text = doc.getText('content');
+
+    // Apply many individual updates to build up history
+    for (let i = 0; i < 100; i++) {
+      text.insert(text.length, `line ${i}\n`);
+    }
+
+    const state = Y.encodeStateAsUpdate(doc);
+    const compacted = compact({ state });
+
+    // Verify the compacted state produces identical content
+    const verifyDoc = new Y.Doc();
+    Y.applyUpdate(verifyDoc, compacted);
+    const verifyText = verifyDoc.getText('content');
+
+    expect(verifyText.toString()).toBe(text.toString());
+
+    doc.destroy();
+    verifyDoc.destroy();
+  });
+
+  it('preserves complex document structures', () => {
+    const doc = new Y.Doc();
+    const text = doc.getText('content');
+    const map = doc.getMap('meta');
+    const array = doc.getArray('items');
+
+    text.insert(0, 'Hello, world!');
+    map.set('title', 'Test Document');
+    map.set('version', 42);
+    array.push(['item1', 'item2', 'item3']);
+
+    const state = Y.encodeStateAsUpdate(doc);
+    const compacted = compact({ state });
+
+    const verifyDoc = new Y.Doc();
+    Y.applyUpdate(verifyDoc, compacted);
+
+    expect(verifyDoc.getText('content').toString()).toBe('Hello, world!');
+    expect(verifyDoc.getMap('meta').get('title')).toBe('Test Document');
+    expect(verifyDoc.getMap('meta').get('version')).toBe(42);
+    expect(verifyDoc.getArray('items').toArray()).toEqual([
+      'item1',
+      'item2',
+      'item3',
+    ]);
+
+    doc.destroy();
+    verifyDoc.destroy();
+  });
+
+  it('handles empty documents', () => {
+    const doc = new Y.Doc();
+    const state = Y.encodeStateAsUpdate(doc);
+    const compacted = compact({ state });
+
+    const verifyDoc = new Y.Doc();
+    Y.applyUpdate(verifyDoc, compacted);
+
+    expect(verifyDoc.getText('content').toString()).toBe('');
+    doc.destroy();
+    verifyDoc.destroy();
+  });
+
+  it('preserves content after delete-heavy editing', () => {
+    const doc = new Y.Doc();
+    const text = doc.getText('content');
+
+    // Insert lots of text then delete most of it
+    for (let i = 0; i < 200; i++) {
+      text.insert(text.length, `chunk-${i} `);
+    }
+    // Delete most content, leaving only the last chunk
+    const finalContent = text.toString();
+    const keepLength = 20;
+    text.delete(0, finalContent.length - keepLength);
+
+    const remaining = text.toString();
+    const state = Y.encodeStateAsUpdate(doc);
+    const compacted = compact({ state });
+
+    const verifyDoc = new Y.Doc();
+    Y.applyUpdate(verifyDoc, compacted);
+
+    expect(verifyDoc.getText('content').toString()).toBe(remaining);
+
+    doc.destroy();
+    verifyDoc.destroy();
+  });
+});

--- a/modules/collab/internal/compaction-worker.ts
+++ b/modules/collab/internal/compaction-worker.ts
@@ -1,0 +1,28 @@
+/** Contract: contracts/collab/rules.md */
+import * as Y from 'yjs';
+
+/**
+ * Pure compaction logic for Yjs CRDT state.
+ *
+ * Creates a fresh Yjs Doc, applies the input state, and re-encodes.
+ * This eliminates tombstones and redundant history from the CRDT.
+ *
+ * The actual worker_threads execution is handled by inline ESM code
+ * in compaction-manager.ts to avoid .ts loader issues in workers.
+ * This module is exported for direct unit testing.
+ */
+
+export interface CompactionInput {
+  state: Uint8Array;
+}
+
+export function compact(input: CompactionInput): Uint8Array {
+  const sourceDoc = new Y.Doc();
+  Y.applyUpdate(sourceDoc, input.state);
+
+  // Encode as full state snapshot (eliminates tombstones + history)
+  const compacted = Y.encodeStateAsUpdate(sourceDoc);
+  sourceDoc.destroy();
+
+  return compacted;
+}

--- a/modules/collab/internal/server.ts
+++ b/modules/collab/internal/server.ts
@@ -5,14 +5,26 @@ import * as Y from 'yjs';
 import type { IncomingMessage } from 'node:http';
 import type { Duplex } from 'node:stream';
 import { saveYjsState, loadYjsState } from '../../storage/internal/pg.ts';
+import { CompactionManager } from './compaction-manager.ts';
+import type { CollabConfig } from '../contract.ts';
 
-export function createCollabServer() {
+const DEFAULT_COMPACTION_THRESHOLD = 1_048_576; // 1 MiB
+
+export function createCollabServer(config?: Partial<CollabConfig>) {
+  const thresholdBytes =
+    config?.compactionThresholdBytes ?? DEFAULT_COMPACTION_THRESHOLD;
+
+  const compactionManager = new CompactionManager(thresholdBytes, {
+    saveYjsState,
+    loadYjsState,
+  });
+
   const hocuspocus = new Hocuspocus({
-    name: 'opendesk-collab',
+    name: config?.hocuspocus?.name ?? 'opendesk-collab',
     timeout: 30000,
     debounce: 2000,
     maxDebounce: 10000,
-    quiet: true,
+    quiet: config?.hocuspocus?.quiet ?? true,
 
     async onLoadDocument({ document, documentName }) {
       const state = await loadYjsState(documentName);
@@ -25,6 +37,15 @@ export function createCollabServer() {
     async onStoreDocument({ documentName, document }) {
       const state = Y.encodeStateAsUpdate(document);
       await saveYjsState(documentName, state);
+
+      // Trigger compaction check asynchronously (fire-and-forget).
+      // Errors are logged but do not block the save cycle.
+      compactionManager.maybeCompact(documentName, state).catch((err) => {
+        console.error(
+          `[collab] compaction failed for ${documentName}:`,
+          err,
+        );
+      });
     },
   });
 
@@ -34,11 +55,15 @@ export function createCollabServer() {
     hocuspocus.handleConnection(ws, request);
   });
 
-  function handleUpgrade(request: IncomingMessage, socket: Duplex, head: Buffer) {
+  function handleUpgrade(
+    request: IncomingMessage,
+    socket: Duplex,
+    head: Buffer,
+  ) {
     wss.handleUpgrade(request, socket, head, (ws) => {
       wss.emit('connection', ws, request);
     });
   }
 
-  return { hocuspocus, handleUpgrade };
+  return { hocuspocus, handleUpgrade, compactionManager };
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['modules/**/*.test.ts'],
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- Compaction worker using `worker_threads` — re-encodes Yjs state to eliminate tombstones
- `CompactionManager` with configurable byte threshold (default 1 MiB)
- Per-document deduplication, parallel compaction across different docs
- Hooked into Hocuspocus `onStoreDocument` (fire-and-forget, never blocks saves)
- Uses inline ESM eval mode for worker (avoids .ts loader issues)

## Test plan
- [ ] 10 new tests (content preservation, size reduction, concurrency dedup, complex structures)
- [ ] `npm run lint` clean
- [ ] `npm test` passes

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)