### PR TITLE
Async error handling: asyncHandler wrapper + error middleware

### DIFF
--- a/modules/api/internal/async-handler.test.ts
+++ b/modules/api/internal/async-handler.test.ts
@@ -1,0 +1,61 @@
+/** Contract: contracts/api/rules.md */
+
+import { describe, it, expect } from 'vitest';
+import express, { type Request, type Response, type NextFunction } from 'express';
+import request from 'supertest';
+import { asyncHandler } from './async-handler.ts';
+
+function createTestApp() {
+  const app = express();
+
+  // A route that throws synchronously inside an async handler
+  app.get(
+    '/throws',
+    asyncHandler(async (_req: Request, _res: Response) => {
+      throw new Error('boom');
+    })
+  );
+
+  // A route that rejects asynchronously
+  app.get(
+    '/rejects',
+    asyncHandler(async (_req: Request, _res: Response) => {
+      await Promise.reject(new Error('async boom'));
+    })
+  );
+
+  // A route that succeeds
+  app.get(
+    '/ok',
+    asyncHandler(async (_req: Request, res: Response) => {
+      res.json({ ok: true });
+    })
+  );
+
+  // Express error-handling middleware (must have 4 params)
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(500).json({ error: 'Internal server error' });
+  });
+
+  return app;
+}
+
+describe('asyncHandler', () => {
+  it('returns 500 when handler throws synchronously', async () => {
+    const res = await request(createTestApp()).get('/throws');
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Internal server error');
+  });
+
+  it('returns 500 when handler rejects asynchronously', async () => {
+    const res = await request(createTestApp()).get('/rejects');
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Internal server error');
+  });
+
+  it('returns 200 when handler succeeds', async () => {
+    const res = await request(createTestApp()).get('/ok');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+});

--- a/modules/api/internal/async-handler.ts
+++ b/modules/api/internal/async-handler.ts
@@ -1,0 +1,15 @@
+/** Contract: contracts/api/rules.md */
+
+import type { Request, Response, NextFunction } from 'express';
+
+type AsyncRouteHandler = (req: Request, res: Response) => Promise<void>;
+
+/**
+ * Wrap an async Express route handler so rejected promises
+ * are forwarded to Express error-handling middleware via next().
+ */
+export function asyncHandler(fn: AsyncRouteHandler) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    fn(req, res).catch(next);
+  };
+}

--- a/modules/api/internal/convert-routes.ts
+++ b/modules/api/internal/convert-routes.ts
@@ -17,6 +17,7 @@ import {
   ImportError,
 } from '../../convert/index.ts';
 import { getDocument } from '../../storage/internal/pg.ts';
+import { asyncHandler } from './async-handler.ts';
 
 const MAX_UPLOAD_SIZE = 50 * 1024 * 1024; // 50 MB
 
@@ -26,10 +27,10 @@ export function createConvertRoutes(): Router {
   router.post(
     '/api/documents/:id/convert-import',
     raw({ type: '*/*', limit: MAX_UPLOAD_SIZE }),
-    handleImport
+    asyncHandler(handleImport)
   );
 
-  router.post('/api/documents/:id/convert-export', handleExport);
+  router.post('/api/documents/:id/convert-export', asyncHandler(handleExport));
 
   return router;
 }

--- a/modules/api/internal/document-routes.ts
+++ b/modules/api/internal/document-routes.ts
@@ -10,6 +10,7 @@ import {
   updateDocumentTitle,
 } from '../../storage/internal/pg.ts';
 import type { PermissionsModule } from '../../permissions/index.ts';
+import { asyncHandler } from './async-handler.ts';
 
 export type DocumentRoutesOptions = {
   permissions: PermissionsModule;
@@ -24,13 +25,13 @@ export function createDocumentRoutes(opts: DocumentRoutesOptions): Router {
   const { permissions } = opts;
 
   // List documents — requires auth only (no specific resource)
-  router.get('/', permissions.requireAuth, async (_req: Request, res: Response) => {
+  router.get('/', permissions.requireAuth, asyncHandler(async (_req: Request, res: Response) => {
     const docs = await listDocuments();
     res.json(docs);
-  });
+  }));
 
   // Create document — requires auth, auto-grants owner role to creator
-  router.post('/', permissions.requireAuth, async (req: Request, res: Response) => {
+  router.post('/', permissions.requireAuth, asyncHandler(async (req: Request, res: Response) => {
     const title = req.body?.title || 'Untitled';
     const id = randomUUID();
     const doc = await createDocument(id, title);
@@ -46,20 +47,20 @@ export function createDocumentRoutes(opts: DocumentRoutesOptions): Router {
     });
 
     res.status(201).json(doc);
-  });
+  }));
 
   // Get document — requires read permission
-  router.get('/:id', permissions.require('read'), async (req: Request, res: Response) => {
+  router.get('/:id', permissions.require('read'), asyncHandler(async (req: Request, res: Response) => {
     const doc = await getDocument(String(req.params.id));
     if (!doc) {
       res.status(404).json({ error: 'Document not found' });
       return;
     }
     res.json(doc);
-  });
+  }));
 
   // Update document title — requires write permission
-  router.patch('/:id', permissions.require('write'), async (req: Request, res: Response) => {
+  router.patch('/:id', permissions.require('write'), asyncHandler(async (req: Request, res: Response) => {
     const { title } = req.body;
     if (!title) {
       res.status(400).json({ error: 'title is required' });
@@ -67,17 +68,17 @@ export function createDocumentRoutes(opts: DocumentRoutesOptions): Router {
     }
     await updateDocumentTitle(String(req.params.id), title);
     res.json({ ok: true });
-  });
+  }));
 
   // Delete document — requires delete permission
-  router.delete('/:id', permissions.require('delete'), async (req: Request, res: Response) => {
+  router.delete('/:id', permissions.require('delete'), asyncHandler(async (req: Request, res: Response) => {
     const deleted = await deleteDocument(String(req.params.id));
     if (!deleted) {
       res.status(404).json({ error: 'Document not found' });
       return;
     }
     res.json({ ok: true });
-  });
+  }));
 
   return router;
 }

--- a/modules/api/internal/export-routes.ts
+++ b/modules/api/internal/export-routes.ts
@@ -4,6 +4,7 @@ import { Router, type Request, type Response } from 'express';
 import { getDocument } from '../../storage/internal/pg.ts';
 import { getDocumentForExport } from '../../convert/internal/converter.ts';
 import type { PermissionsModule } from '../../permissions/index.ts';
+import { asyncHandler } from './async-handler.ts';
 
 export type ExportRoutesOptions = {
   permissions: PermissionsModule;
@@ -18,7 +19,7 @@ export function createExportRoutes(opts: ExportRoutesOptions): Router {
   const { permissions } = opts;
 
   // Export document — requires read permission
-  router.post('/:id/export', permissions.require('read'), async (req: Request, res: Response) => {
+  router.post('/:id/export', permissions.require('read'), asyncHandler(async (req: Request, res: Response) => {
     const format = req.body?.format;
     if (!format || !['html', 'text'].includes(format)) {
       res.status(400).json({ error: 'format must be "html" or "text"' });
@@ -42,10 +43,10 @@ export function createExportRoutes(opts: ExportRoutesOptions): Router {
     res.setHeader('Content-Type', contentType);
     res.setHeader('Content-Disposition', `attachment; filename="${encodeURIComponent(filename)}"`);
     res.send(content);
-  });
+  }));
 
   // Import HTML into document — requires write permission
-  router.post('/:id/import', permissions.require('write'), async (req: Request, res: Response) => {
+  router.post('/:id/import', permissions.require('write'), asyncHandler(async (req: Request, res: Response) => {
     const html = req.body?.html;
     if (!html) {
       res.status(400).json({ error: 'html content is required' });
@@ -57,7 +58,7 @@ export function createExportRoutes(opts: ExportRoutesOptions): Router {
       return;
     }
     res.json({ ok: true, html, documentId: req.params.id });
-  });
+  }));
 
   return router;
 }

--- a/modules/api/internal/server.ts
+++ b/modules/api/internal/server.ts
@@ -1,6 +1,6 @@
 /** Contract: contracts/api/rules.md */
 import { createServer } from 'node:http';
-import express from 'express';
+import express, { type Request, type Response, type NextFunction } from 'express';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createCollabServer } from '../../collab/internal/server.ts';
@@ -58,6 +58,12 @@ export function startServer(port = 3000) {
 
   // Export/import routes with permission checks
   app.use('/api/documents', createExportRoutes({ permissions }));
+
+  // Global error handler — must be registered LAST (after all routes)
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    console.error('[opendesk] unhandled error:', err.message);
+    res.status(500).json({ error: 'Internal server error' });
+  });
 
   const httpServer = createServer(app);
 

--- a/modules/sharing/internal/routes.ts
+++ b/modules/sharing/internal/routes.ts
@@ -3,6 +3,7 @@
 import { Router } from 'express';
 import { GrantRoleSchema, ShareLinkOptionsSchema } from '../contract.ts';
 import type { ShareLinkService } from './share-links.ts';
+import { asyncHandler } from '../../api/internal/async-handler.ts';
 
 /**
  * Create Express routes for share link management.
@@ -12,7 +13,7 @@ export function createShareRoutes(service: ShareLinkService): Router {
   const router = Router();
 
   /** POST /api/documents/:id/share -- create a share link */
-  router.post('/api/documents/:id/share', async (req, res) => {
+  router.post('/api/documents/:id/share', asyncHandler(async (req, res) => {
     const docId = req.params.id;
     const roleResult = GrantRoleSchema.safeParse(req.body?.role);
     if (!roleResult.success) {
@@ -39,10 +40,10 @@ export function createShareRoutes(service: ShareLinkService): Router {
     // Never expose passwordHash to the client
     const { passwordHash: _, ...safeLink } = link;
     res.status(201).json(safeLink);
-  });
+  }));
 
   /** GET /api/share/:token -- resolve (redeem) a share link */
-  router.get('/api/share/:token', async (req, res) => {
+  router.get('/api/share/:token', asyncHandler(async (req, res) => {
     const { token } = req.params;
     const password = req.query.password as string | undefined;
     const result = await service.resolve(token, password);
@@ -61,17 +62,17 @@ export function createShareRoutes(service: ShareLinkService): Router {
 
     const { passwordHash: _, ...safeLink } = result.link;
     res.json({ grant: { docId: safeLink.docId, role: safeLink.role }, link: safeLink });
-  });
+  }));
 
   /** DELETE /api/share/:token -- revoke a share link */
-  router.delete('/api/share/:token', async (req, res) => {
+  router.delete('/api/share/:token', asyncHandler(async (req, res) => {
     const revoked = await service.revoke(req.params.token);
     if (!revoked) {
       res.status(404).json({ error: 'not_found' });
       return;
     }
     res.json({ ok: true });
-  });
+  }));
 
   return router;
 }


### PR DESCRIPTION
## Summary
- `asyncHandler()` utility wraps async route handlers, forwards rejections to Express error handler
- Global error-handling middleware returns structured 500 responses
- All async route handlers wrapped: document-routes, export-routes, convert-routes, sharing/routes
- 3 new tests for the asyncHandler

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)