### PR TITLE
feat: add cell formatting system for spreadsheet editor

### DIFF
--- a/contracts/sheets-formatting/rules.md
+++ b/contracts/sheets-formatting/rules.md
@@ -1,0 +1,69 @@
+# Contract: sheets-formatting
+
+## Purpose
+
+Provide cell formatting types, toolbar UI, format rendering, and keyboard shortcuts for the spreadsheet editor. Formatting data is stored in the Yjs shared document alongside cell values, enabling real-time collaborative formatting changes.
+
+## Inputs
+
+- User interactions: toolbar button clicks, keyboard shortcuts (Ctrl+B, Ctrl+I, Ctrl+U)
+- Active cell coordinates: row and column of the currently selected cell
+- Yjs shared document: the Y.Map-based cell data structure containing format metadata
+
+## Outputs
+
+- `CellFormat` type: bold, italic, underline, strikethrough, fontSize, textColor, backgroundColor, alignment, numberFormat, borders
+- Formatting toolbar DOM element with buttons and selectors
+- Inline styles applied to rendered grid cells based on their format
+- Number display formatting (currency, percentage, date) while preserving raw values
+- Yjs-synced format data that replicates to all collaborators
+
+## Side Effects
+
+- Reads and writes cell format data in the Yjs shared document
+- Modifies DOM styles on spreadsheet grid cells
+- Listens for keyboard events on the document for formatting shortcuts
+
+## Invariants
+
+1. **Format data syncs via Yjs.** All formatting changes are written to the Yjs shared document and replicate to collaborators automatically.
+2. **Raw values are preserved.** Number formatting changes display only; the underlying numeric value is unchanged and available for formula calculations.
+3. **Toolbar reflects active cell state.** When a cell gains focus, the toolbar buttons update to reflect that cell's current formatting.
+4. **Keyboard shortcuts match conventions.** Ctrl+B = bold, Ctrl+I = italic, Ctrl+U = underline.
+5. **Formats are optional.** A cell with no format data renders with default styles. Missing format fields default to their unset state.
+
+## Dependencies
+
+- `document/contract/spreadsheet.ts` (compile-time) -- CellFormat type definition
+- `yjs` (runtime) -- Y.Map for per-cell format storage
+- Spreadsheet editor module (runtime) -- grid rendering and cell selection
+
+## Boundary Rules
+
+### MUST
+
+- Store format data in the Yjs shared document alongside cell values
+- Apply formatting via inline styles on cell DOM elements
+- Keep every file under 200 lines
+- Use modern CSS only (no Tailwind, no preprocessors)
+- Include contract header on every module file
+
+### MUST NOT
+
+- Mutate raw cell values when applying number formats
+- Import server-side modules
+- Use mock data
+- Create files over 200 lines
+
+## File Structure
+
+```
+modules/app/internal/
+  sheets-format-types.ts       -- CellFormat type and number format utilities
+  sheets-format-toolbar.ts     -- Toolbar DOM creation and event handling
+  sheets-format-renderer.ts    -- Apply CellFormat to cell DOM elements
+  sheets-format-store.ts       -- Yjs integration for reading/writing format data
+  spreadsheet-editor.ts        -- Updated to integrate formatting modules
+modules/app/internal/public/
+  spreadsheet.css              -- Updated with formatting toolbar styles
+```

--- a/modules/app/internal/public/spreadsheet.css
+++ b/modules/app/internal/public/spreadsheet.css
@@ -1,5 +1,89 @@
 /* Spreadsheet editor styles */
 
+/* --- Format Toolbar --- */
+
+.format-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 1rem;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+
+.format-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  height: 1.75rem;
+  padding: 0 0.25rem;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: none;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  color: var(--text);
+  transition: background-color 0.1s, border-color 0.1s;
+}
+
+.format-btn:hover {
+  background: var(--bg);
+  border-color: var(--border);
+}
+
+.format-btn.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.format-select {
+  height: 1.75rem;
+  padding: 0 0.25rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.format-separator {
+  width: 1px;
+  height: 1.25rem;
+  background: var(--border);
+  margin: 0 0.25rem;
+}
+
+.format-color-wrapper {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  cursor: pointer;
+  min-width: 1.75rem;
+  height: 1.75rem;
+}
+
+.format-color-label {
+  font-size: 0.875rem;
+  font-weight: 700;
+  pointer-events: none;
+}
+
+.format-color-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+  border: none;
+  padding: 0;
+}
+
 .formula-bar {
   display: flex;
   align-items: center;

--- a/modules/app/internal/public/spreadsheet.html
+++ b/modules/app/internal/public/spreadsheet.html
@@ -25,6 +25,7 @@
       <span id="users" class="users">-</span>
     </div>
   </header>
+  <div id="format-bar-container"></div>
   <div id="formula-bar" class="formula-bar">
     <label class="formula-bar-cell" id="cell-ref">A1</label>
     <input id="formula-input" class="formula-bar-input" type="text" placeholder="Enter value or formula" />

--- a/modules/app/internal/sheets-format-renderer.ts
+++ b/modules/app/internal/sheets-format-renderer.ts
@@ -1,0 +1,56 @@
+/** Contract: contracts/sheets-formatting/rules.md */
+import type { CellFormat } from './sheets-format-types.ts';
+import { formatNumber } from './sheets-format-types.ts';
+
+/**
+ * Apply a CellFormat to a cell DOM element via inline styles.
+ * Does not mutate the cell's text content for number formatting --
+ * that is handled separately by getDisplayValue().
+ */
+export function applyCellFormat(cell: HTMLElement, fmt: CellFormat | undefined): void {
+  // Reset to defaults first
+  cell.style.fontWeight = '';
+  cell.style.fontStyle = '';
+  cell.style.textDecoration = '';
+  cell.style.fontSize = '';
+  cell.style.color = '';
+  cell.style.backgroundColor = '';
+  cell.style.textAlign = '';
+  cell.style.borderTop = '';
+  cell.style.borderBottom = '';
+  cell.style.borderLeft = '';
+  cell.style.borderRight = '';
+
+  if (!fmt) return;
+
+  if (fmt.bold) cell.style.fontWeight = '700';
+  if (fmt.italic) cell.style.fontStyle = 'italic';
+
+  const decorations: string[] = [];
+  if (fmt.underline) decorations.push('underline');
+  if (fmt.strikethrough) decorations.push('line-through');
+  if (decorations.length > 0) cell.style.textDecoration = decorations.join(' ');
+
+  if (fmt.fontSize) cell.style.fontSize = `${fmt.fontSize}px`;
+  if (fmt.textColor) cell.style.color = fmt.textColor;
+  if (fmt.backgroundColor) cell.style.backgroundColor = fmt.backgroundColor;
+  if (fmt.alignment) cell.style.textAlign = fmt.alignment;
+
+  const borderStyle = '1px solid #333';
+  if (fmt.borderTop) cell.style.borderTop = borderStyle;
+  if (fmt.borderBottom) cell.style.borderBottom = borderStyle;
+  if (fmt.borderLeft) cell.style.borderLeft = borderStyle;
+  if (fmt.borderRight) cell.style.borderRight = borderStyle;
+}
+
+/**
+ * Get the display value for a cell, applying number formatting if set.
+ * Raw value is never mutated.
+ */
+export function getDisplayValue(
+  rawValue: string,
+  fmt: CellFormat | undefined,
+): string {
+  if (!fmt?.numberFormat || fmt.numberFormat === 'general') return rawValue;
+  return formatNumber(rawValue, fmt.numberFormat);
+}

--- a/modules/app/internal/sheets-format-shortcuts.ts
+++ b/modules/app/internal/sheets-format-shortcuts.ts
@@ -1,0 +1,38 @@
+/** Contract: contracts/sheets-formatting/rules.md */
+import * as Y from 'yjs';
+import { toggleBoolFormat } from './sheets-format-store.ts';
+
+export type ShortcutCallbacks = {
+  getActiveCell: () => { row: number; col: number };
+  onFormatChanged: () => void;
+};
+
+/**
+ * Attach formatting keyboard shortcuts to the document.
+ * - Ctrl+B: toggle bold
+ * - Ctrl+I: toggle italic
+ * - Ctrl+U: toggle underline
+ */
+export function attachFormatShortcuts(
+  ydoc: Y.Doc,
+  callbacks: ShortcutCallbacks,
+): () => void {
+  function handler(e: KeyboardEvent): void {
+    if (!e.ctrlKey && !e.metaKey) return;
+
+    let prop: 'bold' | 'italic' | 'underline' | undefined;
+    if (e.key === 'b' || e.key === 'B') prop = 'bold';
+    else if (e.key === 'i' || e.key === 'I') prop = 'italic';
+    else if (e.key === 'u' || e.key === 'U') prop = 'underline';
+
+    if (!prop) return;
+
+    e.preventDefault();
+    const { row, col } = callbacks.getActiveCell();
+    toggleBoolFormat(ydoc, row, col, prop);
+    callbacks.onFormatChanged();
+  }
+
+  document.addEventListener('keydown', handler);
+  return () => document.removeEventListener('keydown', handler);
+}

--- a/modules/app/internal/sheets-format-store.ts
+++ b/modules/app/internal/sheets-format-store.ts
@@ -1,0 +1,73 @@
+/** Contract: contracts/sheets-formatting/rules.md */
+import * as Y from 'yjs';
+import type { CellFormat } from './sheets-format-types.ts';
+
+/**
+ * Yjs-backed format store. Stores cell formats in a Y.Map keyed by "row:col".
+ * All mutations go through Yjs transactions for real-time sync.
+ */
+
+const FORMAT_MAP_KEY = 'sheet-0-formats';
+
+/** Get or create the shared format map from the Yjs document. */
+export function getFormatMap(ydoc: Y.Doc): Y.Map<string> {
+  return ydoc.getMap<string>(FORMAT_MAP_KEY);
+}
+
+function cellKey(row: number, col: number): string {
+  return `${row}:${col}`;
+}
+
+/** Read the CellFormat for a given cell. Returns undefined if no format set. */
+export function getCellFormat(ydoc: Y.Doc, row: number, col: number): CellFormat | undefined {
+  const map = getFormatMap(ydoc);
+  const raw = map.get(cellKey(row, col));
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw) as CellFormat;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Write a CellFormat for a given cell. Merges with existing format. */
+export function setCellFormat(ydoc: Y.Doc, row: number, col: number, updates: Partial<CellFormat>): void {
+  const map = getFormatMap(ydoc);
+  const key = cellKey(row, col);
+  const existing = getCellFormat(ydoc, row, col) || {};
+  const merged = { ...existing, ...updates };
+
+  // Remove undefined/false values to keep it clean
+  const cleaned: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(merged)) {
+    if (v !== undefined && v !== false) {
+      cleaned[k] = v;
+    }
+  }
+
+  ydoc.transact(() => {
+    if (Object.keys(cleaned).length === 0) {
+      map.delete(key);
+    } else {
+      map.set(key, JSON.stringify(cleaned));
+    }
+  });
+}
+
+/** Toggle a boolean format property (bold, italic, underline, strikethrough). */
+export function toggleBoolFormat(
+  ydoc: Y.Doc,
+  row: number,
+  col: number,
+  prop: 'bold' | 'italic' | 'underline' | 'strikethrough',
+): void {
+  const current = getCellFormat(ydoc, row, col);
+  const currentVal = current?.[prop] ?? false;
+  setCellFormat(ydoc, row, col, { [prop]: !currentVal });
+}
+
+/** Clear all formatting for a cell. */
+export function clearCellFormat(ydoc: Y.Doc, row: number, col: number): void {
+  const map = getFormatMap(ydoc);
+  map.delete(cellKey(row, col));
+}

--- a/modules/app/internal/sheets-format-toolbar-sections.ts
+++ b/modules/app/internal/sheets-format-toolbar-sections.ts
@@ -1,0 +1,174 @@
+/** Contract: contracts/sheets-formatting/rules.md */
+import * as Y from 'yjs';
+import { FONT_SIZES, type CellFormat, type NumberFormatType } from './sheets-format-types.ts';
+import { getCellFormat, setCellFormat, toggleBoolFormat } from './sheets-format-store.ts';
+import type { FormatToolbarCallbacks } from './sheets-format-toolbar.ts';
+
+function makeButton(label: string, title: string): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'format-btn';
+  btn.textContent = label;
+  btn.title = title;
+  return btn;
+}
+
+export function appendTextStyleButtons(bar: HTMLElement, ydoc: Y.Doc, cb: FormatToolbarCallbacks): void {
+  const styles: Array<{ label: string; prop: 'bold' | 'italic' | 'underline' | 'strikethrough'; title: string }> = [
+    { label: 'B', prop: 'bold', title: 'Bold (Ctrl+B)' },
+    { label: 'I', prop: 'italic', title: 'Italic (Ctrl+I)' },
+    { label: 'U', prop: 'underline', title: 'Underline (Ctrl+U)' },
+    { label: 'S', prop: 'strikethrough', title: 'Strikethrough' },
+  ];
+
+  for (const { label, prop, title } of styles) {
+    const btn = makeButton(label, title);
+    btn.dataset.fmtToggle = prop;
+    if (prop === 'bold') btn.style.fontWeight = '700';
+    if (prop === 'italic') btn.style.fontStyle = 'italic';
+    if (prop === 'underline') btn.style.textDecoration = 'underline';
+    if (prop === 'strikethrough') btn.style.textDecoration = 'line-through';
+
+    btn.addEventListener('click', () => {
+      const { row, col } = cb.getActiveCell();
+      toggleBoolFormat(ydoc, row, col, prop);
+      cb.onFormatChanged();
+    });
+    bar.appendChild(btn);
+  }
+}
+
+export function appendFontSizeSelector(bar: HTMLElement, ydoc: Y.Doc, cb: FormatToolbarCallbacks): void {
+  const select = document.createElement('select');
+  select.className = 'format-select';
+  select.dataset.fmtFontsize = '';
+  select.title = 'Font size';
+
+  const defaultOpt = document.createElement('option');
+  defaultOpt.value = '';
+  defaultOpt.textContent = 'Size';
+  select.appendChild(defaultOpt);
+
+  for (const size of FONT_SIZES) {
+    const opt = document.createElement('option');
+    opt.value = String(size);
+    opt.textContent = String(size);
+    select.appendChild(opt);
+  }
+
+  select.addEventListener('change', () => {
+    const { row, col } = cb.getActiveCell();
+    const val = select.value ? parseInt(select.value, 10) : undefined;
+    setCellFormat(ydoc, row, col, { fontSize: val });
+    cb.onFormatChanged();
+  });
+  bar.appendChild(select);
+}
+
+export function appendColorPickers(bar: HTMLElement, ydoc: Y.Doc, cb: FormatToolbarCallbacks): void {
+  bar.appendChild(makeColorPicker('A', 'Text color', 'textColor', '#000000', ydoc, cb));
+  bar.appendChild(makeColorPicker('\u25A0', 'Fill color', 'backgroundColor', '#ffff00', ydoc, cb));
+}
+
+function makeColorPicker(
+  label: string, title: string, prop: 'textColor' | 'backgroundColor',
+  defaultColor: string, ydoc: Y.Doc, cb: FormatToolbarCallbacks,
+): HTMLLabelElement {
+  const wrapper = document.createElement('label');
+  wrapper.className = 'format-color-wrapper';
+  wrapper.title = title;
+
+  const span = document.createElement('span');
+  span.className = 'format-color-label';
+  span.textContent = label;
+  if (prop === 'textColor') span.style.borderBottom = `3px solid ${defaultColor}`;
+  if (prop === 'backgroundColor') span.style.backgroundColor = defaultColor;
+
+  const input = document.createElement('input');
+  input.type = 'color';
+  input.className = 'format-color-input';
+  input.value = defaultColor;
+
+  input.addEventListener('input', () => {
+    const { row, col } = cb.getActiveCell();
+    setCellFormat(ydoc, row, col, { [prop]: input.value });
+    if (prop === 'textColor') span.style.borderBottomColor = input.value;
+    if (prop === 'backgroundColor') span.style.backgroundColor = input.value;
+    cb.onFormatChanged();
+  });
+
+  wrapper.appendChild(span);
+  wrapper.appendChild(input);
+  return wrapper;
+}
+
+export function appendAlignmentButtons(bar: HTMLElement, ydoc: Y.Doc, cb: FormatToolbarCallbacks): void {
+  const aligns: Array<{ label: string; value: 'left' | 'center' | 'right' }> = [
+    { label: '\u2261', value: 'left' },
+    { label: '\u2263', value: 'center' },
+    { label: '\u2262', value: 'right' },
+  ];
+
+  for (const { label, value } of aligns) {
+    const btn = makeButton(label, `Align ${value}`);
+    btn.dataset.fmtAlign = value;
+    btn.addEventListener('click', () => {
+      const { row, col } = cb.getActiveCell();
+      const current = getCellFormat(ydoc, row, col);
+      const newAlign = current?.alignment === value ? undefined : value;
+      setCellFormat(ydoc, row, col, { alignment: newAlign });
+      cb.onFormatChanged();
+    });
+    bar.appendChild(btn);
+  }
+}
+
+export function appendNumberFormatSelector(bar: HTMLElement, ydoc: Y.Doc, cb: FormatToolbarCallbacks): void {
+  const select = document.createElement('select');
+  select.className = 'format-select';
+  select.dataset.fmtNumformat = '';
+  select.title = 'Number format';
+
+  const fmts: Array<{ value: NumberFormatType; label: string }> = [
+    { value: 'general', label: 'General' },
+    { value: 'number', label: '1,000.00' },
+    { value: 'currency', label: '$1,000.00' },
+    { value: 'percentage', label: '10.0%' },
+    { value: 'date', label: 'Date' },
+  ];
+
+  for (const { value, label } of fmts) {
+    const opt = document.createElement('option');
+    opt.value = value;
+    opt.textContent = label;
+    select.appendChild(opt);
+  }
+
+  select.addEventListener('change', () => {
+    const { row, col } = cb.getActiveCell();
+    setCellFormat(ydoc, row, col, { numberFormat: select.value as NumberFormatType });
+    cb.onFormatChanged();
+  });
+  bar.appendChild(select);
+}
+
+export function appendBorderButtons(bar: HTMLElement, ydoc: Y.Doc, cb: FormatToolbarCallbacks): void {
+  const borders: Array<{ label: string; props: Partial<CellFormat>; title: string }> = [
+    { label: '\u2581', props: { borderBottom: true }, title: 'Bottom border' },
+    { label: '\u2594', props: { borderTop: true }, title: 'Top border' },
+    { label: '\u258F', props: { borderLeft: true }, title: 'Left border' },
+    { label: '\u2595', props: { borderRight: true }, title: 'Right border' },
+    { label: '\u25A1', props: { borderTop: true, borderBottom: true, borderLeft: true, borderRight: true }, title: 'All borders' },
+    { label: '\u00D7', props: { borderTop: false, borderBottom: false, borderLeft: false, borderRight: false }, title: 'No borders' },
+  ];
+
+  for (const { label, props, title } of borders) {
+    const btn = makeButton(label, title);
+    btn.addEventListener('click', () => {
+      const { row, col } = cb.getActiveCell();
+      setCellFormat(ydoc, row, col, props);
+      cb.onFormatChanged();
+    });
+    bar.appendChild(btn);
+  }
+}

--- a/modules/app/internal/sheets-format-toolbar.ts
+++ b/modules/app/internal/sheets-format-toolbar.ts
@@ -1,0 +1,68 @@
+/** Contract: contracts/sheets-formatting/rules.md */
+import * as Y from 'yjs';
+import type { CellFormat } from './sheets-format-types.ts';
+import {
+  appendTextStyleButtons,
+  appendFontSizeSelector,
+  appendColorPickers,
+  appendAlignmentButtons,
+  appendNumberFormatSelector,
+  appendBorderButtons,
+} from './sheets-format-toolbar-sections.ts';
+
+export type FormatToolbarCallbacks = {
+  getActiveCell: () => { row: number; col: number };
+  onFormatChanged: () => void;
+};
+
+/** Create the formatting toolbar and attach it to the given container. */
+export function createFormatToolbar(
+  container: HTMLElement,
+  ydoc: Y.Doc,
+  callbacks: FormatToolbarCallbacks,
+): HTMLElement {
+  const bar = document.createElement('div');
+  bar.className = 'format-toolbar';
+
+  appendTextStyleButtons(bar, ydoc, callbacks);
+  appendSeparator(bar);
+  appendFontSizeSelector(bar, ydoc, callbacks);
+  appendSeparator(bar);
+  appendColorPickers(bar, ydoc, callbacks);
+  appendSeparator(bar);
+  appendAlignmentButtons(bar, ydoc, callbacks);
+  appendSeparator(bar);
+  appendNumberFormatSelector(bar, ydoc, callbacks);
+  appendSeparator(bar);
+  appendBorderButtons(bar, ydoc, callbacks);
+
+  container.appendChild(bar);
+  return bar;
+}
+
+/** Update toolbar button states to reflect the active cell's format. */
+export function updateToolbarState(
+  toolbar: HTMLElement,
+  fmt: CellFormat | undefined,
+): void {
+  toolbar.querySelectorAll<HTMLButtonElement>('[data-fmt-toggle]').forEach((btn) => {
+    const prop = btn.dataset.fmtToggle as keyof CellFormat;
+    btn.classList.toggle('active', !!fmt?.[prop]);
+  });
+
+  const sizeSelect = toolbar.querySelector<HTMLSelectElement>('[data-fmt-fontsize]');
+  if (sizeSelect) sizeSelect.value = String(fmt?.fontSize || '');
+
+  const numFmt = toolbar.querySelector<HTMLSelectElement>('[data-fmt-numformat]');
+  if (numFmt) numFmt.value = fmt?.numberFormat || 'general';
+
+  toolbar.querySelectorAll<HTMLButtonElement>('[data-fmt-align]').forEach((btn) => {
+    btn.classList.toggle('active', fmt?.alignment === btn.dataset.fmtAlign);
+  });
+}
+
+function appendSeparator(bar: HTMLElement): void {
+  const sep = document.createElement('div');
+  sep.className = 'format-separator';
+  bar.appendChild(sep);
+}

--- a/modules/app/internal/sheets-format-types.ts
+++ b/modules/app/internal/sheets-format-types.ts
@@ -1,0 +1,61 @@
+/** Contract: contracts/sheets-formatting/rules.md */
+
+/**
+ * CellFormat shape used in the Yjs store and toolbar.
+ * Matches CellFormatSchema from document/contract/spreadsheet.ts.
+ */
+export type CellFormat = {
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strikethrough?: boolean;
+  fontSize?: number;
+  textColor?: string;
+  backgroundColor?: string;
+  alignment?: 'left' | 'center' | 'right';
+  numberFormat?: NumberFormatType;
+  borderTop?: boolean;
+  borderBottom?: boolean;
+  borderLeft?: boolean;
+  borderRight?: boolean;
+};
+
+export type NumberFormatType = 'general' | 'number' | 'currency' | 'percentage' | 'date';
+
+export const FONT_SIZES = [8, 9, 10, 11, 12, 14, 16, 18, 20, 24, 28, 36] as const;
+
+export const DEFAULT_FONT_SIZE = 13;
+
+/**
+ * Format a raw numeric value according to the specified number format.
+ * Returns the display string; raw value is never mutated.
+ */
+export function formatNumber(value: string | number | boolean | null, fmt: NumberFormatType): string {
+  if (value === null || value === '') return '';
+  const num = typeof value === 'number' ? value : parseFloat(String(value));
+  if (isNaN(num)) return String(value);
+
+  switch (fmt) {
+    case 'general':
+      return String(value);
+    case 'number':
+      return num.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    case 'currency':
+      return num.toLocaleString('en-US', { style: 'currency', currency: 'USD' });
+    case 'percentage':
+      return (num * 100).toLocaleString('en-US', { minimumFractionDigits: 1, maximumFractionDigits: 1 }) + '%';
+    case 'date': {
+      const d = new Date(num);
+      if (isNaN(d.getTime())) return String(value);
+      return d.toLocaleDateString('en-US');
+    }
+    default:
+      return String(value);
+  }
+}
+
+/** Returns true if format has any non-default property set. */
+export function hasFormat(fmt: CellFormat | undefined): boolean {
+  if (!fmt) return false;
+  return Object.values(fmt).some((v) => v !== undefined);
+}

--- a/modules/app/internal/spreadsheet-editor.ts
+++ b/modules/app/internal/spreadsheet-editor.ts
@@ -3,6 +3,10 @@ import { HocuspocusProvider } from '@hocuspocus/provider';
 import * as Y from 'yjs';
 import { getUserIdentity, getDocumentId } from './shared/identity.ts';
 import { setupTitleSync } from './shared/title-sync.ts';
+import { createFormatToolbar, updateToolbarState } from './sheets-format-toolbar.ts';
+import { getCellFormat, getFormatMap } from './sheets-format-store.ts';
+import { applyCellFormat, getDisplayValue } from './sheets-format-renderer.ts';
+import { attachFormatShortcuts } from './sheets-format-shortcuts.ts';
 
 const DEFAULT_COLS = 26;
 const DEFAULT_ROWS = 50;
@@ -23,6 +27,7 @@ function init() {
   const usersEl = document.getElementById('users');
   const cellRefEl = document.getElementById('cell-ref');
   const formulaInput = document.getElementById('formula-input') as HTMLInputElement | null;
+  const formatBarContainer = document.getElementById('format-bar-container');
   if (!gridEl) return;
 
   const documentId = getDocumentId();
@@ -49,10 +54,27 @@ function init() {
     },
   });
 
-  // Yjs shared data: Y.Array of Y.Arrays (rows of cells)
   const ysheet = ydoc.getArray<Y.Array<string>>('sheet-0');
 
-  // Initialize grid if empty
+  let activeRow = 0;
+  let activeCol = 0;
+
+  // --- Format Toolbar ---
+  let formatToolbar: HTMLElement | null = null;
+  if (formatBarContainer) {
+    formatToolbar = createFormatToolbar(formatBarContainer, ydoc, {
+      getActiveCell: () => ({ row: activeRow, col: activeCol }),
+      onFormatChanged: () => renderGrid(),
+    });
+  }
+
+  // --- Keyboard Shortcuts ---
+  attachFormatShortcuts(ydoc, {
+    getActiveCell: () => ({ row: activeRow, col: activeCol }),
+    onFormatChanged: () => renderGrid(),
+  });
+
+  // --- Grid ---
   function ensureGrid() {
     if (ysheet.length === 0) {
       ydoc.transact(() => {
@@ -67,20 +89,15 @@ function init() {
     }
   }
 
-  let activeRow = 0;
-  let activeCol = 0;
-
   function renderGrid() {
     ensureGrid();
     gridEl.innerHTML = '';
     gridEl.style.gridTemplateColumns = `3rem repeat(${DEFAULT_COLS}, minmax(5rem, 1fr))`;
 
-    // Corner cell
     const corner = document.createElement('div');
     corner.className = 'cell header';
     gridEl.appendChild(corner);
 
-    // Column headers
     for (let c = 0; c < DEFAULT_COLS; c++) {
       const hdr = document.createElement('div');
       hdr.className = 'cell header';
@@ -88,9 +105,7 @@ function init() {
       gridEl.appendChild(hdr);
     }
 
-    // Rows
     for (let r = 0; r < Math.min(ysheet.length, DEFAULT_ROWS); r++) {
-      // Row header
       const rh = document.createElement('div');
       rh.className = 'cell row-header';
       rh.textContent = String(r + 1);
@@ -98,44 +113,51 @@ function init() {
 
       const yrow = ysheet.get(r);
       for (let c = 0; c < DEFAULT_COLS; c++) {
+        const rawValue = (yrow && c < yrow.length) ? yrow.get(c) : '';
+        const fmt = getCellFormat(ydoc, r, c);
+
         const cell = document.createElement('div');
         cell.className = 'cell';
         cell.contentEditable = 'true';
-        cell.textContent = (yrow && c < yrow.length) ? yrow.get(c) : '';
+        cell.textContent = getDisplayValue(rawValue, fmt);
         cell.dataset.row = String(r);
         cell.dataset.col = String(c);
 
-        cell.addEventListener('focus', () => {
-          activeRow = r;
-          activeCol = c;
-          if (cellRefEl) cellRefEl.textContent = colLabel(c) + (r + 1);
-          if (formulaInput) formulaInput.value = cell.textContent || '';
-        });
-
-        cell.addEventListener('blur', () => {
-          const val = cell.textContent || '';
-          const yrow = ysheet.get(r);
-          if (yrow && yrow.get(c) !== val) {
-            ydoc.transact(() => {
-              yrow.delete(c, 1);
-              yrow.insert(c, [val]);
-            });
-          }
-        });
-
+        applyCellFormat(cell, fmt);
+        attachCellEvents(cell, r, c, rawValue);
         gridEl.appendChild(cell);
       }
     }
   }
 
+  function attachCellEvents(cell: HTMLElement, r: number, c: number, rawValue: string): void {
+    cell.addEventListener('focus', () => {
+      activeRow = r;
+      activeCol = c;
+      if (cellRefEl) cellRefEl.textContent = colLabel(c) + (r + 1);
+      if (formulaInput) formulaInput.value = rawValue;
+      if (formatToolbar) updateToolbarState(formatToolbar, getCellFormat(ydoc, r, c));
+    });
+
+    cell.addEventListener('blur', () => {
+      const val = cell.textContent || '';
+      const yrow = ysheet.get(r);
+      if (yrow && yrow.get(c) !== val) {
+        ydoc.transact(() => {
+          yrow.delete(c, 1);
+          yrow.insert(c, [val]);
+        });
+      }
+    });
+  }
+
   renderGrid();
 
-  // Re-render on remote changes
-  ysheet.observeDeep(() => {
-    renderGrid();
-  });
+  // Re-render on remote changes (cell values or formats)
+  ysheet.observeDeep(() => renderGrid());
+  getFormatMap(ydoc).observeDeep(() => renderGrid());
 
-  // Formula bar input syncs to active cell
+  // Formula bar
   if (formulaInput) {
     formulaInput.addEventListener('keydown', (e) => {
       if (e.key === 'Enter') {

--- a/modules/document/contract/spreadsheet.ts
+++ b/modules/document/contract/spreadsheet.ts
@@ -15,10 +15,28 @@ export const SpreadsheetSchemaVersionSchema = z.enum(['1.0.0']);
 
 // --- Cell / Sheet Types ---
 
+export const CellFormatSchema = z.object({
+  bold: z.boolean().optional(),
+  italic: z.boolean().optional(),
+  underline: z.boolean().optional(),
+  strikethrough: z.boolean().optional(),
+  fontSize: z.number().positive().optional(),
+  textColor: z.string().optional(),
+  backgroundColor: z.string().optional(),
+  alignment: z.enum(['left', 'center', 'right']).optional(),
+  numberFormat: z.enum(['general', 'number', 'currency', 'percentage', 'date']).optional(),
+  borderTop: z.boolean().optional(),
+  borderBottom: z.boolean().optional(),
+  borderLeft: z.boolean().optional(),
+  borderRight: z.boolean().optional(),
+});
+
+export type CellFormat = z.infer<typeof CellFormatSchema>;
+
 export const CellSchema = z.object({
   value: z.union([z.string(), z.number(), z.boolean(), z.null()]),
   formula: z.string().optional(),
-  format: z.record(z.unknown()).optional(),
+  format: CellFormatSchema.optional(),
 });
 
 export type Cell = z.infer<typeof CellSchema>;


### PR DESCRIPTION
## Summary
- **Formatting toolbar** with text style buttons (B/I/U/S), font size selector (8–36), text/fill color pickers, alignment buttons, number format selector (general/number/currency/percentage/date), border buttons
- **Yjs sync** — formats stored in separate `Y.Map` (`sheet-0-formats`) keyed by `row:col`, all mutations transacted for real-time collaboration
- **Cell rendering** — inline styles applied from format data, number formatting is display-only (raw values preserved for formula calculations)
- **Keyboard shortcuts** — Ctrl/Cmd+B, I, U
- **Zod schema** — `CellFormatSchema` added to `spreadsheet.ts` contract

## Test plan
- [ ] Apply bold/italic/underline via toolbar buttons and keyboard shortcuts
- [ ] Change font size, text color, background color on selected cells
- [ ] Set number format (currency, percentage) and verify display formatting
- [ ] Verify formatting syncs to a second collaborator via Yjs
- [ ] Confirm raw values preserved for formula calculations after number formatting
- [ ] Run full test suite (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)