### PR TITLE
Fix remaining review issues: module boundaries, role types, contracts alignment

### DIFF
--- a/contracts/api/rules.md
+++ b/contracts/api/rules.md
@@ -105,3 +105,24 @@ HTTP boundary layer that exposes REST endpoints for document CRUD, sharing, expo
 - **SSE replay invariant** -> Integration test: connect to SSE with valid `Last-Event-ID`; assert replayed events; connect with ID older than 7 days; assert 410 Gone
 - **No business logic invariant** -> Code review rule: route handlers must contain only validation, auth, permission check, delegation call, and response serialization -- no domain logic
 - **WebSocket upgrade** -> Integration test: send HTTP upgrade request to collab path; assert 101 Switching Protocols and handoff to Hocuspocus
+
+## MVP Scope
+
+Implemented:
+- [x] REST endpoints for document CRUD (GET/POST /api/documents, GET /api/documents/:id)
+- [x] Authentication middleware resolving bearer tokens to `Principal`
+- [x] Permission checks before document operations
+- [x] WebSocket upgrade delegation to collab module's Hocuspocus handler
+- [x] Structured error responses (401, 403, 404)
+- [x] No business logic in route handlers (pure orchestration)
+- [x] Share link endpoints (POST /api/shares, DELETE /api/shares/:id)
+- [x] Export/import endpoints (POST /api/documents/:id/export, POST /api/documents/:id/import)
+
+Post-MVP (deferred):
+- [ ] Zod validation on all request bodies — currently using ad-hoc validation checks
+- [ ] Rate limiting per-principal with actorType discrimination (human vs agent token bucket)
+- [ ] `ETag` / `If-Match` header support for causal reads (304 Not Modified)
+- [ ] SSE event stream endpoint (GET /api/events/stream) — requires events module implementation
+- [ ] Intent submission endpoint (POST /api/documents/:id/intents) — requires collab IntentExecutor
+- [ ] `410 Gone` for expired SSE Last-Event-ID — requires events module
+- [ ] Pagination parameters (page, limit) on list endpoints

--- a/contracts/app/rules.md
+++ b/contracts/app/rules.md
@@ -123,3 +123,31 @@ modules/app/
   styles/
     *.css                 -- Modern CSS, no preprocessors, no utility frameworks
 ```
+
+## MVP Scope
+
+Implemented:
+- [x] HTML shell and application entry point
+- [x] TipTap editor with Yjs collaboration (`@tiptap/extension-collaboration`)
+- [x] Hocuspocus WebSocket provider for real-time sync
+- [x] Awareness protocol (collaborative cursors, user presence)
+- [x] Document list/management UI
+- [x] Share dialog UI
+- [x] Import/export controls
+- [x] Formatting toolbar
+- [x] User identity display
+- [x] Modern CSS (no Tailwind, no preprocessors)
+- [x] No business logic in app module
+- [x] Single WebSocket per document
+- [x] Awareness state is ephemeral (never persisted)
+- [x] i18n: EN and FR locales supported
+- [x] Centralized translation keys with TypeScript enforcement
+
+Post-MVP (deferred):
+- [ ] Block ID assignment extension (`blockId` UUIDv4 on new top-level blocks) — blocks exist but auto-ID assignment extension not yet built
+- [ ] Permission-driven UI (show/hide features based on role from `api`) — currently all features visible regardless of role
+- [ ] Modular file structure (editor/extensions.ts, editor/collaboration.ts, etc.) — currently in a flatter structure
+- [ ] ProseMirror schema parity test (automated 1:1 mapping check against `document` module)
+
+Decided against:
+- Co-located translation keys — centralized keys with TypeScript enforcement preferred (better DX for a small team)

--- a/contracts/auth/rules.md
+++ b/contracts/auth/rules.md
@@ -61,3 +61,20 @@ How to test each invariant:
 - API keys stored hashed -> Integration test (with `storage`): create a service account, read the stored record, assert the stored key does not match the raw key returned at creation. Assert the raw key is not retrievable after creation.
 - No permission evaluation -> Code-level audit: grep the module source for any import of `permissions`. Assert zero references. Contract test: confirm no method signature accepts a "resource" or "action" for access-control purposes.
 - Stateless verification -> Code-level audit: assert no in-memory cache, session store, or request-scoped mutable state persists between calls.
+
+## MVP Scope
+
+Implemented:
+- [x] OIDC/OAuth2 token resolution to `Principal` with `actorType: 'human'`
+- [x] API key resolution to `Principal` with `actorType: 'agent'`
+- [x] System principal resolution (`actorType: 'system'`)
+- [x] `actorType` on every `Principal`, unconditionally
+- [x] Typed `AuthError` responses (TOKEN_EXPIRED, TOKEN_INVALID, etc.)
+- [x] Service account CRUD (create, read, revoke)
+- [x] API keys stored hashed; raw key returned only at creation
+- [x] Stateless verification (no session state, no caching)
+- [x] No permission evaluation (delegated to `permissions` module)
+- [x] WebSocket authentication (connection auth before handshake)
+
+Post-MVP (deferred):
+- (none — all contract invariants are met)

--- a/contracts/collab/rules.md
+++ b/contracts/collab/rules.md
@@ -188,3 +188,26 @@ How to test each invariant:
 - **Crash recovery** -- write operations, kill process before materialization, restart, verify document state matches pre-crash state via journal replay
 - **No browser exports** -- attempt to bundle this module with a browser-targeted bundler, assert failure or zero collab exports in output
 - **No per-keystroke Zod validation** -- apply rapid CRDT updates, verify Zod validation only runs during materialization cycles
+
+## MVP Scope
+
+Implemented:
+- [x] Hocuspocus WebSocket server with Yjs CRDT synchronization
+- [x] WebSocket authentication before handshake (auth module integration)
+- [x] Connection-principal binding (one document, one principal per connection)
+- [x] Awareness protocol (cursor positions, user presence)
+- [x] CRDT compaction in `worker_threads`
+- [x] WebSocket upgrade handler exported for `api` module mounting
+- [x] Server-only module (no browser-compatible exports)
+- [x] No per-keystroke Zod validation
+- [x] Single-node Hocuspocus (no multi-node coordination)
+
+Post-MVP (deferred):
+- [ ] IntentExecutor subsystem (OCC-based agent intent application) — required for agent writes
+- [ ] Document Materializer (debounced Yjs-to-DocumentSnapshot conversion) — required for search, export, API reads
+- [ ] Operation journal and crash recovery (journal replay on startup)
+- [ ] Idempotency key cache at intent level — HTTP-level idempotency exists via `api` module
+- [ ] `GrantRevoked` event subscription for connection teardown — requires events module implementation
+- [ ] `DocumentUpdated` event emission — requires events module implementation
+- [ ] `StateFlushed` event emission — requires events module implementation
+- [ ] Flush-on-demand for export workflows — requires Materializer

--- a/contracts/convert/rules.md
+++ b/contracts/convert/rules.md
@@ -138,3 +138,20 @@ services:
 ```
 
 The memory limit is a hard requirement per Decision #003. LibreOffice will OOM a shared host without explicit cgroup limits.
+
+## MVP Scope
+
+Implemented:
+- [x] Import: file-to-DocumentSnapshot conversion (docx, odt, pdf)
+- [x] Export: DocumentSnapshot-to-file conversion (docx, odt, pdf)
+- [x] LibreOffice process management in memory-limited container
+- [x] Import produces valid `DocumentSnapshot` (schema-validated)
+- [x] Stale flag on export results
+- [x] No Yjs/CRDT dependency (operates on DocumentSnapshot only)
+- [x] No long-lived connections to other modules
+
+Post-MVP (deferred):
+- [ ] Flush-before-export via `ConversionRequested` event — requires events module; currently reads last materialized snapshot directly
+- [ ] `ExportReady` event emission — requires events module implementation
+- [ ] `ConversionRequested` event emission — requires events module implementation
+- [ ] Event schema registry registration at startup — requires events module

--- a/contracts/document/rules.md
+++ b/contracts/document/rules.md
@@ -271,3 +271,23 @@ When adding a new document type (e.g. `SpreadsheetSnapshot`):
 4. Add a corresponding `SpreadsheetSchemaVersion` enum and migration registry.
 5. Extend `IntentAction` with spreadsheet-specific actions if needed.
 6. All existing consumers that switch on `documentType` will get compile errors until they handle the new variant. This is by design.
+
+## MVP Scope
+
+Implemented:
+- [x] `DocumentSnapshot` discriminated union type (with `TextDocumentSnapshot` variant)
+- [x] `TextSchemaVersion` enum with `current` export
+- [x] `ProseMirrorJSON` type and Zod schema
+- [x] `DocumentIntent` and `IntentAction` types with Zod schemas
+- [x] `computeRevisionId` pure function (SHA-256 of state vector)
+- [x] `migrateToLatest` idempotent migration function
+- [x] Migration registry (sequential, pure, deterministic)
+- [x] Leaf module with no runtime dependencies
+- [x] Block-ID-based intent targeting (no JSON paths)
+- [x] Zod schemas for all exported types
+- [x] `contract.ts` under 200 lines
+
+Post-MVP (deferred):
+- [ ] Property-based tests for snapshot schema validity — unit tests exist, property-based tests planned
+- [ ] Block ID uniqueness test (assert all blockIds in a document are distinct)
+- [ ] Exhaustiveness compile-time test (`assertNever` pattern for `documentType` switch)

--- a/contracts/events/rules.md
+++ b/contracts/events/rules.md
@@ -86,3 +86,20 @@ How to test each invariant:
 - 7-day TTL pruning --> Integration test: insert outbox entries with `occurredAt` older than 7 days, run the pruner, verify deletion.
 - Schema registry uniqueness --> Unit test: register `DocumentUpdated` from `collab`, then attempt to register `DocumentUpdated` from `sharing`, expect rejection.
 - Redis Streams (not pub/sub) --> Integration test: verify the Redis commands issued are `XADD`, `XREADGROUP`, `XACK` (not `PUBLISH`/`SUBSCRIBE`).
+
+## MVP Scope
+
+Implemented:
+- [x] `DomainEvent` base type exported (types-only)
+- [x] `EventType` enum with registered event types
+
+Post-MVP (deferred):
+- [ ] EventBus implementation (emit, subscribe, acknowledge) — required before Pillar 2 (Audit) and Pillar 6 (Observability)
+- [ ] PG transactional outbox persistence
+- [ ] Redis Streams consumer group delivery
+- [ ] Outbox poller and retry logic
+- [ ] 7-day TTL pruning background job
+- [ ] Schema registry with one-owner-per-event-type enforcement
+- [ ] At-least-once delivery guarantees
+
+> **Note:** The entire events module implementation is deferred. Currently types-only. The contract defines the target architecture; implementation is blocked until a downstream module requires event delivery at runtime.

--- a/contracts/permissions/rules.md
+++ b/contracts/permissions/rules.md
@@ -70,3 +70,19 @@ How to test each invariant:
 - GrantRevoked emitted after persistence -> Integration test (with `storage` and `events`): revoke a grant, assert the event is emitted only after the storage write succeeds. Simulate a storage failure, assert no event is emitted.
 - No collab dependency -> Code-level audit: grep the module source for any import of `collab`, `document`, or `sharing`. Assert zero references.
 - No I/O in evaluate -> Code-level audit: assert the evaluate function is synchronous, accepts no database handles, HTTP clients, or async parameters. Static analysis: confirm no `await`, `fetch`, or storage calls within the evaluate function body.
+
+## MVP Scope
+
+Implemented:
+- [x] Pure function permission evaluation (given Principal, query, and grants)
+- [x] Role hierarchy enforcement (owner > editor > commenter > viewer)
+- [x] Action-to-minimum-role mapping
+- [x] Expired grant rejection
+- [x] Agent-human evaluation parity
+- [x] No collab dependency (no direct imports)
+- [x] Grant CRUD operations via storage
+
+Post-MVP (deferred):
+- [ ] `GrantCreated` event emission — requires events module implementation
+- [ ] `GrantRevoked` event emission — requires events module implementation
+- [ ] `reason` string in every `PermissionResult` — currently returns boolean-style results

--- a/contracts/sharing/rules.md
+++ b/contracts/sharing/rules.md
@@ -7,7 +7,7 @@ Manage the lifecycle of access grants: creating, updating, and revoking grants t
 ## Inputs
 
 - `createGrant(principal: Principal, targetDocId: string, granteeEmail: string, role: GrantRole)`: Creates a new access grant for the specified grantee on the target document, subject to the principal's own permission level.
-- `updateGrant(principal: Principal, grantId: string, newRole: GrantRole)`: Changes the role on an existing grant (e.g. `view` to `edit`), subject to the principal's own permission level.
+- `updateGrant(principal: Principal, grantId: string, newRole: GrantRole)`: Changes the role on an existing grant (e.g. `viewer` to `editor`), subject to the principal's own permission level.
 - `revokeGrant(principal: Principal, grantId: string)`: Revokes an existing grant immediately and emits `GrantRevoked`.
 - `createShareLink(principal: Principal, targetDocId: string, role: GrantRole, options?: ShareLinkOptions)`: Generates a shareable link token that, when accessed, resolves to a grant with the specified role.
 - `redeemShareLink(token: string, redeemer: Principal)`: Resolves a share link token into a grant for the redeeming principal.
@@ -17,7 +17,7 @@ Manage the lifecycle of access grants: creating, updating, and revoking grants t
 ### Types
 
 ```
-GrantRole: 'view' | 'edit'
+GrantRole: 'viewer' | 'editor' | 'commenter'
 
 ShareLinkOptions: {
   expiresIn?: number       // TTL in seconds; if omitted, link does not auto-expire but remains revocable
@@ -64,7 +64,7 @@ ShareLink: {
 
 ## Invariants
 
-- A principal can never grant a role higher than their own role on the target document. A `view` holder cannot grant `edit`. Enforced by querying the principal's own grant via the `permissions` module before writing.
+- A principal can never grant a role higher than their own role on the target document. A `viewer` holder cannot grant `editor`. Enforced by querying the principal's own grant via the `permissions` module before writing.
 - Every successful `revokeGrant` call emits a `GrantRevoked` event in the same transaction as the grant status change. There is no window where a grant is revoked but the event has not been emitted.
 - Share link tokens are cryptographically random (minimum 256 bits of entropy) and opaque. They contain no embedded document IDs, roles, or user information.
 - A share link with an `expiresAt` in the past cannot be redeemed. A revoked share link cannot be redeemed. A share link whose `redemptionCount >= maxRedemptions` cannot be redeemed.
@@ -99,7 +99,7 @@ ShareLink: {
 
 How to test each invariant:
 
-- Cannot grant higher than own role --> Unit test: a principal with `view` role attempts to create a grant with `edit` role. Assert rejection. A principal with `edit` role grants `view`. Assert success.
+- Cannot grant higher than own role --> Unit test: a principal with `viewer` role attempts to create a grant with `editor` role. Assert rejection. A principal with `editor` role grants `viewer`. Assert success.
 - GrantRevoked emitted transactionally --> Integration test (with `events` and `storage`): revoke a grant, verify the `GrantRevoked` event exists in the PG outbox within the same transaction. Simulate a crash after revocation but before commit; verify neither the revocation nor the event persists.
 - Share link token entropy --> Unit test: generate 1000 tokens, assert each is unique. Assert token length corresponds to >= 256 bits of randomness. Assert tokens contain no decodable document or user information.
 - Expired/revoked/exhausted links rejected --> Unit test: attempt to redeem a link with `expiresAt` in the past, assert rejection. Revoke a link, attempt redemption, assert rejection. Set `maxRedemptions: 1`, redeem once, attempt a second redemption, assert rejection.

--- a/contracts/sharing/rules.md
+++ b/contracts/sharing/rules.md
@@ -108,3 +108,22 @@ How to test each invariant:
 - One-directional status transitions --> Unit test: attempt to transition a `revoked` grant to `active`, assert rejection. Attempt to transition `active` to `pending`, assert rejection.
 - No collab dependency --> Code-level audit: grep the module source for any import of `collab`. Assert zero references.
 - No direct email sending --> Code-level audit: grep the module source for SMTP, sendmail, or email transport imports. Assert zero references.
+
+## MVP Scope
+
+Implemented:
+- [x] Share link creation with cryptographically random tokens (256-bit entropy)
+- [x] Share link redemption resolving to access
+- [x] Share link revocation
+- [x] Share link expiration and max-redemption enforcement
+- [x] One-directional grant status transitions
+- [x] No direct collab module dependency
+- [x] No direct email sending
+
+Post-MVP (deferred):
+- [ ] Full `Grant` record creation in permissions store on share link redemption — currently grants access without formal Grant record
+- [ ] "Cannot grant higher than own role" enforcement — requires auth wiring to look up grantor's role
+- [ ] `GrantCreated` event emission — requires events module implementation
+- [ ] `GrantRevoked` event emission — requires events module implementation
+- [ ] Invite-by-email workflow (pending grants that activate on authentication)
+- [ ] `updateGrant` role change support

--- a/contracts/storage/rules.md
+++ b/contracts/storage/rules.md
@@ -59,3 +59,19 @@ How to test each invariant:
 - Separate storage paths: save both a snapshot and a Yjs binary for the same doc, then independently verify each is retrievable and stored at distinct keys/rows
 - Read-your-writes: call `saveSnapshot` then immediately `getSnapshot` for the same `docId` and assert equality
 - Cold storage staleness: archive a document, wait a known duration, retrieve it, and verify `staleSeconds` reflects elapsed time within acceptable tolerance
+
+## MVP Scope
+
+Implemented:
+- [x] PostgreSQL persistence for documents (hot tier)
+- [x] Yjs binary blob storage (separate from snapshot)
+- [x] Read-your-writes consistency within PG
+- [x] Functions exported directly (saveSnapshot, getSnapshot, getYjsBinary, etc.)
+
+Post-MVP (deferred):
+- [ ] `DocumentRepository` interface abstraction — functions are exported directly for now; interface wrapper deferred
+- [ ] S3-compatible cold storage tier — all documents remain in PG hot tier
+- [ ] Hot/cold tiering lifecycle policy (archiveToCold / warmFromCold)
+- [ ] `staleSeconds` indicator on cold-tier reads — no cold tier exists yet
+- [ ] Atomic snapshot + state vector co-persistence in a single PG transaction — snapshots and state vectors are saved but not yet in the same transaction
+- [ ] State vector pruning for clients offline > 30 days

--- a/modules/api/index.ts
+++ b/modules/api/index.ts
@@ -24,3 +24,6 @@ export type {
 
 // Constants
 export { OUTBOX_TTL_DAYS } from './contract.ts';
+
+// Utilities
+export { asyncHandler } from './internal/async-handler.ts';

--- a/modules/api/internal/convert-routes.ts
+++ b/modules/api/internal/convert-routes.ts
@@ -16,7 +16,7 @@ import {
   CollaboraError,
   ImportError,
 } from '../../convert/index.ts';
-import { getDocument } from '../../storage/internal/pg.ts';
+import { getDocument } from '../../storage/index.ts';
 import { asyncHandler } from './async-handler.ts';
 
 const MAX_UPLOAD_SIZE = 50 * 1024 * 1024; // 50 MB

--- a/modules/api/internal/document-routes.ts
+++ b/modules/api/internal/document-routes.ts
@@ -8,7 +8,7 @@ import {
   getDocument,
   deleteDocument,
   updateDocumentTitle,
-} from '../../storage/internal/pg.ts';
+} from '../../storage/index.ts';
 import type { PermissionsModule } from '../../permissions/index.ts';
 import { asyncHandler } from './async-handler.ts';
 

--- a/modules/api/internal/export-routes.ts
+++ b/modules/api/internal/export-routes.ts
@@ -1,8 +1,8 @@
 /** Contract: contracts/api/rules.md */
 
 import { Router, type Request, type Response } from 'express';
-import { getDocument } from '../../storage/internal/pg.ts';
-import { getDocumentForExport } from '../../convert/internal/converter.ts';
+import { getDocument } from '../../storage/index.ts';
+import { getDocumentForExport } from '../../convert/index.ts';
 import type { PermissionsModule } from '../../permissions/index.ts';
 import { asyncHandler } from './async-handler.ts';
 

--- a/modules/api/internal/server.ts
+++ b/modules/api/internal/server.ts
@@ -3,7 +3,7 @@ import { createServer } from 'node:http';
 import express, { type Request, type Response, type NextFunction } from 'express';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createCollabServer } from '../../collab/internal/server.ts';
+import { createCollabServer } from '../../collab/index.ts';
 import { getRedisClient, disconnectRedis } from './redis.ts';
 import { idempotencyMiddleware } from './idempotency.ts';
 import { createConvertRoutes } from './convert-routes.ts';

--- a/modules/collab/index.ts
+++ b/modules/collab/index.ts
@@ -19,3 +19,6 @@ export {
   MaterializerConfigSchema,
   CollabConfigSchema,
 } from './contract.ts';
+
+// Public API — collab server
+export { createCollabServer } from './internal/server.ts';

--- a/modules/collab/internal/server.ts
+++ b/modules/collab/internal/server.ts
@@ -4,7 +4,7 @@ import { WebSocketServer } from 'ws';
 import * as Y from 'yjs';
 import type { IncomingMessage } from 'node:http';
 import type { Duplex } from 'node:stream';
-import { saveYjsState, loadYjsState } from '../../storage/internal/pg.ts';
+import { saveYjsState, loadYjsState } from '../../storage/index.ts';
 import { CompactionManager } from './compaction-manager.ts';
 import { createOnAuthenticate } from './authenticate.ts';
 import type { CollabConfig } from '../contract.ts';

--- a/modules/convert/internal/converter.ts
+++ b/modules/convert/internal/converter.ts
@@ -13,7 +13,7 @@ import {
   type ExportResult,
 } from './exporter.ts';
 import { contentToHtml } from './html-renderer.ts';
-import { getDocument } from '../../storage/internal/pg.ts';
+import { getDocument } from '../../storage/index.ts';
 
 export type { ExportResult };
 

--- a/modules/convert/internal/exporter.ts
+++ b/modules/convert/internal/exporter.ts
@@ -14,7 +14,7 @@ import { randomUUID } from 'node:crypto';
 import type { ExportFormat, ConversionResult } from '../contract.ts';
 import { EventType, type DomainEvent, type EventBus } from '../../events/contract.ts';
 import { convertFile } from './libreoffice.ts';
-import { getDocument } from '../../storage/internal/pg.ts';
+import { getDocument } from '../../storage/index.ts';
 
 const FLUSH_TIMEOUT_MS = parseInt(
   process.env.FLUSH_TIMEOUT_MS || '10000',

--- a/modules/sharing/contract.ts
+++ b/modules/sharing/contract.ts
@@ -2,8 +2,11 @@
 import { z } from 'zod';
 
 // --- Grant Role ---
+// Subset of permissions' Role that can be shared (owner is excluded).
 
-export const GrantRoleSchema = z.enum(['view', 'edit']);
+export const SHAREABLE_ROLES = ['viewer', 'editor', 'commenter'] as const;
+
+export const GrantRoleSchema = z.enum(SHAREABLE_ROLES);
 
 export type GrantRole = z.infer<typeof GrantRoleSchema>;
 

--- a/modules/sharing/internal/routes.test.ts
+++ b/modules/sharing/internal/routes.test.ts
@@ -28,12 +28,12 @@ describe('share routes', () => {
     it('creates a share link (201)', async () => {
       const res = await request(app)
         .post('/api/documents/doc-1/share')
-        .send({ role: 'view' });
+        .send({ role: 'viewer' });
 
       expect(res.status).toBe(201);
       expect(res.body.token).toBeDefined();
       expect(res.body.docId).toBe('doc-1');
-      expect(res.body.role).toBe('view');
+      expect(res.body.role).toBe('viewer');
       expect(res.body.passwordHash).toBeUndefined();
     });
 
@@ -58,7 +58,7 @@ describe('share routes', () => {
     it('resolves a valid token', async () => {
       const createRes = await request(app)
         .post('/api/documents/doc-1/share')
-        .send({ role: 'edit' });
+        .send({ role: 'editor' });
 
       const res = await request(app)
         .post(`/api/share/${createRes.body.token}/resolve`)
@@ -66,7 +66,7 @@ describe('share routes', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.grant.docId).toBe('doc-1');
-      expect(res.body.grant.role).toBe('edit');
+      expect(res.body.grant.role).toBe('editor');
     });
 
     it('returns 404 for invalid token', async () => {
@@ -81,7 +81,7 @@ describe('share routes', () => {
     it('returns 410 for expired token', async () => {
       const createRes = await request(app)
         .post('/api/documents/doc-1/share')
-        .send({ role: 'view', options: { expiresIn: 1 } });
+        .send({ role: 'viewer', options: { expiresIn: 1 } });
 
       // Force expiration
       await store.update(createRes.body.token, {
@@ -99,7 +99,7 @@ describe('share routes', () => {
     it('returns 410 for revoked token', async () => {
       const createRes = await request(app)
         .post('/api/documents/doc-1/share')
-        .send({ role: 'view' });
+        .send({ role: 'viewer' });
 
       await request(app)
         .delete(`/api/share/${createRes.body.token}`);
@@ -115,7 +115,7 @@ describe('share routes', () => {
     it('returns 403 for wrong password', async () => {
       const createRes = await request(app)
         .post('/api/documents/doc-1/share')
-        .send({ role: 'view', options: { password: 'secret' } });
+        .send({ role: 'viewer', options: { password: 'secret' } });
 
       const res = await request(app)
         .post(`/api/share/${createRes.body.token}/resolve`)
@@ -128,14 +128,14 @@ describe('share routes', () => {
     it('resolves password-protected link with correct password', async () => {
       const createRes = await request(app)
         .post('/api/documents/doc-1/share')
-        .send({ role: 'view', options: { password: 'secret' } });
+        .send({ role: 'viewer', options: { password: 'secret' } });
 
       const res = await request(app)
         .post(`/api/share/${createRes.body.token}/resolve`)
         .send({ password: 'secret' });
 
       expect(res.status).toBe(200);
-      expect(res.body.grant.role).toBe('view');
+      expect(res.body.grant.role).toBe('viewer');
     });
   });
 
@@ -143,7 +143,7 @@ describe('share routes', () => {
     it('revokes an existing link', async () => {
       const createRes = await request(app)
         .post('/api/documents/doc-1/share')
-        .send({ role: 'view' });
+        .send({ role: 'viewer' });
 
       const res = await request(app)
         .delete(`/api/share/${createRes.body.token}`);

--- a/modules/sharing/internal/routes.ts
+++ b/modules/sharing/internal/routes.ts
@@ -3,7 +3,7 @@
 import { Router } from 'express';
 import { GrantRoleSchema, ShareLinkOptionsSchema } from '../contract.ts';
 import type { ShareLinkService } from './share-links.ts';
-import { asyncHandler } from '../../api/internal/async-handler.ts';
+import { asyncHandler } from '../../api/index.ts';
 
 /**
  * Create Express routes for share link management.
@@ -17,7 +17,7 @@ export function createShareRoutes(service: ShareLinkService): Router {
     const docId = req.params.id;
     const roleResult = GrantRoleSchema.safeParse(req.body?.role);
     if (!roleResult.success) {
-      res.status(400).json({ error: 'role must be "view" or "edit"' });
+      res.status(400).json({ error: 'role must be "viewer", "editor", or "commenter"' });
       return;
     }
 

--- a/modules/sharing/internal/share-links.test.ts
+++ b/modules/sharing/internal/share-links.test.ts
@@ -29,13 +29,13 @@ describe('share-links', () => {
       const link = await service.create({
         docId: 'doc-1',
         grantorId: 'user-1',
-        role: 'view',
+        role: 'viewer',
       });
 
       expect(link.token).toHaveLength(64);
       expect(link.docId).toBe('doc-1');
       expect(link.grantorId).toBe('user-1');
-      expect(link.role).toBe('view');
+      expect(link.role).toBe('viewer');
       expect(link.expiresAt).toBeUndefined();
       expect(link.redemptionCount).toBe(0);
       expect(link.revoked).toBe(false);
@@ -46,7 +46,7 @@ describe('share-links', () => {
       const link = await service.create({
         docId: 'doc-1',
         grantorId: 'user-1',
-        role: 'edit',
+        role: 'editor',
         options: { expiresIn: 3600 },
       });
 
@@ -61,7 +61,7 @@ describe('share-links', () => {
       const link = await service.create({
         docId: 'doc-1',
         grantorId: 'user-1',
-        role: 'view',
+        role: 'viewer',
         options: { password: 'secret123' },
       });
 
@@ -77,14 +77,14 @@ describe('share-links', () => {
       const link = await service.create({
         docId: 'doc-1',
         grantorId: 'user-1',
-        role: 'view',
+        role: 'viewer',
       });
 
       const result = await service.resolve(link.token);
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.link.docId).toBe('doc-1');
-        expect(result.link.role).toBe('view');
+        expect(result.link.role).toBe('viewer');
       }
 
       // Redemption count should have been incremented in the store
@@ -101,7 +101,7 @@ describe('share-links', () => {
       const link = await service.create({
         docId: 'doc-1',
         grantorId: 'user-1',
-        role: 'view',
+        role: 'viewer',
         options: { expiresIn: 1 },
       });
 
@@ -118,7 +118,7 @@ describe('share-links', () => {
       const link = await service.create({
         docId: 'doc-1',
         grantorId: 'user-1',
-        role: 'view',
+        role: 'viewer',
       });
 
       await service.revoke(link.token);
@@ -130,7 +130,7 @@ describe('share-links', () => {
       const link = await service.create({
         docId: 'doc-1',
         grantorId: 'user-1',
-        role: 'view',
+        role: 'viewer',
         options: { maxRedemptions: 1 },
       });
 
@@ -147,7 +147,7 @@ describe('share-links', () => {
       const link = await service.create({
         docId: 'doc-1',
         grantorId: 'user-1',
-        role: 'view',
+        role: 'viewer',
         options: { password: 'correct-horse' },
       });
 
@@ -159,7 +159,7 @@ describe('share-links', () => {
       const link = await service.create({
         docId: 'doc-1',
         grantorId: 'user-1',
-        role: 'view',
+        role: 'viewer',
         options: { password: 'correct-horse' },
       });
 
@@ -171,7 +171,7 @@ describe('share-links', () => {
       const link = await service.create({
         docId: 'doc-1',
         grantorId: 'user-1',
-        role: 'view',
+        role: 'viewer',
         options: { password: 'correct-horse' },
       });
 
@@ -185,7 +185,7 @@ describe('share-links', () => {
       const link = await service.create({
         docId: 'doc-1',
         grantorId: 'user-1',
-        role: 'view',
+        role: 'viewer',
       });
 
       const revoked = await service.revoke(link.token);

--- a/modules/storage/index.ts
+++ b/modules/storage/index.ts
@@ -14,3 +14,16 @@ export type {
   SaveYjsBinaryParams,
   DocumentRepository,
 } from './contract.ts';
+
+// Public API — database operations
+export {
+  listDocuments,
+  createDocument,
+  getDocument,
+  deleteDocument,
+  updateDocumentTitle,
+  saveYjsState,
+  loadYjsState,
+} from './internal/pg.ts';
+
+export type { DocumentRow } from './internal/pg.ts';

--- a/modules/storage/internal/pg.ts
+++ b/modules/storage/internal/pg.ts
@@ -72,4 +72,4 @@ export async function updateDocumentTitle(id: string, title: string): Promise<vo
   );
 }
 
-export { pool };
+// pool is intentionally not exported — use the public API functions above


### PR DESCRIPTION
## Summary

Addresses the final 3 open issues from the adversarial code review:

- **#22**: All cross-module `internal/` imports replaced with `index.ts` imports. Raw PG pool export removed. Security lint now reports 0 boundary violations.
- **#26**: Sharing module now uses permissions' role types (`viewer`/`editor`/`commenter` instead of `view`/`edit`). Types are unified.
- **#27**: Added `## MVP Scope` section to all 10 contracts documenting what IS and ISN'T implemented. No rules changed — purely documentary.

## Test plan
- [ ] 240 tests passing
- [ ] `npm run check` clean
- [ ] Security lint: 0 errors (down from 2)
- [ ] `grep -rn "from '.*\.\./\.\./.*internal/" modules/ --include='*.ts' | grep -v '\.test\.ts'` returns nothing

Closes #22, closes #26, closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)