### PR TITLE
Self-host deployment: Docker, schema init, nginx

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.claude
+.playwright-mcp
+node_modules
+docs
+decisions
+audits
+reviews
+scripts
+*.md
+!package.json
+.env
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build:frontend
+
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=build /app .
+EXPOSE 3000
+CMD ["node", "--import=tsx", "server.ts"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,39 @@ services:
     memswap_limit: 2g
     oom_score_adj: 500
 
+  opendesk:
+    build: .
+    environment:
+      PORT: "3000"
+      AUTH_MODE: dev
+      PG_HOST: postgres
+      PG_PORT: "5432"
+      PG_DATABASE: opendesk
+      PG_USER: opendesk
+      PG_PASSWORD: opendesk_dev
+      S3_ENDPOINT: http://minio:9000
+      S3_ACCESS_KEY: opendesk
+      S3_SECRET_KEY: opendesk_dev
+      S3_BUCKET: opendesk
+      REDIS_URL: redis://redis:6379
+      COLLABORA_URL: http://convert:9980
+    ports:
+      - "3000:3000"
+    depends_on:
+      - postgres
+      - redis
+      - minio
+      - convert
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - opendesk
+
 volumes:
   pg_data:
   redis_data:

--- a/modules/api/internal/server.ts
+++ b/modules/api/internal/server.ts
@@ -18,10 +18,14 @@ import { createTemplateRoutes } from './template-routes.ts';
 import { createVersionRoutes } from './version-routes.ts';
 import { createFolderRoutes, createMoveDocumentRoute } from './folder-routes.ts';
 import { createSearchRoutes } from './search-routes.ts';
+import { pool } from '../../storage/internal/pool.ts';
+import { initSchema } from '../../storage/internal/schema.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-export function startServer(port = 3000) {
+export async function startServer(port = 3000) {
+  await initSchema();
+  console.log('[opendesk] database schema initialized');
   const app = express();
 
   // Wire auth module (dev mode uses bypass verifiers)
@@ -60,8 +64,13 @@ export function startServer(port = 3000) {
   app.use(createConvertRoutes());
 
   // Health check (public, skipped by auth middleware)
-  app.get('/api/health', (_req, res) => {
-    res.json({ status: 'ok', version: '0.1.0' });
+  app.get('/api/health', async (_req, res) => {
+    try {
+      await pool.query('SELECT 1');
+      res.json({ status: 'ok', version: '0.1.0' });
+    } catch {
+      res.status(503).json({ status: 'unhealthy' });
+    }
   });
 
   // Search must be mounted before document CRUD so /search is matched before /:id

--- a/modules/storage/internal/schema.ts
+++ b/modules/storage/internal/schema.ts
@@ -1,0 +1,66 @@
+/** Contract: contracts/storage/rules.md */
+import { pool } from './pool.ts';
+import { APPLY_SEARCH_SCHEMA } from './pg-search.ts';
+
+const CREATE_DOCUMENTS_TABLE = `
+  CREATE TABLE IF NOT EXISTS documents (
+    id UUID PRIMARY KEY,
+    title TEXT NOT NULL DEFAULT 'Untitled',
+    yjs_state BYTEA,
+    folder_id UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  )
+`;
+
+const CREATE_FOLDERS_TABLE = `
+  CREATE TABLE IF NOT EXISTS folders (
+    id UUID PRIMARY KEY,
+    name TEXT NOT NULL,
+    parent_id UUID REFERENCES folders(id) ON DELETE SET NULL,
+    created_by TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  )
+`;
+
+const ADD_FOLDER_FK = `
+  ALTER TABLE documents
+    ADD COLUMN IF NOT EXISTS folder_id UUID REFERENCES folders(id) ON DELETE SET NULL
+`;
+
+const CREATE_TEMPLATES_TABLE = `
+  CREATE TABLE IF NOT EXISTS templates (
+    id UUID PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    content JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  )
+`;
+
+const CREATE_VERSIONS_TABLE = `
+  CREATE TABLE IF NOT EXISTS document_versions (
+    id UUID PRIMARY KEY,
+    document_id UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    content JSONB NOT NULL,
+    title TEXT NOT NULL DEFAULT '',
+    created_by TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    version_number INTEGER NOT NULL,
+    UNIQUE (document_id, version_number)
+  )
+`;
+
+/**
+ * Initialize all database tables in dependency order.
+ * Safe to call multiple times (uses IF NOT EXISTS).
+ */
+export async function initSchema(): Promise<void> {
+  await pool.query(CREATE_DOCUMENTS_TABLE);
+  await pool.query(CREATE_FOLDERS_TABLE);
+  await pool.query(ADD_FOLDER_FK);
+  await pool.query(CREATE_TEMPLATES_TABLE);
+  await pool.query(CREATE_VERSIONS_TABLE);
+  await pool.query(APPLY_SEARCH_SCHEMA);
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,23 @@
+server {
+    listen 80;
+    server_name _;
+
+    location / {
+        proxy_pass http://opendesk:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /collab {
+        proxy_pass http://opendesk:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/server.ts
+++ b/server.ts
@@ -3,4 +3,4 @@ import { loadConfig } from './modules/config/index.ts';
 import { startServer } from './modules/api/index.ts';
 
 const config = loadConfig();
-startServer(config.server.port);
+await startServer(config.server.port);


### PR DESCRIPTION
## Summary

Milestone 6 (Self-Host) for MVP — `docker compose up` now brings up the full OpenDesk stack.

- **Dockerfile**: Multi-stage node:22-alpine build (frontend esbuild + runtime)
- **docker-compose.yml**: Added `opendesk` app service + `nginx` reverse proxy alongside existing postgres/redis/minio/collabora
- **nginx.conf**: Reverse proxy with WebSocket upgrade for `/collab`, proper proxy headers
- **schema.ts**: Idempotent `initSchema()` creates all DB tables at startup (documents, folders, templates, versions, search index)
- **server.ts**: Async startup with schema init, health check now queries DB for real connectivity status
- **.dockerignore**: Optimized image size

## Test plan

- [ ] `docker build -t opendesk:test .` succeeds
- [ ] `docker compose up` brings up all 6 services
- [ ] `curl http://localhost/api/health` returns `{"status":"ok"}`
- [ ] Navigate to `http://localhost` — doc list loads
- [ ] Create and edit a document — real-time collab works through nginx proxy
- [ ] Import/export .docx via Collabora

🤖 Generated with [Claude Code](https://claude.com/claude-code)