### PR TITLE
Permissions: enforce at API boundary

### DIFF
--- a/modules/api/internal/document-routes.ts
+++ b/modules/api/internal/document-routes.ts
@@ -50,7 +50,7 @@ export function createDocumentRoutes(opts: DocumentRoutesOptions): Router {
 
   // Get document — requires read permission
   router.get('/:id', permissions.require('read'), async (req: Request, res: Response) => {
-    const doc = await getDocument(req.params.id);
+    const doc = await getDocument(String(req.params.id));
     if (!doc) {
       res.status(404).json({ error: 'Document not found' });
       return;
@@ -65,13 +65,13 @@ export function createDocumentRoutes(opts: DocumentRoutesOptions): Router {
       res.status(400).json({ error: 'title is required' });
       return;
     }
-    await updateDocumentTitle(req.params.id, title);
+    await updateDocumentTitle(String(req.params.id), title);
     res.json({ ok: true });
   });
 
   // Delete document — requires delete permission
   router.delete('/:id', permissions.require('delete'), async (req: Request, res: Response) => {
-    const deleted = await deleteDocument(req.params.id);
+    const deleted = await deleteDocument(String(req.params.id));
     if (!deleted) {
       res.status(404).json({ error: 'Document not found' });
       return;

--- a/modules/api/internal/document-routes.ts
+++ b/modules/api/internal/document-routes.ts
@@ -1,0 +1,83 @@
+/** Contract: contracts/api/rules.md */
+
+import { Router, type Request, type Response } from 'express';
+import { randomUUID } from 'node:crypto';
+import {
+  listDocuments,
+  createDocument,
+  getDocument,
+  deleteDocument,
+  updateDocumentTitle,
+} from '../../storage/internal/pg.ts';
+import type { PermissionsModule } from '../../permissions/index.ts';
+
+export type DocumentRoutesOptions = {
+  permissions: PermissionsModule;
+};
+
+/**
+ * Mount document CRUD routes onto a router.
+ * Each route enforces authentication and permission checks.
+ */
+export function createDocumentRoutes(opts: DocumentRoutesOptions): Router {
+  const router = Router();
+  const { permissions } = opts;
+
+  // List documents — requires auth only (no specific resource)
+  router.get('/', permissions.requireAuth, async (_req: Request, res: Response) => {
+    const docs = await listDocuments();
+    res.json(docs);
+  });
+
+  // Create document — requires auth, auto-grants owner role to creator
+  router.post('/', permissions.requireAuth, async (req: Request, res: Response) => {
+    const title = req.body?.title || 'Untitled';
+    const id = randomUUID();
+    const doc = await createDocument(id, title);
+
+    // Auto-grant owner role to document creator
+    const principal = req.principal!;
+    await permissions.grantStore.create({
+      principalId: principal.id,
+      resourceId: id,
+      resourceType: 'document',
+      role: 'owner',
+      grantedBy: principal.id,
+    });
+
+    res.status(201).json(doc);
+  });
+
+  // Get document — requires read permission
+  router.get('/:id', permissions.require('read'), async (req: Request, res: Response) => {
+    const doc = await getDocument(req.params.id);
+    if (!doc) {
+      res.status(404).json({ error: 'Document not found' });
+      return;
+    }
+    res.json(doc);
+  });
+
+  // Update document title — requires write permission
+  router.patch('/:id', permissions.require('write'), async (req: Request, res: Response) => {
+    const { title } = req.body;
+    if (!title) {
+      res.status(400).json({ error: 'title is required' });
+      return;
+    }
+    await updateDocumentTitle(req.params.id, title);
+    res.json({ ok: true });
+  });
+
+  // Delete document — requires delete permission
+  router.delete('/:id', permissions.require('delete'), async (req: Request, res: Response) => {
+    const deleted = await deleteDocument(req.params.id);
+    if (!deleted) {
+      res.status(404).json({ error: 'Document not found' });
+      return;
+    }
+    res.json({ ok: true });
+  });
+
+  return router;
+}

--- a/modules/api/internal/export-routes.ts
+++ b/modules/api/internal/export-routes.ts
@@ -24,7 +24,7 @@ export function createExportRoutes(opts: ExportRoutesOptions): Router {
       res.status(400).json({ error: 'format must be "html" or "text"' });
       return;
     }
-    const meta = await getDocumentForExport(req.params.id);
+    const meta = await getDocumentForExport(String(req.params.id));
     if (!meta) {
       res.status(404).json({ error: 'Document not found' });
       return;
@@ -51,7 +51,7 @@ export function createExportRoutes(opts: ExportRoutesOptions): Router {
       res.status(400).json({ error: 'html content is required' });
       return;
     }
-    const doc = await getDocument(req.params.id);
+    const doc = await getDocument(String(req.params.id));
     if (!doc) {
       res.status(404).json({ error: 'Document not found' });
       return;

--- a/modules/api/internal/export-routes.ts
+++ b/modules/api/internal/export-routes.ts
@@ -1,0 +1,63 @@
+/** Contract: contracts/api/rules.md */
+
+import { Router, type Request, type Response } from 'express';
+import { getDocument } from '../../storage/internal/pg.ts';
+import { getDocumentForExport } from '../../convert/internal/converter.ts';
+import type { PermissionsModule } from '../../permissions/index.ts';
+
+export type ExportRoutesOptions = {
+  permissions: PermissionsModule;
+};
+
+/**
+ * Mount export/import routes onto a router.
+ * Each route enforces authentication and permission checks.
+ */
+export function createExportRoutes(opts: ExportRoutesOptions): Router {
+  const router = Router();
+  const { permissions } = opts;
+
+  // Export document — requires read permission
+  router.post('/:id/export', permissions.require('read'), async (req: Request, res: Response) => {
+    const format = req.body?.format;
+    if (!format || !['html', 'text'].includes(format)) {
+      res.status(400).json({ error: 'format must be "html" or "text"' });
+      return;
+    }
+    const meta = await getDocumentForExport(req.params.id);
+    if (!meta) {
+      res.status(404).json({ error: 'Document not found' });
+      return;
+    }
+    const content = req.body?.content;
+    if (!content && content !== '') {
+      res.status(400).json({ error: 'content is required (client-side export)' });
+      return;
+    }
+    const ext = format === 'html' ? 'html' : 'txt';
+    const filename = `${meta.title || 'document'}.${ext}`;
+    const contentType = format === 'html'
+      ? 'text/html; charset=utf-8'
+      : 'text/plain; charset=utf-8';
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Content-Disposition', `attachment; filename="${encodeURIComponent(filename)}"`);
+    res.send(content);
+  });
+
+  // Import HTML into document — requires write permission
+  router.post('/:id/import', permissions.require('write'), async (req: Request, res: Response) => {
+    const html = req.body?.html;
+    if (!html) {
+      res.status(400).json({ error: 'html content is required' });
+      return;
+    }
+    const doc = await getDocument(req.params.id);
+    if (!doc) {
+      res.status(404).json({ error: 'Document not found' });
+      return;
+    }
+    res.json({ ok: true, html, documentId: req.params.id });
+  });
+
+  return router;
+}

--- a/modules/api/internal/server.ts
+++ b/modules/api/internal/server.ts
@@ -1,27 +1,36 @@
 /** Contract: contracts/api/rules.md */
 import { createServer } from 'node:http';
-import { randomUUID } from 'node:crypto';
 import express from 'express';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createCollabServer } from '../../collab/internal/server.ts';
-import {
-  listDocuments,
-  createDocument,
-  getDocument,
-  deleteDocument,
-  updateDocumentTitle,
-} from '../../storage/internal/pg.ts';
-import { getDocumentForExport } from '../../convert/internal/converter.ts';
 import { getRedisClient, disconnectRedis } from './redis.ts';
 import { idempotencyMiddleware } from './idempotency.ts';
 import { createConvertRoutes } from './convert-routes.ts';
+import { createAuth } from '../../auth/index.ts';
+import { createPermissions } from '../../permissions/index.ts';
+import { createDocumentRoutes } from './document-routes.ts';
+import { createExportRoutes } from './export-routes.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export function startServer(port = 3000) {
   const app = express();
   const { handleUpgrade } = createCollabServer();
+
+  // Wire auth module (dev mode uses bypass verifiers)
+  const auth = createAuth({
+    serviceAccountStore: { findByHashedKey: async () => null },
+    serviceAccountStorage: {
+      save: async () => {},
+      findById: async () => null,
+      delete: async () => {},
+    },
+    publicPaths: ['/api/health'],
+  });
+
+  // Wire permissions module
+  const permissions = createPermissions();
 
   app.use(express.json());
 
@@ -36,96 +45,19 @@ export function startServer(port = 3000) {
   const publicDir = resolve(__dirname, '../../app/internal/public');
   app.use(express.static(publicDir));
 
-  // Health check
+  // Auth middleware on all /api routes (except public paths)
+  app.use('/api', auth.middleware);
+
+  // Health check (public, skipped by auth middleware)
   app.get('/api/health', (_req, res) => {
     res.json({ status: 'ok', version: '0.1.0' });
   });
 
-  // List documents
-  app.get('/api/documents', async (_req, res) => {
-    const docs = await listDocuments();
-    res.json(docs);
-  });
+  // Document CRUD with permission checks
+  app.use('/api/documents', createDocumentRoutes({ permissions }));
 
-  // Create document
-  app.post('/api/documents', async (req, res) => {
-    const title = req.body?.title || 'Untitled';
-    const id = randomUUID();
-    const doc = await createDocument(id, title);
-    res.status(201).json(doc);
-  });
-
-  // Get document
-  app.get('/api/documents/:id', async (req, res) => {
-    const doc = await getDocument(req.params.id);
-    if (!doc) {
-      res.status(404).json({ error: 'Document not found' });
-      return;
-    }
-    res.json(doc);
-  });
-
-  // Update document title
-  app.patch('/api/documents/:id', async (req, res) => {
-    const { title } = req.body;
-    if (!title) {
-      res.status(400).json({ error: 'title is required' });
-      return;
-    }
-    await updateDocumentTitle(req.params.id, title);
-    res.json({ ok: true });
-  });
-
-  // Delete document
-  app.delete('/api/documents/:id', async (req, res) => {
-    const deleted = await deleteDocument(req.params.id);
-    if (!deleted) {
-      res.status(404).json({ error: 'Document not found' });
-      return;
-    }
-    res.json({ ok: true });
-  });
-
-  // Export document (MVP: returns metadata; actual content comes client-side)
-  app.post('/api/documents/:id/export', async (req, res) => {
-    const format = req.body?.format;
-    if (!format || !['html', 'text'].includes(format)) {
-      res.status(400).json({ error: 'format must be "html" or "text"' });
-      return;
-    }
-    const meta = await getDocumentForExport(req.params.id);
-    if (!meta) {
-      res.status(404).json({ error: 'Document not found' });
-      return;
-    }
-    // For MVP, the client sends content along with the request
-    const content = req.body?.content;
-    if (!content && content !== '') {
-      res.status(400).json({ error: 'content is required (client-side export)' });
-      return;
-    }
-    const filename = `${meta.title || 'document'}.${format === 'html' ? 'html' : 'txt'}`;
-    const contentType = format === 'html' ? 'text/html; charset=utf-8' : 'text/plain; charset=utf-8';
-    res.setHeader('Content-Type', contentType);
-    res.setHeader('Content-Disposition', `attachment; filename="${encodeURIComponent(filename)}"`);
-    res.send(content);
-  });
-
-  // Import HTML file into document (MVP: accept raw HTML in body)
-  app.post('/api/documents/:id/import', async (req, res) => {
-    const html = req.body?.html;
-    if (!html) {
-      res.status(400).json({ error: 'html content is required' });
-      return;
-    }
-    const doc = await getDocument(req.params.id);
-    if (!doc) {
-      res.status(404).json({ error: 'Document not found' });
-      return;
-    }
-    // For MVP, we return the HTML and let the client set it via editor.commands.setContent()
-    res.json({ ok: true, html, documentId: req.params.id });
-  });
+  // Export/import routes with permission checks
+  app.use('/api/documents', createExportRoutes({ permissions }));
 
   const httpServer = createServer(app);
 

--- a/modules/api/internal/server.ts
+++ b/modules/api/internal/server.ts
@@ -20,11 +20,11 @@ export function startServer(port = 3000) {
 
   // Wire auth module (dev mode uses bypass verifiers)
   const auth = createAuth({
-    serviceAccountStore: { findByHashedKey: async () => null },
+    serviceAccountStore: { findByKeyHash: async () => null },
     serviceAccountStorage: {
-      save: async () => {},
-      findById: async () => null,
-      delete: async () => {},
+      insertServiceAccount: async () => {},
+      findServiceAccountById: async () => null,
+      revokeServiceAccount: async () => {},
     },
     publicPaths: ['/api/health'],
   });

--- a/modules/permissions/index.ts
+++ b/modules/permissions/index.ts
@@ -25,3 +25,19 @@ export {
   // Evaluation
   evaluate,
 } from './contract.ts';
+
+// Grant storage
+export {
+  type GrantStore,
+  createInMemoryGrantStore,
+} from './internal/grant-store.ts';
+
+// Middleware
+export { requirePermission, requireAuth } from './internal/middleware.ts';
+
+// Factory
+export {
+  createPermissions,
+  type PermissionsModule,
+  type PermissionsDependencies,
+} from './internal/create-permissions.ts';

--- a/modules/permissions/internal/create-permissions.ts
+++ b/modules/permissions/internal/create-permissions.ts
@@ -1,0 +1,32 @@
+/** Contract: contracts/permissions/rules.md */
+
+import type { Action } from '../contract.ts';
+import { createInMemoryGrantStore, type GrantStore } from './grant-store.ts';
+import { requirePermission, requireAuth } from './middleware.ts';
+
+export type PermissionsModule = {
+  grantStore: GrantStore;
+  /** Middleware: require a specific permission on a document resource. */
+  require: (action: Action) => ReturnType<typeof requirePermission>;
+  /** Middleware: require authentication only (no resource-level check). */
+  requireAuth: ReturnType<typeof requireAuth>;
+};
+
+export type PermissionsDependencies = {
+  grantStore?: GrantStore;
+};
+
+/**
+ * Factory function that wires up the permissions module.
+ * Call once at application startup.
+ */
+export function createPermissions(deps: PermissionsDependencies = {}): PermissionsModule {
+  const grantStore = deps.grantStore ?? createInMemoryGrantStore();
+
+  return {
+    grantStore,
+    require: (action: Action) =>
+      requirePermission(action, { grantStore, resourceType: 'document' }),
+    requireAuth: requireAuth(),
+  };
+}

--- a/modules/permissions/internal/grant-store.test.ts
+++ b/modules/permissions/internal/grant-store.test.ts
@@ -1,0 +1,80 @@
+/** Contract: contracts/permissions/rules.md — Grant store tests */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createInMemoryGrantStore, type GrantStore } from './grant-store.ts';
+import type { GrantDef } from '../contract.ts';
+
+function makeDef(overrides: Partial<GrantDef> = {}): GrantDef {
+  return {
+    principalId: 'user-1',
+    resourceId: 'doc-1',
+    resourceType: 'document',
+    role: 'editor',
+    grantedBy: 'admin',
+    ...overrides,
+  };
+}
+
+describe('InMemoryGrantStore', () => {
+  let store: GrantStore;
+
+  beforeEach(() => {
+    store = createInMemoryGrantStore();
+  });
+
+  it('creates a grant with generated id and timestamp', async () => {
+    const grant = await store.create(makeDef());
+    expect(grant.id).toBeTruthy();
+    expect(grant.grantedAt).toBeTruthy();
+    expect(grant.principalId).toBe('user-1');
+    expect(grant.role).toBe('editor');
+  });
+
+  it('finds grants by principal and resource', async () => {
+    await store.create(makeDef());
+    await store.create(makeDef({ principalId: 'user-2' }));
+
+    const results = await store.findByPrincipalAndResource('user-1', 'doc-1', 'document');
+    expect(results).toHaveLength(1);
+    expect(results[0].principalId).toBe('user-1');
+  });
+
+  it('finds grants by resource', async () => {
+    await store.create(makeDef({ principalId: 'user-1' }));
+    await store.create(makeDef({ principalId: 'user-2' }));
+    await store.create(makeDef({ resourceId: 'doc-2' }));
+
+    const results = await store.findByResource('doc-1', 'document');
+    expect(results).toHaveLength(2);
+  });
+
+  it('revokes a grant by id', async () => {
+    const grant = await store.create(makeDef());
+    const revoked = await store.revoke(grant.id);
+    expect(revoked).toBe(true);
+
+    const found = await store.findById(grant.id);
+    expect(found).toBeNull();
+  });
+
+  it('returns false when revoking nonexistent grant', async () => {
+    const revoked = await store.revoke('nonexistent');
+    expect(revoked).toBe(false);
+  });
+
+  it('finds a grant by id', async () => {
+    const grant = await store.create(makeDef());
+    const found = await store.findById(grant.id);
+    expect(found).toEqual(grant);
+  });
+
+  it('returns null for nonexistent grant id', async () => {
+    const found = await store.findById('nonexistent');
+    expect(found).toBeNull();
+  });
+
+  it('stores expiresAt when provided', async () => {
+    const expiresAt = new Date(Date.now() + 3600000).toISOString();
+    const grant = await store.create(makeDef({ expiresAt }));
+    expect(grant.expiresAt).toBe(expiresAt);
+  });
+});

--- a/modules/permissions/internal/grant-store.ts
+++ b/modules/permissions/internal/grant-store.ts
@@ -1,0 +1,86 @@
+/** Contract: contracts/permissions/rules.md */
+
+import { randomUUID } from 'node:crypto';
+import type { Grant, GrantDef } from '../contract.ts';
+
+/**
+ * Interface for grant persistence.
+ * Implementations must be swappable (in-memory for dev/test, PG for prod).
+ */
+export type GrantStore = {
+  /** Find all grants for a principal on a specific resource. */
+  findByPrincipalAndResource(
+    principalId: string,
+    resourceId: string,
+    resourceType: string,
+  ): Promise<Grant[]>;
+
+  /** Find all grants for a resource (any principal). */
+  findByResource(resourceId: string, resourceType: string): Promise<Grant[]>;
+
+  /** Create a new grant. Returns the persisted grant with generated id/timestamp. */
+  create(def: GrantDef): Promise<Grant>;
+
+  /** Revoke (delete) a grant by id. Returns true if found and removed. */
+  revoke(grantId: string): Promise<boolean>;
+
+  /** Find a grant by id. */
+  findById(grantId: string): Promise<Grant | null>;
+};
+
+/**
+ * In-memory grant store for development and testing.
+ * Not suitable for production — grants are lost on restart.
+ */
+export function createInMemoryGrantStore(): GrantStore {
+  const grants = new Map<string, Grant>();
+
+  return {
+    async findByPrincipalAndResource(principalId, resourceId, resourceType) {
+      const results: Grant[] = [];
+      for (const grant of grants.values()) {
+        if (
+          grant.principalId === principalId &&
+          grant.resourceId === resourceId &&
+          grant.resourceType === resourceType
+        ) {
+          results.push(grant);
+        }
+      }
+      return results;
+    },
+
+    async findByResource(resourceId, resourceType) {
+      const results: Grant[] = [];
+      for (const grant of grants.values()) {
+        if (grant.resourceId === resourceId && grant.resourceType === resourceType) {
+          results.push(grant);
+        }
+      }
+      return results;
+    },
+
+    async create(def) {
+      const grant: Grant = {
+        id: randomUUID(),
+        principalId: def.principalId,
+        resourceId: def.resourceId,
+        resourceType: def.resourceType,
+        role: def.role,
+        grantedBy: def.grantedBy,
+        grantedAt: new Date().toISOString(),
+        expiresAt: def.expiresAt,
+      };
+      grants.set(grant.id, grant);
+      return grant;
+    },
+
+    async revoke(grantId) {
+      return grants.delete(grantId);
+    },
+
+    async findById(grantId) {
+      return grants.get(grantId) ?? null;
+    },
+  };
+}

--- a/modules/permissions/internal/integration.test.ts
+++ b/modules/permissions/internal/integration.test.ts
@@ -1,0 +1,138 @@
+/** Contract: contracts/permissions/rules.md — Integration tests */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createPermissions, type PermissionsModule } from './create-permissions.ts';
+import { createInMemoryGrantStore } from './grant-store.ts';
+import { evaluate } from '../contract.ts';
+import type { Principal } from '../../auth/contract.ts';
+
+const alice: Principal = {
+  id: 'alice-1',
+  actorType: 'human',
+  displayName: 'Alice',
+  scopes: [],
+};
+
+const bob: Principal = {
+  id: 'bob-1',
+  actorType: 'human',
+  displayName: 'Bob',
+  scopes: [],
+};
+
+describe('Owner auto-grant on document creation', () => {
+  let perms: PermissionsModule;
+
+  beforeEach(() => {
+    perms = createPermissions({ grantStore: createInMemoryGrantStore() });
+  });
+
+  it('grants owner role to document creator', async () => {
+    // Simulate what document-routes.ts does on POST /api/documents
+    const docId = 'new-doc-1';
+    await perms.grantStore.create({
+      principalId: alice.id,
+      resourceId: docId,
+      resourceType: 'document',
+      role: 'owner',
+      grantedBy: alice.id,
+    });
+
+    const grants = await perms.grantStore.findByPrincipalAndResource(
+      alice.id, docId, 'document',
+    );
+    const result = evaluate(alice, grants, {
+      principalId: alice.id,
+      action: 'manage',
+      resourceId: docId,
+      resourceType: 'document',
+    });
+    expect(result.allowed).toBe(true);
+    expect(result.role).toBe('owner');
+  });
+
+  it('other users cannot access without a grant', async () => {
+    const docId = 'new-doc-2';
+    // Alice creates and gets owner grant
+    await perms.grantStore.create({
+      principalId: alice.id,
+      resourceId: docId,
+      resourceType: 'document',
+      role: 'owner',
+      grantedBy: alice.id,
+    });
+
+    // Bob has no grant
+    const grants = await perms.grantStore.findByPrincipalAndResource(
+      bob.id, docId, 'document',
+    );
+    const result = evaluate(bob, grants, {
+      principalId: bob.id,
+      action: 'read',
+      resourceId: docId,
+      resourceType: 'document',
+    });
+    expect(result.allowed).toBe(false);
+  });
+
+  it('shared user with viewer role can read but not write', async () => {
+    const docId = 'shared-doc-1';
+    await perms.grantStore.create({
+      principalId: alice.id,
+      resourceId: docId,
+      resourceType: 'document',
+      role: 'owner',
+      grantedBy: alice.id,
+    });
+    await perms.grantStore.create({
+      principalId: bob.id,
+      resourceId: docId,
+      resourceType: 'document',
+      role: 'viewer',
+      grantedBy: alice.id,
+    });
+
+    const bobGrants = await perms.grantStore.findByPrincipalAndResource(
+      bob.id, docId, 'document',
+    );
+
+    const readResult = evaluate(bob, bobGrants, {
+      principalId: bob.id,
+      action: 'read',
+      resourceId: docId,
+      resourceType: 'document',
+    });
+    expect(readResult.allowed).toBe(true);
+
+    const writeResult = evaluate(bob, bobGrants, {
+      principalId: bob.id,
+      action: 'write',
+      resourceId: docId,
+      resourceType: 'document',
+    });
+    expect(writeResult.allowed).toBe(false);
+  });
+
+  it('revoked grants deny access', async () => {
+    const docId = 'revoke-doc-1';
+    const grant = await perms.grantStore.create({
+      principalId: bob.id,
+      resourceId: docId,
+      resourceType: 'document',
+      role: 'editor',
+      grantedBy: alice.id,
+    });
+
+    await perms.grantStore.revoke(grant.id);
+
+    const grants = await perms.grantStore.findByPrincipalAndResource(
+      bob.id, docId, 'document',
+    );
+    const result = evaluate(bob, grants, {
+      principalId: bob.id,
+      action: 'read',
+      resourceId: docId,
+      resourceType: 'document',
+    });
+    expect(result.allowed).toBe(false);
+  });
+});

--- a/modules/permissions/internal/middleware.test.ts
+++ b/modules/permissions/internal/middleware.test.ts
@@ -1,0 +1,182 @@
+/** Contract: contracts/permissions/rules.md — Middleware tests */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { requirePermission, requireAuth } from './middleware.ts';
+import { createInMemoryGrantStore, type GrantStore } from './grant-store.ts';
+import type { Principal } from '../../auth/contract.ts';
+
+/** Minimal Express-like request for testing. */
+function makeReq(overrides: Record<string, unknown> = {}) {
+  return {
+    params: { id: 'doc-1' },
+    principal: undefined as Principal | undefined,
+    ...overrides,
+  } as unknown as import('express').Request;
+}
+
+/** Minimal Express-like response that captures status and json. */
+function makeRes() {
+  let statusCode = 200;
+  let body: unknown = null;
+  const res = {
+    status(code: number) { statusCode = code; return res; },
+    json(data: unknown) { body = data; return res; },
+    get statusCode() { return statusCode; },
+    get body() { return body; },
+  };
+  return res as unknown as import('express').Response & { statusCode: number; body: unknown };
+}
+
+const testPrincipal: Principal = {
+  id: 'user-1',
+  actorType: 'human',
+  displayName: 'Alice',
+  scopes: [],
+};
+
+describe('requireAuth()', () => {
+  it('returns 401 when no principal', () => {
+    const req = makeReq();
+    const res = makeRes();
+    let nextCalled = false;
+    requireAuth()(req, res, () => { nextCalled = true; });
+    expect(res.statusCode).toBe(401);
+    expect(nextCalled).toBe(false);
+  });
+
+  it('calls next when principal exists', () => {
+    const req = makeReq({ principal: testPrincipal });
+    const res = makeRes();
+    let nextCalled = false;
+    requireAuth()(req, res, () => { nextCalled = true; });
+    expect(nextCalled).toBe(true);
+  });
+});
+
+describe('requirePermission()', () => {
+  let store: GrantStore;
+
+  beforeEach(() => {
+    store = createInMemoryGrantStore();
+  });
+
+  it('returns 401 when no principal', async () => {
+    const middleware = requirePermission('read', { grantStore: store });
+    const req = makeReq();
+    const res = makeRes();
+    let nextCalled = false;
+    await middleware(req, res, () => { nextCalled = true; });
+    expect(res.statusCode).toBe(401);
+    expect(nextCalled).toBe(false);
+  });
+
+  it('returns 403 when no grant exists', async () => {
+    const middleware = requirePermission('read', { grantStore: store });
+    const req = makeReq({ principal: testPrincipal });
+    const res = makeRes();
+    let nextCalled = false;
+    await middleware(req, res, () => { nextCalled = true; });
+    expect(res.statusCode).toBe(403);
+    expect(nextCalled).toBe(false);
+  });
+
+  it('allows access with valid grant', async () => {
+    await store.create({
+      principalId: 'user-1',
+      resourceId: 'doc-1',
+      resourceType: 'document',
+      role: 'viewer',
+      grantedBy: 'admin',
+    });
+    const middleware = requirePermission('read', { grantStore: store });
+    const req = makeReq({ principal: testPrincipal });
+    const res = makeRes();
+    let nextCalled = false;
+    await middleware(req, res, () => { nextCalled = true; });
+    expect(nextCalled).toBe(true);
+  });
+
+  it('returns 403 when grant has insufficient role', async () => {
+    await store.create({
+      principalId: 'user-1',
+      resourceId: 'doc-1',
+      resourceType: 'document',
+      role: 'viewer',
+      grantedBy: 'admin',
+    });
+    const middleware = requirePermission('write', { grantStore: store });
+    const req = makeReq({ principal: testPrincipal });
+    const res = makeRes();
+    let nextCalled = false;
+    await middleware(req, res, () => { nextCalled = true; });
+    expect(res.statusCode).toBe(403);
+    expect(nextCalled).toBe(false);
+  });
+
+  it('returns 403 for expired grant', async () => {
+    await store.create({
+      principalId: 'user-1',
+      resourceId: 'doc-1',
+      resourceType: 'document',
+      role: 'owner',
+      grantedBy: 'admin',
+      expiresAt: new Date(Date.now() - 60000).toISOString(),
+    });
+    const middleware = requirePermission('read', { grantStore: store });
+    const req = makeReq({ principal: testPrincipal });
+    const res = makeRes();
+    let nextCalled = false;
+    await middleware(req, res, () => { nextCalled = true; });
+    expect(res.statusCode).toBe(403);
+    expect(nextCalled).toBe(false);
+  });
+
+  it('allows owner to perform editor actions (role hierarchy)', async () => {
+    await store.create({
+      principalId: 'user-1',
+      resourceId: 'doc-1',
+      resourceType: 'document',
+      role: 'owner',
+      grantedBy: 'admin',
+    });
+    for (const action of ['read', 'write', 'comment', 'delete', 'share', 'manage'] as const) {
+      const middleware = requirePermission(action, { grantStore: store });
+      const req = makeReq({ principal: testPrincipal });
+      const res = makeRes();
+      let nextCalled = false;
+      await middleware(req, res, () => { nextCalled = true; });
+      expect(nextCalled).toBe(true);
+    }
+  });
+
+  it('treats agent principals the same as human principals', async () => {
+    const agentPrincipal: Principal = {
+      id: 'agent-1',
+      actorType: 'agent',
+      displayName: 'Bot',
+      scopes: [],
+    };
+    await store.create({
+      principalId: 'agent-1',
+      resourceId: 'doc-1',
+      resourceType: 'document',
+      role: 'editor',
+      grantedBy: 'admin',
+    });
+    const middleware = requirePermission('write', { grantStore: store });
+    const req = makeReq({ principal: agentPrincipal });
+    const res = makeRes();
+    let nextCalled = false;
+    await middleware(req, res, () => { nextCalled = true; });
+    expect(nextCalled).toBe(true);
+  });
+
+  it('returns 400 when resource id is missing', async () => {
+    const middleware = requirePermission('read', { grantStore: store });
+    const req = makeReq({ principal: testPrincipal, params: {} });
+    const res = makeRes();
+    let nextCalled = false;
+    await middleware(req, res, () => { nextCalled = true; });
+    expect(res.statusCode).toBe(400);
+    expect(nextCalled).toBe(false);
+  });
+});

--- a/modules/permissions/internal/middleware.ts
+++ b/modules/permissions/internal/middleware.ts
@@ -21,7 +21,10 @@ export type PermissionMiddlewareOptions = {
  */
 export function requirePermission(action: Action, opts: PermissionMiddlewareOptions) {
   const resourceType = opts.resourceType ?? 'document';
-  const getResourceId = opts.getResourceId ?? ((req: Request) => req.params.id);
+  const getResourceId = opts.getResourceId ?? ((req: Request) => {
+    const id = req.params.id;
+    return Array.isArray(id) ? id[0] : id;
+  });
 
   return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const principal = req.principal;

--- a/modules/permissions/internal/middleware.ts
+++ b/modules/permissions/internal/middleware.ts
@@ -1,0 +1,86 @@
+/** Contract: contracts/permissions/rules.md */
+
+import type { Request, Response, NextFunction } from 'express';
+import { evaluate, type Action } from '../contract.ts';
+import type { GrantStore } from './grant-store.ts';
+
+export type PermissionMiddlewareOptions = {
+  grantStore: GrantStore;
+  /** Extract the resourceId from the request. Defaults to req.params.id. */
+  getResourceId?: (req: Request) => string | undefined;
+  /** Resource type for permission queries. Defaults to 'document'. */
+  resourceType?: string;
+};
+
+/**
+ * Creates Express middleware that checks whether the authenticated principal
+ * has permission to perform the given action on the resource.
+ *
+ * Requires auth middleware to have already populated req.principal.
+ * Returns 401 if no principal, 403 if permission denied.
+ */
+export function requirePermission(action: Action, opts: PermissionMiddlewareOptions) {
+  const resourceType = opts.resourceType ?? 'document';
+  const getResourceId = opts.getResourceId ?? ((req: Request) => req.params.id);
+
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const principal = req.principal;
+    if (!principal) {
+      res.status(401).json({
+        code: 'UNAUTHENTICATED',
+        message: 'Authentication required',
+      });
+      return;
+    }
+
+    const resourceId = getResourceId(req);
+    if (!resourceId) {
+      res.status(400).json({
+        code: 'MISSING_RESOURCE_ID',
+        message: 'Resource identifier is required',
+      });
+      return;
+    }
+
+    const grants = await opts.grantStore.findByPrincipalAndResource(
+      principal.id,
+      resourceId,
+      resourceType,
+    );
+
+    const result = evaluate(principal, grants, {
+      principalId: principal.id,
+      action,
+      resourceId,
+      resourceType,
+    });
+
+    if (!result.allowed) {
+      res.status(403).json({
+        code: 'FORBIDDEN',
+        message: result.reason,
+      });
+      return;
+    }
+
+    next();
+  };
+}
+
+/**
+ * Middleware that only checks authentication (principal exists).
+ * Used for endpoints like document creation where no resource-level
+ * permission check is needed (the resource doesn't exist yet).
+ */
+export function requireAuth() {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (!req.principal) {
+      res.status(401).json({
+        code: 'UNAUTHENTICATED',
+        message: 'Authentication required',
+      });
+      return;
+    }
+    next();
+  };
+}


### PR DESCRIPTION
## Summary
- `GrantStore` interface + in-memory implementation
- `requirePermission(action)` and `requireAuth()` Express middleware
- Auto-grants `owner` role on document creation
- Extracted document/export routes with per-endpoint permission checks
- Proper 401/403 responses

## Test plan
- [ ] 22 new tests (unauthenticated, unauthorized, expired grants, role hierarchy, owner auto-grant, revocation)
- [ ] 111 total tests passing
- [ ] `npm run lint` clean

## Dependencies
- Includes `feat/2-auth-oidc` (merged into branch)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)