### PR TITLE
fix(editor): resolve doc title stuck on "Loading..." — issue #436

### DIFF
--- a/modules/app/internal/shared/app-toolbar.ts
+++ b/modules/app/internal/shared/app-toolbar.ts
@@ -67,7 +67,8 @@ function buildLeft(): HTMLElement {
   titleInput.id = 'doc-title';
   titleInput.className = 'doc-title-input';
   titleInput.type = 'text';
-  titleInput.value = 'Loading...';
+  titleInput.value = '';
+  titleInput.placeholder = 'Loading...';
   titleInput.spellcheck = false;
 
   left.append(logoLink, backBtn, breadcrumb, titleInput);


### PR DESCRIPTION
## Summary

- Changes `titleInput.value = 'Loading...'` to `titleInput.value = ''` + `titleInput.placeholder = 'Loading...'` in `app-toolbar.ts`
- This ensures `setupCanvasTitleSync()` in `editor-page.ts` copies an empty string (not the literal text) to the `canvas-doc-title` input on startup
- When `title-sync.ts` fetch resolves, it sets the real title on both inputs — the toolbar input shows the placeholder during the brief loading window

## Root cause

`setupCanvasTitleSync()` runs synchronously right after `setupTitleSync()`. At that point the async fetch hasn't resolved, so it copies `'Loading...'` into `canvas-doc-title`. Even though `title-sync.ts` already updates `canvas-doc-title` in its fetch callback (added for #337), the toolbar `#doc-title` input showed `'Loading...'` permanently because `setupCanvasTitleSync` mirrors the initial string into canvas-doc-title and the fetch callback was updating it correctly but the toolbar title was never clearing.

## Test plan

- [ ] Open a document — title input shows placeholder `Loading...` briefly (not as a filled value)
- [ ] Title updates to real document title once the API responds
- [ ] Title editing still works (blur saves, input debounces at 800ms)
- [ ] Canvas title stays in sync when editing from toolbar and vice versa

Fixes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)