### PR TITLE
feat(editor): reading time in status bar + focus mode (#453, #454)

### DIFF
--- a/modules/app/internal/css/editor.css
+++ b/modules/app/internal/css/editor.css
@@ -41,3 +41,4 @@
 @import "../public/ai-assist.css";
 @import "../editor/drawing/drawing.css";
 @import "../public/spellcheck.css";
+@import "../public/focus-mode.css";

--- a/modules/app/internal/editor/doc-stats.ts
+++ b/modules/app/internal/editor/doc-stats.ts
@@ -6,7 +6,7 @@ export interface DocStats {
   characters: number;
   charactersNoSpaces: number;
   paragraphs: number;
-  readingTime: string;
+  readingTime: number;
 }
 
 export interface StatsResult {
@@ -20,9 +20,8 @@ function countWords(text: string): number {
   return text.split(/\s+/).filter((w) => w.length > 0).length;
 }
 
-function formatReadingTime(words: number): string {
-  const minutes = Math.round(words / WORDS_PER_MINUTE);
-  return minutes < 1 ? '' : String(minutes);
+function calcReadingTime(words: number): number {
+  return Math.max(1, Math.ceil(words / WORDS_PER_MINUTE));
 }
 
 function countParagraphs(editor: Editor): number {
@@ -43,7 +42,7 @@ function buildStats(text: string, paragraphs: number): DocStats {
     characters: text.length,
     charactersNoSpaces: text.replace(/\s/g, '').length,
     paragraphs,
-    readingTime: formatReadingTime(words),
+    readingTime: calcReadingTime(words),
   };
 }
 

--- a/modules/app/internal/editor/editor.ts
+++ b/modules/app/internal/editor/editor.ts
@@ -43,6 +43,7 @@ import { mountAppToolbar } from '../shared/app-toolbar.ts';
 import { initEditorCollab } from './editor-collab.ts';
 import { initAiAssist } from './ai-assist.ts';
 import { initSpellCheckCycle } from './spell-check.ts';
+import { toggleFocusMode } from './focus-mode.ts';
 
 function updateHtmlLang(): void {
   document.documentElement.lang = getLocale();
@@ -197,6 +198,28 @@ async function init() {
 
   // Spell check — cycle through words, leveraging browser native spellcheck.
   initSpellCheckCycle(editorEl);
+
+  // Focus mode button in toolbar-right
+  const toolbarRightForFocus = document.querySelector('.toolbar-right');
+  if (toolbarRightForFocus) {
+    const focusBtn = document.createElement('button');
+    focusBtn.id = 'focus-mode-btn';
+    focusBtn.className = 'btn btn-ghost btn-sm';
+    focusBtn.setAttribute('aria-pressed', 'false');
+    focusBtn.setAttribute('title', 'Focus mode (\u2318\u21e7F)');
+    focusBtn.textContent = 'Focus';
+    focusBtn.addEventListener('click', () => toggleFocusMode());
+    toolbarRightForFocus.appendChild(focusBtn);
+  }
+
+  // Keyboard shortcut: Cmd/Ctrl+Shift+F → focus mode
+  document.addEventListener('keydown', (e) => {
+    const isMod = e.metaKey || e.ctrlKey;
+    if (isMod && e.shiftKey && e.key === 'F') {
+      e.preventDefault();
+      toggleFocusMode();
+    }
+  });
 
   Object.assign(window, { editor, provider, ydoc, commentStore });
 }

--- a/modules/app/internal/editor/focus-mode.ts
+++ b/modules/app/internal/editor/focus-mode.ts
@@ -1,0 +1,13 @@
+/** Contract: contracts/app/rules.md */
+
+let active = false;
+
+export function toggleFocusMode(): void {
+  active = !active;
+  document.body.classList.toggle('focus-mode', active);
+  // Update button aria-pressed if button exists
+  const btn = document.getElementById('focus-mode-btn');
+  if (btn) btn.setAttribute('aria-pressed', String(active));
+}
+
+export function isFocusModeActive(): boolean { return active; }

--- a/modules/app/internal/editor/status-bar.ts
+++ b/modules/app/internal/editor/status-bar.ts
@@ -19,6 +19,7 @@ function renderText(editor: Editor): string {
     t(doc.words === 1 ? 'stats.word' : 'stats.words', { count: String(doc.words) }),
     t(doc.characters === 1 ? 'stats.character' : 'stats.characters', { count: String(doc.characters) }),
     t(doc.paragraphs === 1 ? 'stats.paragraph' : 'stats.paragraphs', { count: String(doc.paragraphs) }),
+    t('stats.readingTime', { time: String(doc.readingTime) }),
   ].join('  \u00b7  ');
 }
 

--- a/modules/app/internal/public/focus-mode.css
+++ b/modules/app/internal/public/focus-mode.css
@@ -1,0 +1,29 @@
+/** Focus mode — hides chrome and narrows the editor for distraction-free writing */
+
+body.focus-mode .formatting-toolbar,
+body.focus-mode #ruler-h,
+body.focus-mode .status-bar,
+body.focus-mode .editor-top-chrome {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+body.focus-mode {
+  background: #0a0a0a;
+}
+
+body.focus-mode .editor-wrapper {
+  background: #0a0a0a;
+}
+
+body.focus-mode .editor-page,
+body.focus-mode #editor {
+  max-width: 42rem;
+}
+
+/* Reveal toolbar when hovering near top of screen */
+body.focus-mode .editor-top-chrome:hover {
+  opacity: 1;
+  pointer-events: auto;
+}


### PR DESCRIPTION
## Summary

- **#453 Reading time**: `doc-stats.ts` now computes `readingTime` as `Math.max(1, Math.ceil(words/200))` (number, not string). The status bar appends `~N min read` via the existing `stats.readingTime` i18n key; the segment is suppressed when text is selected.
- **#454 Focus mode**: New `focus-mode.ts` module with `toggleFocusMode()` / `isFocusModeActive()`. `focus-mode.css` dims all chrome (toolbar, ruler, status bar, top chrome) and narrows the editor to 42rem. Toolbar re-appears on hover. Wired into `editor.ts` via `Cmd/Ctrl+Shift+F` shortcut and a Focus button (`#focus-mode-btn`) appended to `.toolbar-right`.

## Test plan

- [ ] Open a document — status bar should show `~1 min read` (or more for longer docs)
- [ ] Select text — reading time segment disappears, selection count shows instead
- [ ] Press Cmd+Shift+F (Mac) or Ctrl+Shift+F (Win/Linux) — page goes dark, chrome hides
- [ ] Hover near top — formatting toolbar reappears
- [ ] Press Cmd+Shift+F again — exits focus mode, all chrome restores
- [ ] Click the "Focus" button in toolbar-right — same toggle behavior
- [ ] French locale — status bar shows `~N min de lecture`

🤖 Generated with [Claude Code](https://claude.com/claude-code)