### PR TITLE
Sharing: link-based document access

### DIFF
--- a/modules/sharing/contract.ts
+++ b/modules/sharing/contract.ts
@@ -35,6 +35,7 @@ export type Grant = z.infer<typeof GrantSchema>;
 export const ShareLinkOptionsSchema = z.object({
   expiresIn: z.number().int().positive().optional(),
   maxRedemptions: z.number().int().positive().optional(),
+  password: z.string().min(1).optional(),
 });
 
 export type ShareLinkOptions = z.infer<typeof ShareLinkOptionsSchema>;
@@ -50,6 +51,7 @@ export const ShareLinkSchema = z.object({
   maxRedemptions: z.number().int().positive().optional(),
   redemptionCount: z.number().int().nonnegative(),
   revoked: z.boolean(),
+  passwordHash: z.string().optional(),
   createdAt: isoStringSchema,
 });
 

--- a/modules/sharing/index.ts
+++ b/modules/sharing/index.ts
@@ -23,3 +23,22 @@ export type {
   GrantCreatedEvent,
   GrantRevokedEvent,
 } from './contract.ts';
+
+// Share link service
+export {
+  createShareLinkService,
+  hashPassword,
+  generateToken,
+  type ShareLinkService,
+  type ShareLinkResult,
+  type CreateShareLinkInput,
+} from './internal/share-links.ts';
+
+// Store
+export {
+  createInMemoryShareLinkStore,
+  type ShareLinkStore,
+} from './internal/store.ts';
+
+// Routes
+export { createShareRoutes } from './internal/routes.ts';

--- a/modules/sharing/internal/routes.test.ts
+++ b/modules/sharing/internal/routes.test.ts
@@ -1,0 +1,156 @@
+/** Contract: contracts/sharing/rules.md */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createShareRoutes } from './routes.ts';
+import { createShareLinkService } from './share-links.ts';
+import { createInMemoryShareLinkStore, type ShareLinkStore } from './store.ts';
+
+function createTestApp(store: ShareLinkStore) {
+  const app = express();
+  app.use(express.json());
+  const service = createShareLinkService(store);
+  app.use(createShareRoutes(service));
+  return app;
+}
+
+describe('share routes', () => {
+  let store: ShareLinkStore;
+  let app: ReturnType<typeof express>;
+
+  beforeEach(() => {
+    store = createInMemoryShareLinkStore();
+    app = createTestApp(store);
+  });
+
+  describe('POST /api/documents/:id/share', () => {
+    it('creates a share link (201)', async () => {
+      const res = await request(app)
+        .post('/api/documents/doc-1/share')
+        .send({ role: 'view' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.token).toBeDefined();
+      expect(res.body.docId).toBe('doc-1');
+      expect(res.body.role).toBe('view');
+      expect(res.body.passwordHash).toBeUndefined();
+    });
+
+    it('rejects invalid role (400)', async () => {
+      const res = await request(app)
+        .post('/api/documents/doc-1/share')
+        .send({ role: 'admin' });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects missing role (400)', async () => {
+      const res = await request(app)
+        .post('/api/documents/doc-1/share')
+        .send({});
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('GET /api/share/:token', () => {
+    it('resolves a valid token', async () => {
+      const createRes = await request(app)
+        .post('/api/documents/doc-1/share')
+        .send({ role: 'edit' });
+
+      const res = await request(app)
+        .get(`/api/share/${createRes.body.token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.grant.docId).toBe('doc-1');
+      expect(res.body.grant.role).toBe('edit');
+    });
+
+    it('returns 404 for invalid token', async () => {
+      const res = await request(app)
+        .get('/api/share/nonexistent');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('not_found');
+    });
+
+    it('returns 410 for expired token', async () => {
+      const createRes = await request(app)
+        .post('/api/documents/doc-1/share')
+        .send({ role: 'view', options: { expiresIn: 1 } });
+
+      // Force expiration
+      await store.update(createRes.body.token, {
+        expiresAt: new Date(Date.now() - 1000).toISOString(),
+      });
+
+      const res = await request(app)
+        .get(`/api/share/${createRes.body.token}`);
+
+      expect(res.status).toBe(410);
+      expect(res.body.error).toBe('expired');
+    });
+
+    it('returns 410 for revoked token', async () => {
+      const createRes = await request(app)
+        .post('/api/documents/doc-1/share')
+        .send({ role: 'view' });
+
+      await request(app)
+        .delete(`/api/share/${createRes.body.token}`);
+
+      const res = await request(app)
+        .get(`/api/share/${createRes.body.token}`);
+
+      expect(res.status).toBe(410);
+      expect(res.body.error).toBe('revoked');
+    });
+
+    it('returns 403 for wrong password', async () => {
+      const createRes = await request(app)
+        .post('/api/documents/doc-1/share')
+        .send({ role: 'view', options: { password: 'secret' } });
+
+      const res = await request(app)
+        .get(`/api/share/${createRes.body.token}?password=wrong`);
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe('wrong_password');
+    });
+
+    it('resolves password-protected link with correct password', async () => {
+      const createRes = await request(app)
+        .post('/api/documents/doc-1/share')
+        .send({ role: 'view', options: { password: 'secret' } });
+
+      const res = await request(app)
+        .get(`/api/share/${createRes.body.token}?password=secret`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.grant.role).toBe('view');
+    });
+  });
+
+  describe('DELETE /api/share/:token', () => {
+    it('revokes an existing link', async () => {
+      const createRes = await request(app)
+        .post('/api/documents/doc-1/share')
+        .send({ role: 'view' });
+
+      const res = await request(app)
+        .delete(`/api/share/${createRes.body.token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+
+    it('returns 404 for non-existent token', async () => {
+      const res = await request(app)
+        .delete('/api/share/nonexistent');
+
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/modules/sharing/internal/routes.ts
+++ b/modules/sharing/internal/routes.ts
@@ -27,7 +27,7 @@ export function createShareRoutes(service: ShareLinkService): Router {
     }
 
     // TODO: once auth middleware is wired, use req.principal.id
-    const grantorId = (req as Record<string, unknown>).principalId as string ?? 'anonymous';
+    const grantorId = (req as unknown as Record<string, unknown>).principalId as string ?? 'anonymous';
 
     const link = await service.create({
       docId,

--- a/modules/sharing/internal/routes.ts
+++ b/modules/sharing/internal/routes.ts
@@ -1,0 +1,77 @@
+/** Contract: contracts/sharing/rules.md */
+
+import { Router } from 'express';
+import { GrantRoleSchema, ShareLinkOptionsSchema } from '../contract.ts';
+import type { ShareLinkService } from './share-links.ts';
+
+/**
+ * Create Express routes for share link management.
+ * Mounts on the parent router; does not create its own app.
+ */
+export function createShareRoutes(service: ShareLinkService): Router {
+  const router = Router();
+
+  /** POST /api/documents/:id/share -- create a share link */
+  router.post('/api/documents/:id/share', async (req, res) => {
+    const docId = req.params.id;
+    const roleResult = GrantRoleSchema.safeParse(req.body?.role);
+    if (!roleResult.success) {
+      res.status(400).json({ error: 'role must be "view" or "edit"' });
+      return;
+    }
+
+    const optsParse = ShareLinkOptionsSchema.safeParse(req.body?.options ?? {});
+    if (!optsParse.success) {
+      res.status(400).json({ error: 'invalid options', details: optsParse.error.issues });
+      return;
+    }
+
+    // TODO: once auth middleware is wired, use req.principal.id
+    const grantorId = (req as Record<string, unknown>).principalId as string ?? 'anonymous';
+
+    const link = await service.create({
+      docId,
+      grantorId,
+      role: roleResult.data,
+      options: optsParse.data,
+    });
+
+    // Never expose passwordHash to the client
+    const { passwordHash: _, ...safeLink } = link;
+    res.status(201).json(safeLink);
+  });
+
+  /** GET /api/share/:token -- resolve (redeem) a share link */
+  router.get('/api/share/:token', async (req, res) => {
+    const { token } = req.params;
+    const password = req.query.password as string | undefined;
+    const result = await service.resolve(token, password);
+
+    if (!result.ok) {
+      const statusMap = {
+        not_found: 404,
+        expired: 410,
+        revoked: 410,
+        exhausted: 410,
+        wrong_password: 403,
+      } as const;
+      res.status(statusMap[result.reason]).json({ error: result.reason });
+      return;
+    }
+
+    const { passwordHash: _, ...safeLink } = result.link;
+    res.json({ grant: { docId: safeLink.docId, role: safeLink.role }, link: safeLink });
+  });
+
+  /** DELETE /api/share/:token -- revoke a share link */
+  router.delete('/api/share/:token', async (req, res) => {
+    const revoked = await service.revoke(req.params.token);
+    if (!revoked) {
+      res.status(404).json({ error: 'not_found' });
+      return;
+    }
+    res.json({ ok: true });
+  });
+
+  return router;
+}

--- a/modules/sharing/internal/share-links.test.ts
+++ b/modules/sharing/internal/share-links.test.ts
@@ -1,0 +1,200 @@
+/** Contract: contracts/sharing/rules.md */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createShareLinkService, hashPassword, generateToken, type ShareLinkService } from './share-links.ts';
+import { createInMemoryShareLinkStore, type ShareLinkStore } from './store.ts';
+
+describe('share-links', () => {
+  let store: ShareLinkStore;
+  let service: ShareLinkService;
+  beforeEach(() => {
+    store = createInMemoryShareLinkStore();
+    service = createShareLinkService(store);
+  });
+
+  describe('generateToken', () => {
+    it('produces 64-char hex string (256 bits)', () => {
+      const token = generateToken();
+      expect(token).toHaveLength(64);
+      expect(token).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('produces unique tokens', () => {
+      const tokens = Array.from({ length: 100 }, () => generateToken());
+      expect(new Set(tokens).size).toBe(100);
+    });
+  });
+
+  describe('create', () => {
+    it('creates a share link with role and no expiry', async () => {
+      const link = await service.create({
+        docId: 'doc-1',
+        grantorId: 'user-1',
+        role: 'view',
+      });
+
+      expect(link.token).toHaveLength(64);
+      expect(link.docId).toBe('doc-1');
+      expect(link.grantorId).toBe('user-1');
+      expect(link.role).toBe('view');
+      expect(link.expiresAt).toBeUndefined();
+      expect(link.redemptionCount).toBe(0);
+      expect(link.revoked).toBe(false);
+    });
+
+    it('creates a share link with expiry', async () => {
+      const before = Date.now();
+      const link = await service.create({
+        docId: 'doc-1',
+        grantorId: 'user-1',
+        role: 'edit',
+        options: { expiresIn: 3600 },
+      });
+
+      expect(link.expiresAt).toBeDefined();
+      const expiresMs = new Date(link.expiresAt!).getTime();
+      // Should expire ~1 hour from now (within 5s tolerance)
+      expect(expiresMs).toBeGreaterThanOrEqual(before + 3595_000);
+      expect(expiresMs).toBeLessThanOrEqual(before + 3605_000);
+    });
+
+    it('creates a password-protected link', async () => {
+      const link = await service.create({
+        docId: 'doc-1',
+        grantorId: 'user-1',
+        role: 'view',
+        options: { password: 'secret123' },
+      });
+
+      expect(link.passwordHash).toBe(hashPassword('secret123'));
+    });
+  });
+
+  describe('resolve', () => {
+    it('resolves a valid token and increments redemption count', async () => {
+      const link = await service.create({
+        docId: 'doc-1',
+        grantorId: 'user-1',
+        role: 'view',
+      });
+
+      const result = await service.resolve(link.token);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.link.docId).toBe('doc-1');
+        expect(result.link.role).toBe('view');
+      }
+
+      // Redemption count should have been incremented in the store
+      const stored = await store.findByToken(link.token);
+      expect(stored?.redemptionCount).toBe(1);
+    });
+
+    it('returns not_found for invalid token', async () => {
+      const result = await service.resolve('nonexistent-token');
+      expect(result).toEqual({ ok: false, reason: 'not_found' });
+    });
+
+    it('returns expired for expired token', async () => {
+      const link = await service.create({
+        docId: 'doc-1',
+        grantorId: 'user-1',
+        role: 'view',
+        options: { expiresIn: 1 },
+      });
+
+      // Manually set expiresAt to the past
+      await store.update(link.token, {
+        expiresAt: new Date(Date.now() - 1000).toISOString(),
+      });
+
+      const result = await service.resolve(link.token);
+      expect(result).toEqual({ ok: false, reason: 'expired' });
+    });
+
+    it('returns revoked for revoked token', async () => {
+      const link = await service.create({
+        docId: 'doc-1',
+        grantorId: 'user-1',
+        role: 'view',
+      });
+
+      await service.revoke(link.token);
+      const result = await service.resolve(link.token);
+      expect(result).toEqual({ ok: false, reason: 'revoked' });
+    });
+
+    it('returns exhausted when max redemptions reached', async () => {
+      const link = await service.create({
+        docId: 'doc-1',
+        grantorId: 'user-1',
+        role: 'view',
+        options: { maxRedemptions: 1 },
+      });
+
+      // First redemption succeeds
+      const first = await service.resolve(link.token);
+      expect(first.ok).toBe(true);
+
+      // Second fails
+      const second = await service.resolve(link.token);
+      expect(second).toEqual({ ok: false, reason: 'exhausted' });
+    });
+
+    it('resolves password-protected link with correct password', async () => {
+      const link = await service.create({
+        docId: 'doc-1',
+        grantorId: 'user-1',
+        role: 'view',
+        options: { password: 'correct-horse' },
+      });
+
+      const result = await service.resolve(link.token, 'correct-horse');
+      expect(result.ok).toBe(true);
+    });
+
+    it('rejects password-protected link with wrong password', async () => {
+      const link = await service.create({
+        docId: 'doc-1',
+        grantorId: 'user-1',
+        role: 'view',
+        options: { password: 'correct-horse' },
+      });
+
+      const result = await service.resolve(link.token, 'wrong-password');
+      expect(result).toEqual({ ok: false, reason: 'wrong_password' });
+    });
+
+    it('rejects password-protected link with no password', async () => {
+      const link = await service.create({
+        docId: 'doc-1',
+        grantorId: 'user-1',
+        role: 'view',
+        options: { password: 'correct-horse' },
+      });
+
+      const result = await service.resolve(link.token);
+      expect(result).toEqual({ ok: false, reason: 'wrong_password' });
+    });
+  });
+
+  describe('revoke', () => {
+    it('revokes an existing link', async () => {
+      const link = await service.create({
+        docId: 'doc-1',
+        grantorId: 'user-1',
+        role: 'view',
+      });
+
+      const revoked = await service.revoke(link.token);
+      expect(revoked).toBe(true);
+
+      const stored = await store.findByToken(link.token);
+      expect(stored?.revoked).toBe(true);
+    });
+
+    it('returns false for non-existent token', async () => {
+      const revoked = await service.revoke('nonexistent');
+      expect(revoked).toBe(false);
+    });
+  });
+});

--- a/modules/sharing/internal/share-links.ts
+++ b/modules/sharing/internal/share-links.ts
@@ -1,0 +1,92 @@
+/** Contract: contracts/sharing/rules.md */
+
+import { randomBytes, createHash } from 'node:crypto';
+import type { ShareLink, ShareLinkOptions, GrantRole } from '../contract.ts';
+import type { ShareLinkStore } from './store.ts';
+
+/** Hash a password with SHA-256 (consistent with auth module). */
+export function hashPassword(password: string): string {
+  return createHash('sha256').update(password).digest('hex');
+}
+
+/** Generate a cryptographically random token (256 bits / 32 bytes). */
+export function generateToken(): string {
+  return randomBytes(32).toString('hex');
+}
+
+export interface CreateShareLinkInput {
+  docId: string;
+  grantorId: string;
+  role: GrantRole;
+  options?: ShareLinkOptions;
+}
+
+export interface ShareLinkService {
+  create(input: CreateShareLinkInput): Promise<ShareLink>;
+  resolve(token: string, password?: string): Promise<ShareLinkResult>;
+  revoke(token: string): Promise<boolean>;
+}
+
+export type ShareLinkResult =
+  | { ok: true; link: ShareLink }
+  | { ok: false; reason: 'not_found' | 'expired' | 'revoked' | 'exhausted' | 'wrong_password' };
+
+export function createShareLinkService(store: ShareLinkStore): ShareLinkService {
+  return {
+    async create(input) {
+      const now = new Date().toISOString();
+      const expiresAt = input.options?.expiresIn
+        ? new Date(Date.now() + input.options.expiresIn * 1000).toISOString()
+        : undefined;
+
+      const link: ShareLink = {
+        token: generateToken(),
+        docId: input.docId,
+        grantorId: input.grantorId,
+        role: input.role,
+        expiresAt,
+        maxRedemptions: input.options?.maxRedemptions,
+        redemptionCount: 0,
+        revoked: false,
+        passwordHash: input.options?.password
+          ? hashPassword(input.options.password)
+          : undefined,
+        createdAt: now,
+      };
+
+      await store.save(link);
+      return link;
+    },
+
+    async resolve(token, password) {
+      const link = await store.findByToken(token);
+      if (!link) return { ok: false, reason: 'not_found' };
+      if (link.revoked) return { ok: false, reason: 'revoked' };
+
+      if (link.expiresAt && new Date(link.expiresAt) <= new Date()) {
+        return { ok: false, reason: 'expired' };
+      }
+
+      if (link.maxRedemptions && link.redemptionCount >= link.maxRedemptions) {
+        return { ok: false, reason: 'exhausted' };
+      }
+
+      if (link.passwordHash) {
+        if (!password) return { ok: false, reason: 'wrong_password' };
+        if (hashPassword(password) !== link.passwordHash) {
+          return { ok: false, reason: 'wrong_password' };
+        }
+      }
+
+      await store.update(token, { redemptionCount: link.redemptionCount + 1 });
+      return { ok: true, link };
+    },
+
+    async revoke(token) {
+      const link = await store.findByToken(token);
+      if (!link) return false;
+      await store.update(token, { revoked: true });
+      return true;
+    },
+  };
+}

--- a/modules/sharing/internal/store.ts
+++ b/modules/sharing/internal/store.ts
@@ -1,0 +1,43 @@
+/** Contract: contracts/sharing/rules.md */
+
+import type { ShareLink } from '../contract.ts';
+
+/**
+ * Storage interface for share links.
+ * Implementations must be swappable (in-memory, PostgreSQL, etc.).
+ */
+export interface ShareLinkStore {
+  save(link: ShareLink): Promise<void>;
+  findByToken(token: string): Promise<ShareLink | null>;
+  update(token: string, patch: Partial<ShareLink>): Promise<void>;
+  listByDoc(docId: string): Promise<ShareLink[]>;
+}
+
+/**
+ * In-memory implementation of ShareLinkStore.
+ * Suitable for development and testing only.
+ */
+export function createInMemoryShareLinkStore(): ShareLinkStore {
+  const links = new Map<string, ShareLink>();
+
+  return {
+    async save(link) {
+      links.set(link.token, { ...link });
+    },
+
+    async findByToken(token) {
+      const link = links.get(token);
+      return link ? { ...link } : null;
+    },
+
+    async update(token, patch) {
+      const existing = links.get(token);
+      if (!existing) return;
+      links.set(token, { ...existing, ...patch });
+    },
+
+    async listByDoc(docId) {
+      return [...links.values()].filter((l) => l.docId === docId);
+    },
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,11 +31,13 @@
         "@types/express": "^5.0.6",
         "@types/node": "^22.0.0",
         "@types/pg": "^8.20.0",
+        "@types/supertest": "^7.2.0",
         "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^8.58.0",
         "@typescript-eslint/parser": "^8.58.0",
         "esbuild": "^0.28.0",
         "eslint": "^9.0.0",
+        "supertest": "^7.2.2",
         "tsx": "^4.21.0",
         "typescript": "^5.8.0",
         "vitest": "^3.1.0"
@@ -740,6 +742,29 @@
       "resolved": "https://registry.npmjs.org/@lifeomic/attempt/-/attempt-3.1.0.tgz",
       "integrity": "sha512-QZqem4QuAnAyzfz+Gj5/+SLxqwCAw2qmt7732ZXodr6VDWGeYLG6w1i/vYLa55JQM9wRuBKLmXmiZ2P0LtE5rw==",
       "license": "MIT"
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
     },
     "node_modules/@remirror/core-constants": {
       "version": "3.0.0",
@@ -1553,6 +1578,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1628,6 +1660,13 @@
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "license": "MIT"
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
@@ -1683,6 +1722,30 @@
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "node_modules/@types/ws": {
@@ -2167,6 +2230,13 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2191,6 +2261,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2365,6 +2442,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2411,6 +2511,13 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/crelt": {
       "version": "1.0.6",
@@ -2467,6 +2574,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/denque": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
@@ -2483,6 +2600,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dunder-proto": {
@@ -2558,6 +2686,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2870,6 +3014,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2959,6 +3110,64 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -3105,6 +3314,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -3504,6 +3729,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -4548,6 +4796,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -41,11 +41,13 @@
     "@types/express": "^5.0.6",
     "@types/node": "^22.0.0",
     "@types/pg": "^8.20.0",
+    "@types/supertest": "^7.2.0",
     "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",
     "esbuild": "^0.28.0",
     "eslint": "^9.0.0",
+    "supertest": "^7.2.2",
     "tsx": "^4.21.0",
     "typescript": "^5.8.0",
     "vitest": "^3.1.0"


### PR DESCRIPTION
## Summary
- Share link service: create, resolve, revoke with 256-bit crypto tokens
- Password-protected links with SHA-256 hashing
- API endpoints: `POST /api/documents/:id/share`, `GET /api/share/:token`, `DELETE /api/share/:token`
- Proper HTTP semantics: 410 expired/revoked, 403 wrong password, 404 unknown
- `ShareLinkStore` interface (in-memory, swappable to PostgreSQL)

## Test plan
- [ ] 26 new tests (token generation, expiry, revocation, password flows, route integration)
- [ ] `npm run lint` clean
- [ ] `npm test` passes

## Dependencies
- Includes `feat/2-auth-oidc` (merged into branch)
- Should be merged after #3 (permissions enforcement) for full integration

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)