### PR TITLE
Authenticate WebSocket collab endpoint

### DIFF
--- a/modules/api/internal/server.ts
+++ b/modules/api/internal/server.ts
@@ -16,7 +16,6 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export function startServer(port = 3000) {
   const app = express();
-  const { handleUpgrade } = createCollabServer();
 
   // Wire auth module (dev mode uses bypass verifiers)
   const auth = createAuth({
@@ -27,6 +26,11 @@ export function startServer(port = 3000) {
       revokeServiceAccount: async () => {},
     },
     publicPaths: ['/api/health'],
+  });
+
+  // Wire collab server with auth dependency
+  const { handleUpgrade } = createCollabServer({
+    tokenVerifier: auth.tokenVerifier,
   });
 
   // Wire permissions module

--- a/modules/collab/internal/authenticate.test.ts
+++ b/modules/collab/internal/authenticate.test.ts
@@ -1,0 +1,119 @@
+/** Contract: contracts/collab/rules.md */
+import { describe, it, expect } from 'vitest';
+import { createOnAuthenticate } from './authenticate.ts';
+import type { TokenVerifier, VerificationResult, Principal } from '../../auth/contract.ts';
+
+/** Creates a real dev-style token verifier for testing. */
+function createTestVerifier(): TokenVerifier {
+  return {
+    async verifyToken(token: string): Promise<VerificationResult> {
+      if (token === 'dev') {
+        return {
+          ok: true,
+          principal: {
+            id: 'dev-user',
+            actorType: 'human',
+            displayName: 'Dev User',
+            email: 'dev@opendesk.local',
+            scopes: ['*'],
+          },
+        };
+      }
+
+      if (token.startsWith('valid:')) {
+        const name = token.slice(6);
+        return {
+          ok: true,
+          principal: {
+            id: `user-${name}`,
+            actorType: 'human',
+            displayName: name,
+            email: `${name}@opendesk.local`,
+            scopes: ['*'],
+          },
+        };
+      }
+
+      return {
+        ok: false,
+        error: { code: 'TOKEN_INVALID', message: 'Invalid token' },
+      };
+    },
+  };
+}
+
+function makeAuthData(overrides: Partial<{
+  token: string;
+  documentName: string;
+  requestParameters: URLSearchParams;
+}> = {}) {
+  return {
+    token: overrides.token ?? '',
+    documentName: overrides.documentName ?? 'doc-1',
+    connection: { readOnly: false },
+    requestHeaders: {},
+    requestParameters: overrides.requestParameters ?? new URLSearchParams(),
+  };
+}
+
+describe('createOnAuthenticate', () => {
+  const verifier = createTestVerifier();
+  const onAuthenticate = createOnAuthenticate(verifier);
+
+  it('authenticates with a valid token from data.token', async () => {
+    const result = await onAuthenticate(makeAuthData({ token: 'dev' }));
+    expect(result).toEqual({
+      principal: expect.objectContaining({
+        id: 'dev-user',
+        actorType: 'human',
+      }),
+    });
+  });
+
+  it('authenticates with a valid token from query string', async () => {
+    const params = new URLSearchParams({ token: 'valid:Alice' });
+    const result = await onAuthenticate(makeAuthData({
+      requestParameters: params,
+    }));
+    const principal = result.principal as Principal;
+    expect(principal.id).toBe('user-Alice');
+    expect(principal.displayName).toBe('Alice');
+  });
+
+  it('prefers data.token over query string token', async () => {
+    const params = new URLSearchParams({ token: 'valid:QueryUser' });
+    const result = await onAuthenticate(makeAuthData({
+      token: 'valid:DataUser',
+      requestParameters: params,
+    }));
+    const principal = result.principal as Principal;
+    expect(principal.id).toBe('user-DataUser');
+  });
+
+  it('rejects when no token is provided', async () => {
+    await expect(
+      onAuthenticate(makeAuthData()),
+    ).rejects.toThrow('No authentication token provided');
+  });
+
+  it('rejects when the token is invalid', async () => {
+    await expect(
+      onAuthenticate(makeAuthData({ token: 'bad-token' })),
+    ).rejects.toThrow('Invalid token');
+  });
+
+  it('rejects when query string token is invalid', async () => {
+    const params = new URLSearchParams({ token: 'garbage' });
+    await expect(
+      onAuthenticate(makeAuthData({ requestParameters: params })),
+    ).rejects.toThrow('Invalid token');
+  });
+
+  it('returns principal in context for downstream hooks', async () => {
+    const result = await onAuthenticate(makeAuthData({ token: 'dev' }));
+    expect(result).toHaveProperty('principal');
+    expect(result.principal).toHaveProperty('id');
+    expect(result.principal).toHaveProperty('actorType');
+    expect(result.principal).toHaveProperty('scopes');
+  });
+});

--- a/modules/collab/internal/authenticate.ts
+++ b/modules/collab/internal/authenticate.ts
@@ -1,0 +1,44 @@
+/** Contract: contracts/collab/rules.md */
+
+import type { TokenVerifier } from '../../auth/contract.ts';
+
+/**
+ * Creates the Hocuspocus onAuthenticate hook.
+ *
+ * Verifies the bearer token provided by the client and stores
+ * the resolved Principal in the connection context. Throws on
+ * invalid or missing tokens, which causes Hocuspocus to reject
+ * the connection before the handshake completes.
+ *
+ * Token sources (checked in order):
+ * 1. `data.token` — the standard Hocuspocus provider token field
+ * 2. Query string `?token=xxx` on the upgrade URL
+ */
+export function createOnAuthenticate(tokenVerifier: TokenVerifier) {
+  return async (data: {
+    token: string;
+    documentName: string;
+    connection: { readOnly: boolean };
+    requestHeaders: Record<string, string>;
+    requestParameters: URLSearchParams;
+  }) => {
+    const token =
+      data.token ||
+      data.requestParameters.get('token') ||
+      '';
+
+    if (!token) {
+      throw new Error('No authentication token provided');
+    }
+
+    const result = await tokenVerifier.verifyToken(token);
+
+    if (!result.ok) {
+      throw new Error(result.error.message);
+    }
+
+    // Return the principal as context — Hocuspocus merges this
+    // into the connection context for downstream hooks.
+    return { principal: result.principal };
+  };
+}

--- a/modules/collab/internal/server.ts
+++ b/modules/collab/internal/server.ts
@@ -6,11 +6,16 @@ import type { IncomingMessage } from 'node:http';
 import type { Duplex } from 'node:stream';
 import { saveYjsState, loadYjsState } from '../../storage/internal/pg.ts';
 import { CompactionManager } from './compaction-manager.ts';
+import { createOnAuthenticate } from './authenticate.ts';
 import type { CollabConfig } from '../contract.ts';
+import type { CollabDependencies } from './types.ts';
 
 const DEFAULT_COMPACTION_THRESHOLD = 1_048_576; // 1 MiB
 
-export function createCollabServer(config?: Partial<CollabConfig>) {
+export function createCollabServer(
+  deps: CollabDependencies,
+  config?: Partial<CollabConfig>,
+) {
   const thresholdBytes =
     config?.compactionThresholdBytes ?? DEFAULT_COMPACTION_THRESHOLD;
 
@@ -19,12 +24,16 @@ export function createCollabServer(config?: Partial<CollabConfig>) {
     loadYjsState,
   });
 
+  const onAuthenticate = createOnAuthenticate(deps.tokenVerifier);
+
   const hocuspocus = new Hocuspocus({
     name: config?.hocuspocus?.name ?? 'opendesk-collab',
     timeout: 30000,
     debounce: 2000,
     maxDebounce: 10000,
     quiet: config?.hocuspocus?.quiet ?? true,
+
+    onAuthenticate,
 
     async onLoadDocument({ document, documentName }) {
       const state = await loadYjsState(documentName);

--- a/modules/collab/internal/types.ts
+++ b/modules/collab/internal/types.ts
@@ -1,0 +1,12 @@
+/** Contract: contracts/collab/rules.md */
+
+import type { TokenVerifier } from '../../auth/contract.ts';
+
+/**
+ * External dependencies injected into the collab module.
+ * Keeps module boundaries clean — collab never imports auth internals.
+ */
+export type CollabDependencies = {
+  /** Verifies bearer tokens and resolves them to a Principal. */
+  tokenVerifier: TokenVerifier;
+};


### PR DESCRIPTION
## Summary
- Add `onAuthenticate` hook to Hocuspocus — verifies bearer token on WebSocket upgrade
- Extracts token from `data.token` or `?token=xxx` query string
- Rejects unauthenticated connections immediately
- `TokenVerifier` injected via `CollabDependencies` (clean module boundary)
- 7 new tests

## Security
Fixes **CRITICAL** finding from adversarial review: any client could previously connect to `/collab` and read/write any document without authentication.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)