### PR TITLE
Security quick wins: convert auth, dev mode guard, idempotency key

### DIFF
--- a/modules/api/internal/idempotency.test.ts
+++ b/modules/api/internal/idempotency.test.ts
@@ -15,20 +15,26 @@ import { InMemoryCache, makeReq, makeRes } from './test-helpers.ts';
 // --- Unit tests: cache key generation ---
 
 describe('buildCacheKey', () => {
-  it('builds a deterministic key from method, path, and idempotency key', () => {
-    const key = buildCacheKey('POST', '/api/documents', 'abc-123');
-    expect(key).toBe(`${IDEMPOTENCY_KEY_PREFIX}POST:/api/documents:abc-123`);
+  it('builds a deterministic key from method, path, principal, and idempotency key', () => {
+    const key = buildCacheKey('POST', '/api/documents', 'user-1', 'abc-123');
+    expect(key).toBe(`${IDEMPOTENCY_KEY_PREFIX}POST:/api/documents:user-1:abc-123`);
   });
 
   it('different methods produce different keys', () => {
-    const a = buildCacheKey('POST', '/api/documents', 'key-1');
-    const b = buildCacheKey('DELETE', '/api/documents', 'key-1');
+    const a = buildCacheKey('POST', '/api/documents', 'user-1', 'key-1');
+    const b = buildCacheKey('DELETE', '/api/documents', 'user-1', 'key-1');
     expect(a).not.toBe(b);
   });
 
   it('different paths produce different keys', () => {
-    const a = buildCacheKey('POST', '/api/documents', 'key-1');
-    const b = buildCacheKey('POST', '/api/documents/123', 'key-1');
+    const a = buildCacheKey('POST', '/api/documents', 'user-1', 'key-1');
+    const b = buildCacheKey('POST', '/api/documents/123', 'user-1', 'key-1');
+    expect(a).not.toBe(b);
+  });
+
+  it('different principals produce different keys', () => {
+    const a = buildCacheKey('POST', '/api/documents', 'user-1', 'key-1');
+    const b = buildCacheKey('POST', '/api/documents', 'user-2', 'key-1');
     expect(a).not.toBe(b);
   });
 });

--- a/modules/api/internal/idempotency.ts
+++ b/modules/api/internal/idempotency.ts
@@ -14,9 +14,9 @@ export interface CachedResponse {
   body: string;
 }
 
-/** Build the cache key from the request method, path, and idempotency key header. */
-export function buildCacheKey(method: string, path: string, idempotencyKey: string): string {
-  return `${IDEMPOTENCY_KEY_PREFIX}${method}:${path}:${idempotencyKey}`;
+/** Build the cache key from the request method, path, principal identity, and idempotency key header. */
+export function buildCacheKey(method: string, path: string, principalId: string, idempotencyKey: string): string {
+  return `${IDEMPOTENCY_KEY_PREFIX}${method}:${path}:${principalId}:${idempotencyKey}`;
 }
 
 /** Serialize a response for caching. */
@@ -74,7 +74,8 @@ export function idempotencyMiddleware(options: IdempotencyOptions) {
       return;
     }
 
-    const cacheKey = buildCacheKey(method, req.path, idempotencyKey);
+    const principalId = (req as unknown as { principal?: { id?: string } }).principal?.id || 'anonymous';
+    const cacheKey = buildCacheKey(method, req.path, principalId, idempotencyKey);
 
     // Check cache for existing response
     try {

--- a/modules/api/internal/server.ts
+++ b/modules/api/internal/server.ts
@@ -38,15 +38,15 @@ export function startServer(port = 3000) {
   const redisClient = getRedisClient();
   app.use('/api', idempotencyMiddleware({ cache: redisClient }));
 
-  // Collabora convert routes (import/export binary formats)
-  app.use(createConvertRoutes());
-
   // Serve static frontend
   const publicDir = resolve(__dirname, '../../app/internal/public');
   app.use(express.static(publicDir));
 
   // Auth middleware on all /api routes (except public paths)
   app.use('/api', auth.middleware);
+
+  // Collabora convert routes (import/export binary formats) — after auth
+  app.use(createConvertRoutes());
 
   // Health check (public, skipped by auth middleware)
   app.get('/api/health', (_req, res) => {

--- a/modules/auth/internal/config.ts
+++ b/modules/auth/internal/config.ts
@@ -23,6 +23,10 @@ export function loadAuthConfig(): AuthConfig {
     throw new Error(`Invalid AUTH_MODE: ${mode}. Must be 'oidc' or 'dev'.`);
   }
 
+  if (mode === 'dev' && process.env.NODE_ENV === 'production') {
+    throw new Error('FATAL: AUTH_MODE=dev is forbidden when NODE_ENV=production');
+  }
+
   return {
     mode,
     oidcIssuer: process.env.OIDC_ISSUER || '',


### PR DESCRIPTION
## Summary
- **#19**: Move convert routes after auth middleware (was completely unauthenticated)
- **#20**: Add NODE_ENV=production guard for AUTH_MODE=dev (throws on misconfiguration)
- **#24**: Include principal ID in idempotency cache key (prevents cross-user response leakage)
- **#25**: Verified StarterKit `undoRedo: false` is correct for installed TipTap version (no change needed)

Closes #19, closes #20, closes #24, closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)