### PR TITLE
fix(editor): focus editor on click in empty page space — issue #437

### DIFF
--- a/modules/app/internal/editor/editor.ts
+++ b/modules/app/internal/editor/editor.ts
@@ -124,6 +124,18 @@ async function init() {
   editor.registerPlugin(createSuggestModePlugin(editor));
   setupSuggestionClickHandler(editor);
 
+  // Focus editor at end when clicking empty page space below content (issue #437)
+  const editorWrapper = document.querySelector<HTMLElement>('.editor-wrapper');
+  if (editorWrapper) {
+    editorWrapper.addEventListener('click', (e) => {
+      const target = e.target as Node;
+      const canvasTitleWrap = document.querySelector('.editor-canvas-title-wrap');
+      if (!editorEl.contains(target) && !(canvasTitleWrap?.contains(target))) {
+        editor.commands.focus('end');
+      }
+    });
+  }
+
   // Allow native context menu — prevent any TipTap extension or parent listener
   // from suppressing right-click (issue #255)
   editorEl.addEventListener('contextmenu', (e) => {


### PR DESCRIPTION
## Summary

- Clicking on whitespace below the last line of content in the editor now correctly focuses the cursor at the end of the document
- A click handler on `.editor-wrapper` calls `editor.commands.focus('end')` when the click target falls outside the ProseMirror content area and outside the canvas title input
- Clicks inside the editor content (`editorEl.contains(target)`) pass through normally — no behavior change for existing interactions

## Root cause

The TipTap/ProseMirror `div#editor` is sized to match its content, so clicks on the surrounding `.editor-wrapper` "paper" area were not captured by ProseMirror and did nothing.

## Test plan

- [ ] Open a document with a few lines of text
- [ ] Click in the empty white space below the last line — cursor should appear at end of document
- [ ] Type after clicking — text should be inserted
- [ ] Click directly inside existing text — normal cursor placement still works
- [ ] Click on the canvas title input — should NOT redirect focus to the editor

Fixes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)