### PR TITLE
feat: add slides element types — image, shape, table with insert toolbar

### DIFF
--- a/contracts/app/slides-element-types.md
+++ b/contracts/app/slides-element-types.md
@@ -1,0 +1,92 @@
+# Contract: app/slides-element-types
+
+## Purpose
+
+Provide element type renderers, factories, and insert UI for the slide editor. Supports text, image, shape, and table element types, all integrated with the existing interaction system (drag, resize, rotate, snap, multi-select, z-order).
+
+## Inputs
+
+- `SlideElement` objects parsed from Yjs shared state, including type-specific fields (src, shapeType, fill, stroke, strokeWidth, tableData)
+- User interactions: toolbar clicks to insert elements, file picker / drag-and-drop for images, cell editing for tables
+- `documentId` for image upload API calls
+
+## Outputs
+
+- DOM elements rendered into the slide viewport for each element type
+- New Yjs element maps inserted via the element factory + insert functions
+- Content/cell updates written back to Yjs on blur events
+- Insert toolbar DOM element attached to the presentation header
+
+## Side Effects
+
+- Calls the `/api/upload` endpoint for image uploads (reuses existing image-upload module)
+- Mutates Yjs shared element maps inside `ydoc.transact()` for element insertion and content updates
+- Renders DOM elements and toolbar UI into the slide viewport and header
+
+## Invariants
+
+1. **All element types support interaction.** Every rendered element uses the `.slide-element` class and `data-element-id` attribute, making it compatible with the existing interaction controller (drag, resize, rotate, snap, select).
+
+2. **Percentage-based positioning.** All element positions and sizes use the same percentage coordinate system (0-100) as the interaction system.
+
+3. **Yjs transactional updates.** All element insertions and content updates are wrapped in `ydoc.transact()` for undo/redo atomicity.
+
+4. **No mock data.** Images use real upload to S3-compatible storage. Table cells contain real user input.
+
+5. **Shape SVG is non-interactive.** SVG shapes render as visual backgrounds; the text overlay on top captures user input.
+
+6. **Table cell dimensions match metadata.** `TableData.cells` array dimensions always match `rows x cols`.
+
+## Dependencies
+
+- `./types.ts` (sibling) -- `SlideElement`, `ShapeType`, `TableData` types
+- `../image-upload.ts` (parent module) -- `uploadImage`, `validateImageFile`, `extractImageFiles`
+- `yjs` (runtime) -- Yjs shared types for element insertion and mutation
+- `./element-interaction.ts` (sibling) -- interaction controller consumes rendered elements
+
+## Boundary Rules
+
+### MUST
+
+- Render all element types with `.slide-element` class and `data-element-id` for interaction compatibility
+- Use percentage-based positioning matching the interaction system
+- Wrap all Yjs mutations in `ydoc.transact()`
+- Reuse existing `image-upload.ts` for image file handling
+- Keep every file under 200 lines
+- Use modern CSS (no Tailwind)
+- Store all element data in Yjs for real-time sync
+
+### MUST NOT
+
+- Import server-side modules (api, auth, storage, etc.)
+- Use mock data or placeholder URLs for images
+- Break the interaction system's coordinate model
+- Exceed 200 lines per file
+- Render elements without the required class/dataset attributes
+
+## File Structure
+
+```
+modules/app/internal/slides/
+  types.ts              -- Extended with ShapeType, TableData
+  element-renderer.ts   -- Dispatcher: routes element to type-specific renderer
+  render-text.ts        -- Text element renderer (contentEditable)
+  render-image.ts       -- Image element renderer (img tag)
+  render-shape.ts       -- Shape element renderer (SVG + text overlay)
+  render-table.ts       -- Table element renderer (HTML table with editable cells)
+  element-factory.ts    -- Factory functions for creating new elements
+  insert-toolbar.ts     -- Insert toolbar UI with shape submenu and table grid picker
+  slide-image-upload.ts -- Image upload bridge for slide editor
+  yjs-element-insert.ts -- Yjs insertion and table cell update functions
+  parse-elements.ts     -- Parse Yjs maps into typed SlideElement objects
+  element-types.css     -- Styles for all element types and insert toolbar
+```
+
+## Verification
+
+1. **Renderer dispatch** -- Each element type produces a DOM element with correct class and dataset attributes.
+2. **Image upload** -- File picker triggers upload, returned URL is stored in Yjs element.
+3. **Shape SVG** -- Each shape type produces valid SVG with correct fill/stroke attributes.
+4. **Table grid** -- Table renders correct number of rows and columns. Cell edits write to Yjs.
+5. **Insert toolbar** -- Each button inserts the correct element type into Yjs.
+6. **Interaction compatibility** -- Inserted elements can be dragged, resized, rotated, selected.

--- a/modules/app/internal/css/presentation.css
+++ b/modules/app/internal/css/presentation.css
@@ -2,3 +2,4 @@
 @import "../public/styles.css";
 @import "../public/presentation.css";
 @import "../slides/interaction.css";
+@import "../slides/element-types.css";

--- a/modules/app/internal/presentation-editor.ts
+++ b/modules/app/internal/presentation-editor.ts
@@ -5,10 +5,12 @@ import { getUserIdentity, getDocumentId } from './shared/identity.ts';
 import { setupTitleSync } from './shared/title-sync.ts';
 import { createInteractionController, type InteractionController } from './slides/element-interaction.ts';
 import type { SlideElement } from './slides/types.ts';
-
-function generateId(): string {
-  return crypto.randomUUID();
-}
+import { renderElement } from './slides/element-renderer.ts';
+import { createInsertToolbar, type InsertAction } from './slides/insert-toolbar.ts';
+import { insertElement, updateTableCell } from './slides/yjs-element-insert.ts';
+import { createTextElement, createImageElement, createShapeElement, createTableElement } from './slides/element-factory.ts';
+import { openSlideImagePicker, setupSlideDragDrop } from './slides/slide-image-upload.ts';
+import { parseSlideElements } from './slides/parse-elements.ts';
 
 function init() {
   const slideListEl = document.getElementById('slide-list')!;
@@ -16,6 +18,7 @@ function init() {
   const statusEl = document.getElementById('status');
   const usersEl = document.getElementById('users');
   const addSlideBtn = document.getElementById('add-slide-btn');
+  const toolbarRight = document.querySelector('.toolbar-right');
   if (!slideListEl || !viewportEl) return;
 
   const documentId = getDocumentId();
@@ -32,9 +35,7 @@ function init() {
     onDisconnect() { if (statusEl) { statusEl.textContent = 'Disconnected'; statusEl.className = 'status disconnected'; } },
   });
 
-  // Yjs shared data: Y.Array of Y.Maps (slides)
   const yslides = ydoc.getArray<Y.Map<unknown>>('slides');
-
   let activeSlideIndex = 0;
 
   function ensureSlides() {
@@ -45,8 +46,8 @@ function init() {
       const elements = new Y.Array<Y.Map<unknown>>();
       const titleEl = new Y.Map<unknown>();
       const defaults: Record<string, unknown> = {
-        id: generateId(), type: 'text', x: 10, y: 10, width: 80, height: 20,
-        content: 'Click to add title',
+        id: crypto.randomUUID(), type: 'text', x: 10, y: 10, width: 80, height: 20,
+        rotation: 0, content: 'Click to add title',
       };
       for (const [k, v] of Object.entries(defaults)) titleEl.set(k, v);
       elements.insert(0, [titleEl]);
@@ -55,26 +56,34 @@ function init() {
     });
   }
 
+  function getActiveYElements(): Y.Array<Y.Map<unknown>> {
+    const slide = yslides.get(activeSlideIndex);
+    return (slide?.get('elements') as Y.Array<Y.Map<unknown>>) || new Y.Array<Y.Map<unknown>>();
+  }
+
   function getSlideElements(slideIndex: number): SlideElement[] {
     const slide = yslides.get(slideIndex);
     if (!slide) return [];
     const elements = slide.get('elements') as Y.Array<Y.Map<unknown>> | undefined;
     if (!elements) return [];
-    const result: SlideElement[] = [];
-    for (let i = 0; i < elements.length; i++) {
-      const el = elements.get(i);
-      result.push({
-        id: el.get('id') as string,
-        type: (el.get('type') as 'text' | 'shape' | 'image') || 'text',
-        x: (el.get('x') as number) || 0,
-        y: (el.get('y') as number) || 0,
-        width: (el.get('width') as number) || 50,
-        height: (el.get('height') as number) || 20,
-        rotation: (el.get('rotation') as number) || 0,
-        content: (el.get('content') as string) || '',
-      });
-    }
-    return result;
+    return parseSlideElements(elements);
+  }
+
+  function handleContentUpdate(elementId: string, content: string) {
+    const yElements = getActiveYElements();
+    ydoc.transact(() => {
+      for (let i = 0; i < yElements.length; i++) {
+        const yel = yElements.get(i);
+        if (yel.get('id') === elementId) {
+          yel.set('content', content);
+          break;
+        }
+      }
+    });
+  }
+
+  function handleCellUpdate(elementId: string, row: number, col: number, value: string) {
+    updateTableCell(ydoc, getActiveYElements(), elementId, row, col, value);
   }
 
   function renderSlideList() {
@@ -100,59 +109,53 @@ function init() {
     viewportEl.innerHTML = '';
     const elements = getSlideElements(activeSlideIndex);
     for (const el of elements) {
-      const div = document.createElement('div');
-      div.className = 'slide-element';
-      div.dataset.type = el.type;
-      div.dataset.elementId = el.id;
-      div.style.left = el.x + '%';
-      div.style.top = el.y + '%';
-      div.style.width = el.width + '%';
-      div.style.height = el.height + '%';
-      if (el.rotation) {
-        div.style.transform = `rotate(${el.rotation}deg)`;
-      }
-      div.contentEditable = 'true';
-      div.textContent = el.content;
-
-      div.addEventListener('blur', () => {
-        const slide = yslides.get(activeSlideIndex);
-        if (!slide) return;
-        const elements = slide.get('elements') as Y.Array<Y.Map<unknown>> | undefined;
-        if (!elements) return;
-        for (let i = 0; i < elements.length; i++) {
-          const yel = elements.get(i);
-          if (yel.get('id') === el.id) {
-            yel.set('content', div.textContent || '');
-            break;
-          }
-        }
-      });
-
-      viewportEl.appendChild(div);
+      const domEl = renderElement(el, handleContentUpdate, handleCellUpdate);
+      viewportEl.appendChild(domEl);
     }
   }
 
   renderSlideList();
   renderActiveSlide();
 
-  // Initialize slide element interaction (drag, resize, rotate, select)
+  // Interaction controller
   let interactionCtrl: InteractionController | null = null;
-
   function initInteraction() {
     if (interactionCtrl) interactionCtrl.destroy();
     interactionCtrl = createInteractionController({
       ydoc,
       viewport: viewportEl,
       getActiveSlideElements() {
-        const slide = yslides.get(activeSlideIndex);
-        const yElements = (slide?.get('elements') as Y.Array<Y.Map<unknown>>) ||
-          new Y.Array<Y.Map<unknown>>();
-        return { yElements, elements: getSlideElements(activeSlideIndex) };
+        return { yElements: getActiveYElements(), elements: getSlideElements(activeSlideIndex) };
       },
     });
   }
-
   initInteraction();
+
+  // Insert toolbar
+  function handleInsertAction(action: InsertAction) {
+    const yElements = getActiveYElements();
+    if (action.type === 'text') {
+      insertElement(ydoc, yElements, createTextElement());
+    } else if (action.type === 'image') {
+      openSlideImagePicker(documentId, (url) => {
+        insertElement(ydoc, yElements, createImageElement(url));
+      });
+    } else if (action.type === 'shape') {
+      insertElement(ydoc, yElements, createShapeElement(action.shapeType));
+    } else if (action.type === 'table') {
+      insertElement(ydoc, yElements, createTableElement(action.rows, action.cols));
+    }
+  }
+
+  const insertToolbar = createInsertToolbar(handleInsertAction);
+  if (toolbarRight) {
+    toolbarRight.insertBefore(insertToolbar, toolbarRight.firstChild);
+  }
+
+  // Image drag-and-drop on viewport
+  setupSlideDragDrop(viewportEl, documentId, (url) => {
+    insertElement(ydoc, getActiveYElements(), createImageElement(url));
+  });
 
   // Add slide button
   if (addSlideBtn) {

--- a/modules/app/internal/slides/element-factory.test.ts
+++ b/modules/app/internal/slides/element-factory.test.ts
@@ -1,0 +1,82 @@
+/** Contract: contracts/app/slides-element-types.md */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createTextElement,
+  createImageElement,
+  createShapeElement,
+  createTableElement,
+} from './element-factory.ts';
+
+describe('createTextElement', () => {
+  it('returns a text element with a UUID id', () => {
+    const el = createTextElement();
+    expect(el.type).toBe('text');
+    expect(el.id).toMatch(/^[0-9a-f]{8}-/);
+    expect(el.content).toBe('Click to edit text');
+    expect(el.width).toBeGreaterThan(0);
+    expect(el.height).toBeGreaterThan(0);
+  });
+
+  it('produces unique IDs on each call', () => {
+    const a = createTextElement();
+    const b = createTextElement();
+    expect(a.id).not.toBe(b.id);
+  });
+});
+
+describe('createImageElement', () => {
+  it('stores the src URL', () => {
+    const el = createImageElement('https://example.com/photo.png');
+    expect(el.type).toBe('image');
+    expect(el.src).toBe('https://example.com/photo.png');
+  });
+});
+
+describe('createShapeElement', () => {
+  it('creates a rectangle shape', () => {
+    const el = createShapeElement('rectangle');
+    expect(el.type).toBe('shape');
+    expect(el.shapeType).toBe('rectangle');
+    expect(el.fill).toBeTruthy();
+    expect(el.stroke).toBeTruthy();
+    expect(el.strokeWidth).toBeGreaterThan(0);
+  });
+
+  it('creates a line with different default dimensions', () => {
+    const line = createShapeElement('line');
+    const rect = createShapeElement('rectangle');
+    expect(line.shapeType).toBe('line');
+    expect(line.fill).toBe('none');
+    expect(line.width).toBeGreaterThan(rect.width);
+    expect(line.height).toBeLessThan(rect.height);
+  });
+
+  it('supports all shape types', () => {
+    const types = ['rectangle', 'rounded-rect', 'ellipse', 'triangle', 'arrow', 'line'] as const;
+    for (const t of types) {
+      const el = createShapeElement(t);
+      expect(el.shapeType).toBe(t);
+    }
+  });
+});
+
+describe('createTableElement', () => {
+  it('creates a table with correct dimensions', () => {
+    const el = createTableElement(4, 5);
+    expect(el.type).toBe('table');
+    expect(el.tableData.rows).toBe(4);
+    expect(el.tableData.cols).toBe(5);
+    expect(el.tableData.cells).toHaveLength(4);
+    expect(el.tableData.cells[0]).toHaveLength(5);
+  });
+
+  it('initializes all cells as empty strings', () => {
+    const el = createTableElement(2, 3);
+    for (const row of el.tableData.cells) {
+      for (const cell of row) {
+        expect(cell).toBe('');
+      }
+    }
+  });
+});

--- a/modules/app/internal/slides/element-factory.ts
+++ b/modules/app/internal/slides/element-factory.ts
@@ -1,0 +1,108 @@
+/** Contract: contracts/app/slides-element-types.md */
+
+import type { ShapeType, TableData } from './types.ts';
+import { createDefaultTableData } from './render-table.ts';
+
+type NewElementBase = {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  rotation: number;
+};
+
+export type NewTextElement = NewElementBase & {
+  type: 'text';
+  content: string;
+};
+
+export type NewImageElement = NewElementBase & {
+  type: 'image';
+  content: string;
+  src: string;
+};
+
+export type NewShapeElement = NewElementBase & {
+  type: 'shape';
+  content: string;
+  shapeType: ShapeType;
+  fill: string;
+  stroke: string;
+  strokeWidth: number;
+};
+
+export type NewTableElement = NewElementBase & {
+  type: 'table';
+  content: string;
+  tableData: TableData;
+};
+
+export type NewElement = NewTextElement | NewImageElement | NewShapeElement | NewTableElement;
+
+function generateId(): string {
+  return crypto.randomUUID();
+}
+
+/** Create a new text element with default dimensions */
+export function createTextElement(): NewTextElement {
+  return {
+    id: generateId(),
+    type: 'text',
+    x: 20,
+    y: 30,
+    width: 60,
+    height: 15,
+    rotation: 0,
+    content: 'Click to edit text',
+  };
+}
+
+/** Create a new image element (src filled later after upload) */
+export function createImageElement(src: string): NewImageElement {
+  return {
+    id: generateId(),
+    type: 'image',
+    x: 25,
+    y: 15,
+    width: 50,
+    height: 50,
+    rotation: 0,
+    content: '',
+    src,
+  };
+}
+
+/** Create a new shape element */
+export function createShapeElement(shapeType: ShapeType): NewShapeElement {
+  const isLine = shapeType === 'line';
+  return {
+    id: generateId(),
+    type: 'shape',
+    x: 30,
+    y: 30,
+    width: isLine ? 40 : 30,
+    height: isLine ? 5 : 30,
+    rotation: 0,
+    content: '',
+    shapeType,
+    fill: isLine ? 'none' : '#4f87e0',
+    stroke: '#2563eb',
+    strokeWidth: 2,
+  };
+}
+
+/** Create a new table element */
+export function createTableElement(rows: number, cols: number): NewTableElement {
+  return {
+    id: generateId(),
+    type: 'table',
+    x: 15,
+    y: 20,
+    width: 70,
+    height: 50,
+    rotation: 0,
+    content: '',
+    tableData: createDefaultTableData(rows, cols),
+  };
+}

--- a/modules/app/internal/slides/element-renderer.ts
+++ b/modules/app/internal/slides/element-renderer.ts
@@ -1,0 +1,34 @@
+/** Contract: contracts/app/slides-element-types.md */
+
+import type { SlideElement } from './types.ts';
+import { renderTextElement } from './render-text.ts';
+import { renderImageElement } from './render-image.ts';
+import { renderShapeElement } from './render-shape.ts';
+import { renderTableElement } from './render-table.ts';
+
+export type ContentUpdateHandler = (elementId: string, content: string) => void;
+export type CellUpdateHandler = (elementId: string, row: number, col: number, value: string) => void;
+
+/** Render a slide element to a DOM node based on its type */
+export function renderElement(
+  el: SlideElement,
+  onContentUpdate: ContentUpdateHandler,
+  onCellUpdate: CellUpdateHandler,
+): HTMLElement {
+  switch (el.type) {
+    case 'text':
+      return renderTextElement(el, (content) => onContentUpdate(el.id, content));
+
+    case 'image':
+      return renderImageElement(el);
+
+    case 'shape':
+      return renderShapeElement(el, (content) => onContentUpdate(el.id, content));
+
+    case 'table':
+      return renderTableElement(el, (row, col, value) => onCellUpdate(el.id, row, col, value));
+
+    default:
+      return renderTextElement(el, (content) => onContentUpdate(el.id, content));
+  }
+}

--- a/modules/app/internal/slides/element-types.css
+++ b/modules/app/internal/slides/element-types.css
@@ -1,0 +1,190 @@
+/* Element type styles: image, shape, table, and insert toolbar */
+
+/* --- Image elements --- */
+.slide-element--image {
+  padding: 0;
+  overflow: hidden;
+}
+
+.slide-image-content {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+  pointer-events: none;
+}
+
+.slide-image-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg, #f3f4f6);
+  color: var(--text-muted, #9ca3af);
+  font-size: 0.75rem;
+  border: 1px dashed var(--border, #d1d5db);
+}
+
+/* --- Shape elements --- */
+.slide-element--shape {
+  padding: 0;
+  overflow: visible;
+}
+
+.slide-shape-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  position: absolute;
+  inset: 0;
+}
+
+.slide-shape-text {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 0.5rem;
+  z-index: 1;
+  outline: none;
+  font-size: 0.875rem;
+  color: var(--text, #1f2937);
+  overflow: hidden;
+}
+
+/* --- Table elements --- */
+.slide-element--table {
+  padding: 0;
+  overflow: hidden;
+}
+
+.slide-table {
+  width: 100%;
+  height: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.slide-table-cell {
+  border: 1px solid var(--border, #d1d5db);
+  padding: 0.25rem 0.375rem;
+  font-size: 0.6875rem;
+  vertical-align: top;
+  outline: none;
+  overflow: hidden;
+  word-break: break-word;
+}
+
+.slide-table-cell:focus {
+  background: rgba(37, 99, 235, 0.05);
+  box-shadow: inset 0 0 0 1px var(--accent, #2563eb);
+}
+
+/* --- Insert toolbar --- */
+.slide-insert-toolbar {
+  display: flex;
+  gap: 0.25rem;
+  align-items: center;
+  margin-right: 0.5rem;
+}
+
+.slide-insert-btn {
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface, #fff);
+  border: 1px solid var(--border, #d1d5db);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.875rem;
+  color: var(--text, #1f2937);
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.slide-insert-btn:hover {
+  background: var(--bg, #f3f4f6);
+  border-color: var(--accent, #2563eb);
+}
+
+/* Dropdown menus */
+.slide-insert-dropdown {
+  position: relative;
+}
+
+.slide-insert-menu {
+  display: none;
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  background: var(--surface, #fff);
+  border: 1px solid var(--border, #d1d5db);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  z-index: 200;
+  min-width: 8rem;
+  padding: 0.25rem;
+}
+
+.slide-insert-menu.visible {
+  display: block;
+}
+
+.slide-insert-menu-item {
+  display: block;
+  width: 100%;
+  padding: 0.375rem 0.5rem;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  color: var(--text, #1f2937);
+  border-radius: 3px;
+}
+
+.slide-insert-menu-item:hover {
+  background: var(--bg, #f3f4f6);
+}
+
+/* --- Table grid picker --- */
+.slide-table-grid {
+  padding: 0.5rem;
+}
+
+.slide-table-grid-label {
+  font-size: 0.75rem;
+  color: var(--text-muted, #9ca3af);
+  margin-bottom: 0.375rem;
+  text-align: center;
+}
+
+.slide-table-grid-cells {
+  display: grid;
+  grid-template-columns: repeat(6, 1.25rem);
+  grid-template-rows: repeat(6, 1.25rem);
+  gap: 2px;
+}
+
+.slide-table-grid-cell {
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 1px solid var(--border, #d1d5db);
+  border-radius: 2px;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.slide-table-grid-cell:hover,
+.slide-table-grid-cell.highlighted {
+  background: var(--accent, #2563eb);
+  opacity: 0.3;
+}
+
+.slide-table-grid-cell.highlighted {
+  opacity: 0.5;
+}

--- a/modules/app/internal/slides/insert-toolbar.ts
+++ b/modules/app/internal/slides/insert-toolbar.ts
@@ -1,0 +1,174 @@
+/** Contract: contracts/app/slides-element-types.md */
+
+import type { ShapeType } from './types.ts';
+
+export type InsertAction =
+  | { type: 'text' }
+  | { type: 'image' }
+  | { type: 'shape'; shapeType: ShapeType }
+  | { type: 'table'; rows: number; cols: number };
+
+export type InsertHandler = (action: InsertAction) => void;
+
+type ToolbarItem = {
+  label: string;
+  icon: string;
+  action: InsertAction | null;
+  submenu?: ToolbarItem[];
+};
+
+const TOOLBAR_ITEMS: ToolbarItem[] = [
+  { label: 'Text', icon: 'T', action: { type: 'text' } },
+  { label: 'Image', icon: '\u{1F5BC}', action: { type: 'image' } },
+  {
+    label: 'Shapes', icon: '\u25A0', action: null,
+    submenu: [
+      { label: 'Rectangle', icon: '\u25AC', action: { type: 'shape', shapeType: 'rectangle' } },
+      { label: 'Rounded', icon: '\u25A2', action: { type: 'shape', shapeType: 'rounded-rect' } },
+      { label: 'Circle', icon: '\u25CF', action: { type: 'shape', shapeType: 'ellipse' } },
+      { label: 'Triangle', icon: '\u25B2', action: { type: 'shape', shapeType: 'triangle' } },
+      { label: 'Arrow', icon: '\u27A1', action: { type: 'shape', shapeType: 'arrow' } },
+      { label: 'Line', icon: '\u2014', action: { type: 'shape', shapeType: 'line' } },
+    ],
+  },
+  { label: 'Table', icon: '\u229E', action: null },
+];
+
+/** Create the insert toolbar DOM element */
+export function createInsertToolbar(onInsert: InsertHandler): HTMLElement {
+  const toolbar = document.createElement('div');
+  toolbar.className = 'slide-insert-toolbar';
+
+  for (const item of TOOLBAR_ITEMS) {
+    if (item.label === 'Table') {
+      toolbar.appendChild(createTableButton(onInsert));
+    } else if (item.submenu) {
+      toolbar.appendChild(createDropdownButton(item, onInsert));
+    } else if (item.action) {
+      toolbar.appendChild(createButton(item, onInsert));
+    }
+  }
+
+  return toolbar;
+}
+
+function createButton(item: ToolbarItem, onInsert: InsertHandler): HTMLElement {
+  const btn = document.createElement('button');
+  btn.className = 'slide-insert-btn';
+  btn.title = item.label;
+  btn.textContent = item.icon;
+  btn.addEventListener('click', () => {
+    if (item.action) onInsert(item.action);
+  });
+  return btn;
+}
+
+function createDropdownButton(item: ToolbarItem, onInsert: InsertHandler): HTMLElement {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'slide-insert-dropdown';
+
+  const btn = document.createElement('button');
+  btn.className = 'slide-insert-btn';
+  btn.title = item.label;
+  btn.textContent = item.icon;
+  wrapper.appendChild(btn);
+
+  const menu = document.createElement('div');
+  menu.className = 'slide-insert-menu';
+
+  for (const sub of item.submenu || []) {
+    const subBtn = document.createElement('button');
+    subBtn.className = 'slide-insert-menu-item';
+    subBtn.textContent = `${sub.icon} ${sub.label}`;
+    subBtn.addEventListener('click', () => {
+      if (sub.action) onInsert(sub.action);
+      menu.classList.remove('visible');
+    });
+    menu.appendChild(subBtn);
+  }
+
+  btn.addEventListener('click', () => {
+    menu.classList.toggle('visible');
+  });
+
+  // Close menu when clicking outside
+  document.addEventListener('click', (e) => {
+    if (!wrapper.contains(e.target as Node)) {
+      menu.classList.remove('visible');
+    }
+  });
+
+  wrapper.appendChild(menu);
+  return wrapper;
+}
+
+function createTableButton(onInsert: InsertHandler): HTMLElement {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'slide-insert-dropdown';
+
+  const btn = document.createElement('button');
+  btn.className = 'slide-insert-btn';
+  btn.title = 'Table';
+  btn.textContent = '\u229E';
+  wrapper.appendChild(btn);
+
+  const menu = document.createElement('div');
+  menu.className = 'slide-insert-menu slide-table-grid-menu';
+
+  const grid = createTableGrid(onInsert, menu);
+  menu.appendChild(grid);
+
+  btn.addEventListener('click', () => {
+    menu.classList.toggle('visible');
+  });
+
+  document.addEventListener('click', (e) => {
+    if (!wrapper.contains(e.target as Node)) {
+      menu.classList.remove('visible');
+    }
+  });
+
+  wrapper.appendChild(menu);
+  return wrapper;
+}
+
+function createTableGrid(onInsert: InsertHandler, menu: HTMLElement): HTMLElement {
+  const container = document.createElement('div');
+  container.className = 'slide-table-grid';
+
+  const label = document.createElement('div');
+  label.className = 'slide-table-grid-label';
+  label.textContent = 'Select size';
+  container.appendChild(label);
+
+  const grid = document.createElement('div');
+  grid.className = 'slide-table-grid-cells';
+
+  for (let r = 0; r < 6; r++) {
+    for (let c = 0; c < 6; c++) {
+      const cell = document.createElement('div');
+      cell.className = 'slide-table-grid-cell';
+      cell.dataset.row = String(r);
+      cell.dataset.col = String(c);
+      cell.addEventListener('mouseenter', () => highlightGrid(grid, r, c, label));
+      cell.addEventListener('click', () => {
+        onInsert({ type: 'table', rows: r + 1, cols: c + 1 });
+        menu.classList.remove('visible');
+      });
+      grid.appendChild(cell);
+    }
+  }
+
+  container.appendChild(grid);
+  return container;
+}
+
+function highlightGrid(grid: HTMLElement, row: number, col: number, label: HTMLElement): void {
+  const cells = grid.querySelectorAll('.slide-table-grid-cell');
+  cells.forEach((cell) => {
+    const cr = Number((cell as HTMLElement).dataset.row);
+    const cc = Number((cell as HTMLElement).dataset.col);
+    cell.classList.toggle('highlighted', cr <= row && cc <= col);
+  });
+  label.textContent = `${row + 1} x ${col + 1}`;
+}

--- a/modules/app/internal/slides/parse-elements.test.ts
+++ b/modules/app/internal/slides/parse-elements.test.ts
@@ -1,0 +1,95 @@
+/** Contract: contracts/app/slides-element-types.md */
+
+import { describe, it, expect } from 'vitest';
+import * as Y from 'yjs';
+import { parseSlideElements } from './parse-elements.ts';
+
+function createYElement(props: Record<string, unknown>): Y.Map<unknown> {
+  const m = new Y.Map<unknown>();
+  for (const [k, v] of Object.entries(props)) {
+    m.set(k, v);
+  }
+  return m;
+}
+
+describe('parseSlideElements', () => {
+  it('parses text elements', () => {
+    const doc = new Y.Doc();
+    const arr = doc.getArray<Y.Map<unknown>>('test');
+    doc.transact(() => {
+      arr.push([createYElement({
+        id: 'aaa-bbb-ccc', type: 'text', x: 10, y: 20, width: 50, height: 30,
+        rotation: 0, content: 'Hello',
+      })]);
+    });
+    const elements = parseSlideElements(arr);
+    expect(elements).toHaveLength(1);
+    expect(elements[0].type).toBe('text');
+    expect(elements[0].content).toBe('Hello');
+  });
+
+  it('parses image elements with src', () => {
+    const doc = new Y.Doc();
+    const arr = doc.getArray<Y.Map<unknown>>('test');
+    doc.transact(() => {
+      arr.push([createYElement({
+        id: 'img-1', type: 'image', x: 0, y: 0, width: 40, height: 40,
+        rotation: 0, content: '', src: 'https://example.com/img.png',
+      })]);
+    });
+    const elements = parseSlideElements(arr);
+    expect(elements[0].type).toBe('image');
+    expect(elements[0].src).toBe('https://example.com/img.png');
+  });
+
+  it('parses shape elements with shape properties', () => {
+    const doc = new Y.Doc();
+    const arr = doc.getArray<Y.Map<unknown>>('test');
+    doc.transact(() => {
+      arr.push([createYElement({
+        id: 'shape-1', type: 'shape', x: 5, y: 5, width: 20, height: 20,
+        rotation: 45, content: '', shapeType: 'ellipse', fill: '#ff0000',
+        stroke: '#000', strokeWidth: 3,
+      })]);
+    });
+    const elements = parseSlideElements(arr);
+    expect(elements[0].type).toBe('shape');
+    expect(elements[0].shapeType).toBe('ellipse');
+    expect(elements[0].fill).toBe('#ff0000');
+    expect(elements[0].stroke).toBe('#000');
+    expect(elements[0].strokeWidth).toBe(3);
+    expect(elements[0].rotation).toBe(45);
+  });
+
+  it('parses table elements with table data', () => {
+    const doc = new Y.Doc();
+    const arr = doc.getArray<Y.Map<unknown>>('test');
+    const tableData = JSON.stringify({ rows: 2, cols: 2, cells: [['A', 'B'], ['C', 'D']] });
+    doc.transact(() => {
+      arr.push([createYElement({
+        id: 'tbl-1', type: 'table', x: 10, y: 10, width: 60, height: 40,
+        rotation: 0, content: '', tableData,
+      })]);
+    });
+    const elements = parseSlideElements(arr);
+    expect(elements[0].type).toBe('table');
+    expect(elements[0].tableData).toBeDefined();
+    expect(elements[0].tableData!.rows).toBe(2);
+    expect(elements[0].tableData!.cols).toBe(2);
+    expect(elements[0].tableData!.cells[0][0]).toBe('A');
+    expect(elements[0].tableData!.cells[1][1]).toBe('D');
+  });
+
+  it('handles missing optional fields with defaults', () => {
+    const doc = new Y.Doc();
+    const arr = doc.getArray<Y.Map<unknown>>('test');
+    doc.transact(() => {
+      arr.push([createYElement({ id: 'min-1', type: 'shape' })]);
+    });
+    const elements = parseSlideElements(arr);
+    expect(elements[0].shapeType).toBe('rectangle');
+    expect(elements[0].fill).toBe('#4f87e0');
+    expect(elements[0].stroke).toBe('#2563eb');
+    expect(elements[0].strokeWidth).toBe(2);
+  });
+});

--- a/modules/app/internal/slides/parse-elements.ts
+++ b/modules/app/internal/slides/parse-elements.ts
@@ -1,0 +1,43 @@
+/** Contract: contracts/app/slides-element-types.md */
+
+import * as Y from 'yjs';
+import type { SlideElement, ShapeType, TableData } from './types.ts';
+import { parseTableData } from './yjs-element-insert.ts';
+
+/** Parse Yjs element maps into typed SlideElement objects */
+export function parseSlideElements(yElements: Y.Array<Y.Map<unknown>>): SlideElement[] {
+  const result: SlideElement[] = [];
+  for (let i = 0; i < yElements.length; i++) {
+    const el = yElements.get(i);
+    const type = (el.get('type') as string) || 'text';
+    const base = {
+      id: el.get('id') as string,
+      type: type as SlideElement['type'],
+      x: (el.get('x') as number) || 0,
+      y: (el.get('y') as number) || 0,
+      width: (el.get('width') as number) || 50,
+      height: (el.get('height') as number) || 20,
+      rotation: (el.get('rotation') as number) || 0,
+      content: (el.get('content') as string) || '',
+    };
+
+    if (type === 'image') {
+      result.push({ ...base, src: (el.get('src') as string) || '' });
+    } else if (type === 'shape') {
+      result.push({
+        ...base,
+        shapeType: (el.get('shapeType') as ShapeType) || 'rectangle',
+        fill: (el.get('fill') as string) || '#4f87e0',
+        stroke: (el.get('stroke') as string) || '#2563eb',
+        strokeWidth: (el.get('strokeWidth') as number) ?? 2,
+      });
+    } else if (type === 'table') {
+      const rawTableData = el.get('tableData');
+      const tableData: TableData = parseTableData(rawTableData) || { rows: 3, cols: 3, cells: [['', '', ''], ['', '', ''], ['', '', '']] };
+      result.push({ ...base, tableData });
+    } else {
+      result.push(base);
+    }
+  }
+  return result;
+}

--- a/modules/app/internal/slides/render-image.ts
+++ b/modules/app/internal/slides/render-image.ts
@@ -1,0 +1,38 @@
+/** Contract: contracts/app/slides-element-types.md */
+
+import type { SlideElement } from './types.ts';
+
+/** Render an image element */
+export function renderImageElement(el: SlideElement): HTMLElement {
+  const div = document.createElement('div');
+  div.className = 'slide-element slide-element--image';
+  div.dataset.type = 'image';
+  div.dataset.elementId = el.id;
+  applyTransform(div, el);
+
+  if (el.src) {
+    const img = document.createElement('img');
+    img.src = el.src;
+    img.alt = el.content || 'Slide image';
+    img.draggable = false;
+    img.className = 'slide-image-content';
+    div.appendChild(img);
+  } else {
+    const placeholder = document.createElement('div');
+    placeholder.className = 'slide-image-placeholder';
+    placeholder.textContent = 'No image';
+    div.appendChild(placeholder);
+  }
+
+  return div;
+}
+
+function applyTransform(div: HTMLElement, el: SlideElement): void {
+  div.style.left = `${el.x}%`;
+  div.style.top = `${el.y}%`;
+  div.style.width = `${el.width}%`;
+  div.style.height = `${el.height}%`;
+  if (el.rotation) {
+    div.style.transform = `rotate(${el.rotation}deg)`;
+  }
+}

--- a/modules/app/internal/slides/render-shape.ts
+++ b/modules/app/internal/slides/render-shape.ts
@@ -1,0 +1,117 @@
+/** Contract: contracts/app/slides-element-types.md */
+
+import type { ShapeType, SlideElement } from './types.ts';
+
+/** Render a shape element using inline SVG */
+export function renderShapeElement(
+  el: SlideElement,
+  onTextBlur: (content: string) => void,
+): HTMLElement {
+  const div = document.createElement('div');
+  div.className = 'slide-element slide-element--shape';
+  div.dataset.type = 'shape';
+  div.dataset.elementId = el.id;
+  applyTransform(div, el);
+
+  const svg = createShapeSvg(
+    el.shapeType || 'rectangle',
+    el.fill || '#4f87e0',
+    el.stroke || '#2563eb',
+    el.strokeWidth ?? 2,
+  );
+  div.appendChild(svg);
+
+  // Text overlay on shape
+  const textOverlay = document.createElement('div');
+  textOverlay.className = 'slide-shape-text';
+  textOverlay.contentEditable = 'true';
+  textOverlay.textContent = el.content || '';
+  textOverlay.addEventListener('blur', () => {
+    onTextBlur(textOverlay.textContent || '');
+  });
+  div.appendChild(textOverlay);
+
+  return div;
+}
+
+function createShapeSvg(
+  shapeType: ShapeType,
+  fill: string,
+  stroke: string,
+  strokeWidth: number,
+): SVGSVGElement {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('viewBox', '0 0 100 100');
+  svg.setAttribute('preserveAspectRatio', 'none');
+  svg.className.baseVal = 'slide-shape-svg';
+
+  const shape = createShapePath(shapeType, svg);
+  shape.setAttribute('fill', fill);
+  shape.setAttribute('stroke', stroke);
+  shape.setAttribute('stroke-width', String(strokeWidth));
+  svg.appendChild(shape);
+
+  return svg;
+}
+
+function createShapePath(shapeType: ShapeType, svg: SVGSVGElement): SVGElement {
+  const ns = 'http://www.w3.org/2000/svg';
+
+  switch (shapeType) {
+    case 'rectangle': {
+      const rect = document.createElementNS(ns, 'rect');
+      rect.setAttribute('x', '2');
+      rect.setAttribute('y', '2');
+      rect.setAttribute('width', '96');
+      rect.setAttribute('height', '96');
+      return rect;
+    }
+    case 'rounded-rect': {
+      const rect = document.createElementNS(ns, 'rect');
+      rect.setAttribute('x', '2');
+      rect.setAttribute('y', '2');
+      rect.setAttribute('width', '96');
+      rect.setAttribute('height', '96');
+      rect.setAttribute('rx', '12');
+      rect.setAttribute('ry', '12');
+      return rect;
+    }
+    case 'ellipse': {
+      const ellipse = document.createElementNS(ns, 'ellipse');
+      ellipse.setAttribute('cx', '50');
+      ellipse.setAttribute('cy', '50');
+      ellipse.setAttribute('rx', '48');
+      ellipse.setAttribute('ry', '48');
+      return ellipse;
+    }
+    case 'triangle': {
+      const polygon = document.createElementNS(ns, 'polygon');
+      polygon.setAttribute('points', '50,2 98,98 2,98');
+      return polygon;
+    }
+    case 'arrow': {
+      const polygon = document.createElementNS(ns, 'polygon');
+      polygon.setAttribute('points', '0,35 65,35 65,10 100,50 65,90 65,65 0,65');
+      return polygon;
+    }
+    case 'line': {
+      const line = document.createElementNS(ns, 'line');
+      line.setAttribute('x1', '2');
+      line.setAttribute('y1', '50');
+      line.setAttribute('x2', '98');
+      line.setAttribute('y2', '50');
+      line.setAttribute('fill', 'none');
+      return line;
+    }
+  }
+}
+
+function applyTransform(div: HTMLElement, el: SlideElement): void {
+  div.style.left = `${el.x}%`;
+  div.style.top = `${el.y}%`;
+  div.style.width = `${el.width}%`;
+  div.style.height = `${el.height}%`;
+  if (el.rotation) {
+    div.style.transform = `rotate(${el.rotation}deg)`;
+  }
+}

--- a/modules/app/internal/slides/render-table.ts
+++ b/modules/app/internal/slides/render-table.ts
@@ -1,0 +1,64 @@
+/** Contract: contracts/app/slides-element-types.md */
+
+import type { SlideElement, TableData } from './types.ts';
+
+/** Render a table element as an HTML table within the slide */
+export function renderTableElement(
+  el: SlideElement,
+  onCellBlur: (row: number, col: number, value: string) => void,
+): HTMLElement {
+  const div = document.createElement('div');
+  div.className = 'slide-element slide-element--table';
+  div.dataset.type = 'table';
+  div.dataset.elementId = el.id;
+  applyTransform(div, el);
+
+  const tableData = el.tableData || createDefaultTableData(3, 3);
+  const table = document.createElement('table');
+  table.className = 'slide-table';
+
+  for (let r = 0; r < tableData.rows; r++) {
+    const tr = document.createElement('tr');
+    for (let c = 0; c < tableData.cols; c++) {
+      const td = document.createElement('td');
+      td.className = 'slide-table-cell';
+      td.contentEditable = 'true';
+      td.textContent = tableData.cells[r]?.[c] ?? '';
+
+      const row = r;
+      const col = c;
+      td.addEventListener('blur', () => {
+        onCellBlur(row, col, td.textContent || '');
+      });
+
+      tr.appendChild(td);
+    }
+    table.appendChild(tr);
+  }
+
+  div.appendChild(table);
+  return div;
+}
+
+/** Create a default empty table grid */
+export function createDefaultTableData(rows: number, cols: number): TableData {
+  const cells: string[][] = [];
+  for (let r = 0; r < rows; r++) {
+    const row: string[] = [];
+    for (let c = 0; c < cols; c++) {
+      row.push('');
+    }
+    cells.push(row);
+  }
+  return { rows, cols, cells };
+}
+
+function applyTransform(div: HTMLElement, el: SlideElement): void {
+  div.style.left = `${el.x}%`;
+  div.style.top = `${el.y}%`;
+  div.style.width = `${el.width}%`;
+  div.style.height = `${el.height}%`;
+  if (el.rotation) {
+    div.style.transform = `rotate(${el.rotation}deg)`;
+  }
+}

--- a/modules/app/internal/slides/render-text.ts
+++ b/modules/app/internal/slides/render-text.ts
@@ -1,0 +1,30 @@
+/** Contract: contracts/app/slides-element-types.md */
+
+import type { SlideElement } from './types.ts';
+
+/** Render a text element as a contentEditable div */
+export function renderTextElement(el: SlideElement, onBlur: (content: string) => void): HTMLElement {
+  const div = document.createElement('div');
+  div.className = 'slide-element';
+  div.dataset.type = 'text';
+  div.dataset.elementId = el.id;
+  applyTransform(div, el);
+  div.contentEditable = 'true';
+  div.textContent = el.content;
+
+  div.addEventListener('blur', () => {
+    onBlur(div.textContent || '');
+  });
+
+  return div;
+}
+
+function applyTransform(div: HTMLElement, el: SlideElement): void {
+  div.style.left = `${el.x}%`;
+  div.style.top = `${el.y}%`;
+  div.style.width = `${el.width}%`;
+  div.style.height = `${el.height}%`;
+  if (el.rotation) {
+    div.style.transform = `rotate(${el.rotation}deg)`;
+  }
+}

--- a/modules/app/internal/slides/slide-image-upload.ts
+++ b/modules/app/internal/slides/slide-image-upload.ts
@@ -1,0 +1,57 @@
+/** Contract: contracts/app/slides-element-types.md */
+
+import { uploadImage, validateImageFile, extractImageFiles } from '../editor/image-upload.ts';
+
+export type ImageInsertCallback = (url: string) => void;
+
+/** Open file picker for image selection in the slide editor */
+export function openSlideImagePicker(documentId: string, onInsert: ImageInsertCallback): void {
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = 'image/png,image/jpeg,image/gif,image/webp';
+  input.addEventListener('change', () => {
+    const file = input.files?.[0];
+    if (file) handleSlideImageUpload(file, documentId, onInsert);
+  });
+  input.click();
+}
+
+/** Handle image upload for slide elements */
+async function handleSlideImageUpload(
+  file: File,
+  documentId: string,
+  onInsert: ImageInsertCallback,
+): Promise<void> {
+  const error = validateImageFile(file);
+  if (error) {
+    alert(error);
+    return;
+  }
+  try {
+    const result = await uploadImage(file, documentId);
+    onInsert(result.url);
+  } catch {
+    alert('Image upload failed');
+  }
+}
+
+/** Setup drag-and-drop image handling on the slide viewport */
+export function setupSlideDragDrop(
+  viewport: HTMLElement,
+  documentId: string,
+  onInsert: ImageInsertCallback,
+): void {
+  viewport.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+  });
+
+  viewport.addEventListener('drop', (e) => {
+    const files = e.dataTransfer ? extractImageFiles(e.dataTransfer) : [];
+    if (files.length === 0) return;
+    e.preventDefault();
+    for (const file of files) {
+      handleSlideImageUpload(file, documentId, onInsert);
+    }
+  });
+}

--- a/modules/app/internal/slides/types.ts
+++ b/modules/app/internal/slides/types.ts
@@ -1,14 +1,31 @@
 /** Contract: contracts/app/slides-interaction.md */
 
+export type ShapeType = 'rectangle' | 'rounded-rect' | 'ellipse' | 'triangle' | 'arrow' | 'line';
+
+export type TableData = {
+  rows: number;
+  cols: number;
+  cells: string[][];
+};
+
 export type SlideElement = {
   id: string;
-  type: 'text' | 'shape' | 'image';
+  type: 'text' | 'shape' | 'image' | 'table';
   x: number;
   y: number;
   width: number;
   height: number;
   rotation: number;
   content: string;
+  // Image elements
+  src?: string;
+  // Shape elements
+  shapeType?: ShapeType;
+  fill?: string;
+  stroke?: string;
+  strokeWidth?: number;
+  // Table elements
+  tableData?: TableData;
 };
 
 export type Transform = {

--- a/modules/app/internal/slides/yjs-element-insert.test.ts
+++ b/modules/app/internal/slides/yjs-element-insert.test.ts
@@ -1,0 +1,112 @@
+/** Contract: contracts/app/slides-element-types.md */
+
+import { describe, it, expect } from 'vitest';
+import * as Y from 'yjs';
+import { insertElement, updateTableCell, parseTableData } from './yjs-element-insert.ts';
+import { createTextElement, createImageElement, createShapeElement, createTableElement } from './element-factory.ts';
+
+function setupYElements(): { ydoc: Y.Doc; yElements: Y.Array<Y.Map<unknown>> } {
+  const ydoc = new Y.Doc();
+  const yElements = ydoc.getArray<Y.Map<unknown>>('elements');
+  return { ydoc, yElements };
+}
+
+describe('insertElement', () => {
+  it('inserts a text element into Yjs', () => {
+    const { ydoc, yElements } = setupYElements();
+    insertElement(ydoc, yElements, createTextElement());
+    expect(yElements.length).toBe(1);
+    expect(yElements.get(0).get('type')).toBe('text');
+  });
+
+  it('inserts an image element with src', () => {
+    const { ydoc, yElements } = setupYElements();
+    insertElement(ydoc, yElements, createImageElement('https://example.com/pic.jpg'));
+    const yel = yElements.get(0);
+    expect(yel.get('type')).toBe('image');
+    expect(yel.get('src')).toBe('https://example.com/pic.jpg');
+  });
+
+  it('inserts a shape element with shape properties', () => {
+    const { ydoc, yElements } = setupYElements();
+    insertElement(ydoc, yElements, createShapeElement('triangle'));
+    const yel = yElements.get(0);
+    expect(yel.get('type')).toBe('shape');
+    expect(yel.get('shapeType')).toBe('triangle');
+    expect(yel.get('fill')).toBeTruthy();
+    expect(yel.get('stroke')).toBeTruthy();
+  });
+
+  it('inserts a table element with serialized table data', () => {
+    const { ydoc, yElements } = setupYElements();
+    insertElement(ydoc, yElements, createTableElement(3, 4));
+    const yel = yElements.get(0);
+    expect(yel.get('type')).toBe('table');
+    const rawData = yel.get('tableData') as string;
+    const parsed = parseTableData(rawData);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.rows).toBe(3);
+    expect(parsed!.cols).toBe(4);
+  });
+
+  it('appends elements in order', () => {
+    const { ydoc, yElements } = setupYElements();
+    insertElement(ydoc, yElements, createTextElement());
+    insertElement(ydoc, yElements, createShapeElement('ellipse'));
+    expect(yElements.length).toBe(2);
+    expect(yElements.get(0).get('type')).toBe('text');
+    expect(yElements.get(1).get('type')).toBe('shape');
+  });
+});
+
+describe('updateTableCell', () => {
+  it('updates a specific cell value', () => {
+    const { ydoc, yElements } = setupYElements();
+    insertElement(ydoc, yElements, createTableElement(2, 2));
+    const id = yElements.get(0).get('id') as string;
+
+    updateTableCell(ydoc, yElements, id, 0, 1, 'Hello');
+    const raw = yElements.get(0).get('tableData') as string;
+    const parsed = parseTableData(raw);
+    expect(parsed!.cells[0][1]).toBe('Hello');
+  });
+
+  it('preserves other cell values when updating one', () => {
+    const { ydoc, yElements } = setupYElements();
+    insertElement(ydoc, yElements, createTableElement(2, 2));
+    const id = yElements.get(0).get('id') as string;
+
+    updateTableCell(ydoc, yElements, id, 0, 0, 'A');
+    updateTableCell(ydoc, yElements, id, 1, 1, 'D');
+    const raw = yElements.get(0).get('tableData') as string;
+    const parsed = parseTableData(raw);
+    expect(parsed!.cells[0][0]).toBe('A');
+    expect(parsed!.cells[1][1]).toBe('D');
+    expect(parsed!.cells[0][1]).toBe('');
+  });
+});
+
+describe('parseTableData', () => {
+  it('parses valid JSON table data', () => {
+    const raw = JSON.stringify({ rows: 2, cols: 3, cells: [['a', 'b', 'c'], ['d', 'e', 'f']] });
+    const result = parseTableData(raw);
+    expect(result).not.toBeNull();
+    expect(result!.rows).toBe(2);
+    expect(result!.cols).toBe(3);
+  });
+
+  it('returns null for invalid JSON', () => {
+    expect(parseTableData('not json')).toBeNull();
+  });
+
+  it('returns null for non-string input', () => {
+    expect(parseTableData(42)).toBeNull();
+    expect(parseTableData(null)).toBeNull();
+  });
+
+  it('returns null for missing required fields', () => {
+    expect(parseTableData(JSON.stringify({ rows: 2 }))).toBeNull();
+    expect(parseTableData(JSON.stringify({ cols: 2 }))).toBeNull();
+    expect(parseTableData(JSON.stringify({ rows: 2, cols: 2 }))).toBeNull();
+  });
+});

--- a/modules/app/internal/slides/yjs-element-insert.ts
+++ b/modules/app/internal/slides/yjs-element-insert.ts
@@ -1,0 +1,82 @@
+/** Contract: contracts/app/slides-element-types.md */
+
+import * as Y from 'yjs';
+import type { NewElement } from './element-factory.ts';
+import type { TableData } from './types.ts';
+
+/** Insert a new element into the Yjs slide elements array */
+export function insertElement(
+  ydoc: Y.Doc,
+  yElements: Y.Array<Y.Map<unknown>>,
+  element: NewElement,
+): void {
+  ydoc.transact(() => {
+    const yel = new Y.Map<unknown>();
+    yel.set('id', element.id);
+    yel.set('type', element.type);
+    yel.set('x', element.x);
+    yel.set('y', element.y);
+    yel.set('width', element.width);
+    yel.set('height', element.height);
+    yel.set('rotation', element.rotation);
+    yel.set('content', element.content);
+
+    if (element.type === 'image') {
+      yel.set('src', element.src);
+    } else if (element.type === 'shape') {
+      yel.set('shapeType', element.shapeType);
+      yel.set('fill', element.fill);
+      yel.set('stroke', element.stroke);
+      yel.set('strokeWidth', element.strokeWidth);
+    } else if (element.type === 'table') {
+      yel.set('tableData', serializeTableData(element.tableData));
+    }
+
+    yElements.push([yel]);
+  });
+}
+
+/** Update a single table cell in Yjs */
+export function updateTableCell(
+  ydoc: Y.Doc,
+  yElements: Y.Array<Y.Map<unknown>>,
+  elementId: string,
+  row: number,
+  col: number,
+  value: string,
+): void {
+  ydoc.transact(() => {
+    for (let i = 0; i < yElements.length; i++) {
+      const yel = yElements.get(i);
+      if (yel.get('id') !== elementId) continue;
+
+      const rawData = yel.get('tableData') as string | undefined;
+      if (!rawData) break;
+
+      const tableData = parseTableData(rawData);
+      if (!tableData) break;
+
+      if (tableData.cells[row]) {
+        tableData.cells[row][col] = value;
+        yel.set('tableData', serializeTableData(tableData));
+      }
+      break;
+    }
+  });
+}
+
+function serializeTableData(data: TableData): string {
+  return JSON.stringify(data);
+}
+
+export function parseTableData(raw: unknown): TableData | null {
+  if (typeof raw !== 'string') return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed.rows !== 'number' || typeof parsed.cols !== 'number') return null;
+    if (!Array.isArray(parsed.cells)) return null;
+    return parsed as TableData;
+  } catch {
+    return null;
+  }
+}

--- a/modules/document/contract/presentation.ts
+++ b/modules/document/contract/presentation.ts
@@ -21,15 +21,35 @@ const elementIdSchema = z.string().regex(uuidv4Regex, 'Must be a valid UUIDv4');
 export const SlideLayoutSchema = z.enum(['blank', 'title', 'content', 'two-column']);
 export type SlideLayout = z.infer<typeof SlideLayoutSchema>;
 
+export const TableDataSchema = z.object({
+  rows: z.number().int().positive(),
+  cols: z.number().int().positive(),
+  cells: z.array(z.array(z.string())),
+}).refine(
+  (d) => d.cells.length === d.rows && d.cells.every((r) => r.length === d.cols),
+  { message: 'cells dimensions must match rows x cols' },
+);
+
+export type TableData = z.infer<typeof TableDataSchema>;
+
 export const SlideElementSchema = z.object({
   id: elementIdSchema,
-  type: z.enum(['text', 'image', 'shape']),
+  type: z.enum(['text', 'image', 'shape', 'table']),
   x: z.number(),
   y: z.number(),
   width: z.number().positive(),
   height: z.number().positive(),
   content: z.string(),
   attrs: z.record(z.unknown()).optional(),
+  // Image fields
+  src: z.string().optional(),
+  // Shape fields
+  shapeType: z.enum(['rectangle', 'rounded-rect', 'ellipse', 'triangle', 'arrow', 'line']).optional(),
+  fill: z.string().optional(),
+  stroke: z.string().optional(),
+  strokeWidth: z.number().optional(),
+  // Table fields
+  tableData: TableDataSchema.optional(),
 });
 
 export type SlideElement = z.infer<typeof SlideElementSchema>;


### PR DESCRIPTION
## Summary
- **Image elements** — file picker + drag-and-drop upload via existing S3 infra, aspect ratio preservation within element bounds
- **Shape elements** — 6 SVG shapes (rectangle, rounded rect, ellipse, triangle, arrow, line) with configurable fill/stroke, text overlay via contentEditable
- **Table elements** — editable grid with visual dimension picker, cell editing, data serialized as JSON in Yjs
- **Insert toolbar** — buttons for Text, Image, Shapes dropdown, Table grid picker
- **Element renderer** dispatcher routing to type-specific renderers, factory functions with defaults
- All element types fully compatible with existing interaction system (drag/resize/rotate/snap/multi-select/z-order)
- 24 new tests, all 782 tests pass

## Test plan
- [ ] Insert each element type via toolbar (text, image, shapes, table)
- [ ] Drag-and-drop image onto slide viewport
- [ ] Verify all element types support drag, resize, rotate, snap, z-order
- [ ] Edit text overlay on shapes
- [ ] Edit table cells, resize table element
- [ ] Verify all elements sync via Yjs to collaborator
- [ ] Run full test suite (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)