### PR TITLE
feat(editor): visual hover grid picker for table insertion — issue #452

### DIFF
--- a/modules/app/internal/editor/formatting-toolbar-actions.ts
+++ b/modules/app/internal/editor/formatting-toolbar-actions.ts
@@ -4,6 +4,7 @@ import { t, type TranslationKey } from '../i18n/index.ts';
 import { openImagePicker } from './image-handlers.ts';
 import { openDrawingDialog } from './drawing/index.ts';
 import { isSuggesting, setSuggesting } from './suggestions/suggest-mode.ts';
+import { showTableGridPicker } from './table-grid-picker.ts';
 import { printDocument, exportPdf } from '../shared/print-utils.ts';
 
 export interface ToolbarButton {
@@ -60,13 +61,9 @@ export function buildToolbarButtons(editor: Editor): ToolbarButton[] {
     { key: null, action: () => false },
     // ── Insert ────────────────────────────────────────────────────────
     { key: 'toolbar.link', icon: 'link', ariaKey: 'a11y.linkLabel', titleKey: 'shortcuts.link', action: (btn?: HTMLButtonElement) => { document.dispatchEvent(new CustomEvent('opendesk:open-link-popover', { detail: { anchor: btn } })); return true; }, passSelf: true, isActive: () => editor.isActive('link') },
-    { key: 'table.insert', icon: 'table', ariaKey: 'a11y.tableLabel', action: () => {
-      const { state } = editor;
-      const { $from } = state.selection;
-      const isEmptyParagraph = $from.parent.type.name === 'paragraph' && $from.parent.textContent === '';
-      const chain = editor.chain().focus();
-      if (!isEmptyParagraph) chain.createParagraphNear();
-      return chain.insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run();
+    { key: 'table.insert', icon: 'table', ariaKey: 'a11y.tableLabel', passSelf: true, action: (btn?: HTMLButtonElement) => {
+      if (btn) showTableGridPicker(editor, btn);
+      return true;
     } },
     { key: 'toolbar.image', icon: 'image', ariaKey: 'a11y.imageLabel', action: () => { openImagePicker(editor); return true; } },
     { key: 'toolbar.drawing', icon: 'drawing', ariaKey: 'a11y.drawingLabel', action: () => {

--- a/modules/app/internal/editor/table-grid-picker.ts
+++ b/modules/app/internal/editor/table-grid-picker.ts
@@ -1,0 +1,69 @@
+/** Contract: contracts/app/rules.md */
+import type { Editor } from '@tiptap/core';
+
+const COLS = 8;
+const ROWS = 8;
+
+export function showTableGridPicker(editor: Editor, anchor: HTMLElement): void {
+  document.querySelector('.table-grid-picker')?.remove();
+
+  const picker = document.createElement('div');
+  picker.className = 'table-grid-picker';
+
+  const label = document.createElement('div');
+  label.className = 'table-grid-label';
+  label.textContent = 'Insert table';
+  picker.appendChild(label);
+
+  const grid = document.createElement('div');
+  grid.className = 'table-grid';
+  grid.style.gridTemplateColumns = `repeat(${COLS}, 1fr)`;
+
+  let hoverCol = 0;
+  let hoverRow = 0;
+
+  function updateHighlight(): void {
+    grid.querySelectorAll<HTMLElement>('.table-grid-cell').forEach(cell => {
+      const c = Number(cell.dataset.col);
+      const r = Number(cell.dataset.row);
+      cell.classList.toggle('highlighted', c <= hoverCol && r <= hoverRow);
+    });
+    label.textContent = hoverCol > 0 ? `${hoverCol}×${hoverRow} table` : 'Insert table';
+  }
+
+  for (let r = 1; r <= ROWS; r++) {
+    for (let c = 1; c <= COLS; c++) {
+      const cell = document.createElement('button');
+      cell.className = 'table-grid-cell';
+      cell.dataset.col = String(c);
+      cell.dataset.row = String(r);
+      cell.setAttribute('aria-label', `${c}×${r} table`);
+      cell.addEventListener('mouseenter', () => { hoverCol = c; hoverRow = r; updateHighlight(); });
+      cell.addEventListener('click', () => {
+        editor.chain().focus().insertTable({ rows: r, cols: c, withHeaderRow: true }).run();
+        picker.remove();
+      });
+      grid.appendChild(cell);
+    }
+  }
+
+  picker.appendChild(grid);
+
+  document.body.appendChild(picker);
+  const rect = anchor.getBoundingClientRect();
+  picker.style.position = 'fixed';
+  picker.style.top = `${rect.bottom + 4}px`;
+  picker.style.left = `${rect.left}px`;
+
+  function close(e: MouseEvent | KeyboardEvent): void {
+    if (e instanceof KeyboardEvent ? e.key === 'Escape' : !picker.contains(e.target as Node)) {
+      picker.remove();
+      document.removeEventListener('click', close as EventListener);
+      document.removeEventListener('keydown', close as EventListener);
+    }
+  }
+  setTimeout(() => {
+    document.addEventListener('click', close as EventListener);
+    document.addEventListener('keydown', close as EventListener);
+  }, 0);
+}

--- a/modules/app/internal/public/tables.css
+++ b/modules/app/internal/public/tables.css
@@ -103,3 +103,45 @@
   transform: scale(1.15);
   border-color: var(--accent);
 }
+
+/* Table grid picker popup */
+.table-grid-picker {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  z-index: 1000;
+  user-select: none;
+}
+
+.table-grid-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-align: center;
+  margin-bottom: 6px;
+}
+
+.table-grid {
+  display: grid;
+  gap: 2px;
+}
+
+.table-grid-cell {
+  width: 18px;
+  height: 18px;
+  background: var(--surface-2, #f0f0f0);
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  cursor: pointer;
+  padding: 0;
+}
+
+.table-grid-cell.highlighted {
+  background: var(--primary, #4f6ef7);
+  border-color: var(--primary, #4f6ef7);
+}
+
+[data-theme="dark"] .table-grid-cell {
+  background: var(--surface-2, #2a2a3a);
+}


### PR DESCRIPTION
## Summary

- Replaces the direct 3×3 table insert with an 8×8 hover-to-select grid picker popup
- Clicking the toolbar "Insert Table" button now opens the picker anchored below the button
- Hovering over cells highlights the (1,1)→(col,row) range and shows a live label (e.g. "3×4 table")
- Clicking a cell inserts the table at the chosen dimensions with a header row
- Escape key or click-outside dismisses without inserting

## Implementation

- **New file**: `modules/app/internal/editor/table-grid-picker.ts` — self-contained 69-line DOM module that builds and manages the picker
- **Modified**: `modules/app/internal/editor/formatting-toolbar-actions.ts` — table insert button now uses `passSelf: true` to receive the button element, calls `showTableGridPicker(editor, btn)` instead of directly inserting
- **Modified**: `modules/app/internal/public/tables.css` — added `.table-grid-picker`, `.table-grid-label`, `.table-grid`, `.table-grid-cell`, and dark-mode support

## Test plan

- [ ] Click the table toolbar button — picker popup appears anchored below the button
- [ ] Hover over grid cells — highlights extend from top-left corner, label updates (e.g. "5×3 table")
- [ ] Click a cell — table inserts with correct dimensions and header row, picker closes
- [ ] Press Escape — picker closes without inserting
- [ ] Click outside picker — picker closes without inserting
- [ ] Open picker, open again — only one picker exists at a time

🤖 Generated with [Claude Code](https://claude.com/claude-code)