### PR TITLE
feat(ux): toolbar overflow priorities + link popover view/edit — issues #457 #455

### DIFF
--- a/modules/app/internal/editor/link-popover-dom.ts
+++ b/modules/app/internal/editor/link-popover-dom.ts
@@ -1,0 +1,88 @@
+/** Contract: contracts/app/rules.md */
+/**
+ * DOM-building helpers for the link popover.
+ * Extracted from link-popover.ts to keep each file under 200 lines.
+ */
+
+export interface InsertViewCallbacks {
+  onApply: (url: string) => void;
+  onCancel: () => void;
+}
+
+export interface ViewModeCallbacks {
+  onEdit: () => void;
+  onCopy: (url: string) => void;
+  onRemove: () => void;
+}
+
+/**
+ * Build the insert/edit sub-view: URL input + Apply button.
+ * Returns the container element and the input (for auto-focus).
+ */
+export function buildInsertView(
+  initialValue: string,
+  cb: InsertViewCallbacks,
+): { container: HTMLElement; input: HTMLInputElement } {
+  const container = document.createElement('div');
+  container.className = 'link-popover-insert';
+
+  const input = document.createElement('input');
+  input.type = 'url';
+  input.className = 'link-popover-input';
+  input.placeholder = 'https://...';
+  input.value = initialValue;
+
+  const submitBtn = document.createElement('button');
+  submitBtn.type = 'button';
+  submitBtn.className = 'link-popover-submit';
+  submitBtn.textContent = 'Apply';
+
+  submitBtn.addEventListener('mousedown', (e) => { e.preventDefault(); cb.onApply(input.value.trim()); });
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') { e.preventDefault(); cb.onApply(input.value.trim()); }
+    else if (e.key === 'Escape') { e.preventDefault(); cb.onCancel(); }
+  });
+
+  container.appendChild(input);
+  container.appendChild(submitBtn);
+  return { container, input };
+}
+
+/**
+ * Build the view-mode sub-view: URL display + Edit / Copy / Remove buttons.
+ * Tab order is Edit → Copy → Remove (natural DOM order).
+ */
+export function buildViewMode(href: string, cb: ViewModeCallbacks): HTMLElement {
+  const container = document.createElement('div');
+  container.className = 'link-popover-view';
+
+  const urlDisplay = document.createElement('span');
+  urlDisplay.className = 'link-popover-url';
+  urlDisplay.title = href;
+  urlDisplay.textContent = href.length > 40 ? `${href.slice(0, 37)}\u2026` : href;
+
+  const actions = document.createElement('div');
+  actions.className = 'link-popover-actions';
+
+  const editBtn = makeActionBtn('Edit', 'Edit link', () => cb.onEdit());
+  const copyBtn = makeActionBtn('Copy', 'Copy link URL', () => cb.onCopy(href));
+  const removeBtn = makeActionBtn('Remove', 'Remove link', () => cb.onRemove());
+  removeBtn.classList.add('link-popover-action--remove');
+
+  actions.appendChild(editBtn);
+  actions.appendChild(copyBtn);
+  actions.appendChild(removeBtn);
+  container.appendChild(urlDisplay);
+  container.appendChild(actions);
+  return container;
+}
+
+function makeActionBtn(label: string, ariaLabel: string, handler: () => void): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'link-popover-action';
+  btn.textContent = label;
+  btn.setAttribute('aria-label', ariaLabel);
+  btn.addEventListener('mousedown', (e) => { e.preventDefault(); handler(); });
+  return btn;
+}

--- a/modules/app/internal/editor/link-popover.ts
+++ b/modules/app/internal/editor/link-popover.ts
@@ -1,108 +1,103 @@
 /** Contract: contracts/app/rules.md */
 /**
  * Inline link input popover — replaces the browser prompt() for link entry.
- * Shows a small input+button bar anchored below the bubble menu.
+ * Shows a small popover anchored below the trigger element.
+ *
+ * Modes:
+ *  - Insert mode: text is selected (or no existing link). Shows URL input + Apply.
+ *  - View mode:   cursor is ON a link with no selection. Shows URL + Edit/Copy/Remove.
  */
 import type { Editor } from '@tiptap/core';
-
-export function showLinkPopover(editor: Editor, anchor: HTMLElement): void {
-  // Remove any existing popover first
-  removeLinkPopover();
-
-  const rect = anchor.getBoundingClientRect();
-
-  const popover = document.createElement('div');
-  popover.className = 'link-popover';
-  popover.style.top = `${rect.bottom + 8}px`;
-  popover.style.left = `${rect.left}px`;
-
-  const input = document.createElement('input');
-  input.type = 'url';
-  input.className = 'link-popover-input';
-  input.placeholder = 'https://...';
-
-  // Pre-fill if a link is already active
-  const existingHref = editor.getAttributes('link').href as string | undefined;
-  if (existingHref) {
-    input.value = existingHref;
-  }
-
-  const submitBtn = document.createElement('button');
-  submitBtn.type = 'button';
-  submitBtn.className = 'link-popover-submit';
-  submitBtn.textContent = 'Apply';
-
-  popover.appendChild(input);
-  popover.appendChild(submitBtn);
-
-  // "Remove link" button only when a link is active
-  if (existingHref) {
-    const removeBtn = document.createElement('button');
-    removeBtn.type = 'button';
-    removeBtn.className = 'link-popover-remove';
-    removeBtn.textContent = 'Remove link';
-    removeBtn.addEventListener('mousedown', (e) => {
-      e.preventDefault();
-      editor.chain().focus().unsetLink().run();
-      removeLinkPopover();
-    });
-    popover.appendChild(removeBtn);
-  }
-
-  function applyLink(): void {
-    const url = input.value.trim();
-    if (url) {
-      editor.chain().focus().setLink({ href: url }).run();
-    }
-    removeLinkPopover();
-  }
-
-  submitBtn.addEventListener('mousedown', (e) => {
-    e.preventDefault();
-    applyLink();
-  });
-
-  input.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      applyLink();
-    } else if (e.key === 'Escape') {
-      e.preventDefault();
-      removeLinkPopover();
-    }
-  });
-
-  // Click-outside handler
-  function onDocClick(e: MouseEvent): void {
-    if (!popover.contains(e.target as Node)) {
-      removeLinkPopover();
-    }
-  }
-
-  // Store cleanup on the element so removeLinkPopover can tear it down
-  (popover as PopoverElement)._cleanup = () => {
-    document.removeEventListener('mousedown', onDocClick);
-  };
-
-  document.body.appendChild(popover);
-
-  // Delay listener so this mousedown event doesn't immediately close it
-  requestAnimationFrame(() => {
-    document.addEventListener('mousedown', onDocClick);
-  });
-
-  input.focus();
-  input.select();
-}
+import { buildInsertView, buildViewMode } from './link-popover-dom.ts';
 
 interface PopoverElement extends HTMLDivElement {
   _cleanup?: () => void;
 }
 
-function removeLinkPopover(): void {
-  const existing = document.querySelector('.link-popover') as PopoverElement | null;
-  if (existing) {
-    existing._cleanup?.();
-    existing.remove();
+export function showLinkPopover(editor: Editor, anchor: HTMLElement): void {
+  removeLinkPopover();
+
+  const existingHref = editor.getAttributes('link').href as string | undefined;
+  const hasSelection = !editor.state.selection.empty;
+
+  // View mode: cursor is sitting on a link with no text selection
+  const isViewMode = !!(existingHref && !hasSelection);
+
+  const popover = document.createElement('div') as PopoverElement;
+  popover.className = 'link-popover';
+  popover.setAttribute('role', 'dialog');
+  popover.setAttribute('aria-label', isViewMode ? 'Link options' : 'Insert link');
+
+  positionPopover(popover, anchor);
+
+  if (isViewMode) {
+    renderViewMode(popover, editor, existingHref!);
+  } else {
+    renderInsertMode(popover, editor, existingHref ?? '');
   }
+
+  const onDocClick = (e: MouseEvent) => {
+    if (!popover.contains(e.target as Node)) removeLinkPopover();
+  };
+  const onKeydown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') { e.preventDefault(); removeLinkPopover(); }
+  };
+
+  popover._cleanup = () => {
+    document.removeEventListener('mousedown', onDocClick);
+    document.removeEventListener('keydown', onKeydown);
+  };
+
+  document.body.appendChild(popover);
+
+  // Delay so this triggering mousedown/keydown doesn't immediately close the popover
+  requestAnimationFrame(() => {
+    document.addEventListener('mousedown', onDocClick);
+    document.addEventListener('keydown', onKeydown);
+  });
+}
+
+function renderInsertMode(popover: HTMLElement, editor: Editor, initialValue: string): void {
+  const { container, input } = buildInsertView(initialValue, {
+    onApply(url) {
+      if (url) editor.chain().focus().setLink({ href: url }).run();
+      removeLinkPopover();
+    },
+    onCancel() { removeLinkPopover(); },
+  });
+  popover.appendChild(container);
+  requestAnimationFrame(() => { input.focus(); input.select(); });
+}
+
+function renderViewMode(popover: HTMLElement, editor: Editor, href: string): void {
+  popover.appendChild(buildViewMode(href, {
+    onEdit() {
+      popover.innerHTML = '';
+      popover.setAttribute('aria-label', 'Edit link');
+      renderInsertMode(popover, editor, href);
+    },
+    onCopy(url) { navigator.clipboard.writeText(url).catch(() => {/* best-effort */}); },
+    onRemove() { editor.chain().focus().unsetLink().run(); removeLinkPopover(); },
+  }));
+  requestAnimationFrame(() => {
+    popover.querySelector<HTMLElement>('.link-popover-action')?.focus();
+  });
+}
+
+function positionPopover(popover: HTMLElement, anchor: HTMLElement): void {
+  const rect = anchor.getBoundingClientRect();
+  popover.style.position = 'fixed';
+  popover.style.top = `${rect.bottom + 8}px`;
+  popover.style.left = `${rect.left}px`;
+  // Clamp to viewport after paint
+  requestAnimationFrame(() => {
+    const pr = popover.getBoundingClientRect();
+    if (pr.right > window.innerWidth) popover.style.left = `${window.innerWidth - pr.width - 8}px`;
+    if (pr.bottom > window.innerHeight) popover.style.top = `${rect.top - pr.height - 8}px`;
+  });
+}
+
+export function removeLinkPopover(): void {
+  const existing = document.querySelector('.link-popover') as PopoverElement | null;
+  if (existing) { existing._cleanup?.(); existing.remove(); }
 }

--- a/modules/app/internal/editor/toolbar-overflow.ts
+++ b/modules/app/internal/editor/toolbar-overflow.ts
@@ -1,20 +1,15 @@
 /** Contract: contracts/app/rules.md */
 import { t, onLocaleChange } from '../i18n/index.ts';
 
-/** Priority groups: lower number = higher priority (stays visible longer). */
-const HIGH_PRIORITY_KEYS = new Set([
-  // Core text formatting
+/** Keys that must always remain visible — never pushed to the overflow menu. */
+const NEVER_OVERFLOW = new Set([
   'toolbar.undo', 'toolbar.redo',
-  'toolbar.bold', 'toolbar.italic', 'toolbar.strike', 'toolbar.code',
-  'toolbar.heading1', 'toolbar.heading2', 'toolbar.heading3',
-  // Alignment
-  'toolbar.alignLeft', 'toolbar.alignCenter', 'toolbar.alignRight', 'toolbar.alignJustify',
-  // Lists
-  'toolbar.bulletList', 'toolbar.orderedList',
+  'toolbar.stylePicker', 'toolbar.fontSize',
+  'toolbar.bold', 'toolbar.italic', 'toolbar.underline',
 ]);
 
-/** Low-priority keys pushed to overflow first when space is limited. */
-const LOW_PRIORITY_KEYS = new Set([
+/** Keys that overflow first when space is tight. */
+const LOW_PRIORITY = new Set([
   'toolbar.print', 'toolbar.pdf',
   'toolbar.references', 'toolbar.versions', 'toolbar.workflows',
   'toolbar.saveToKb',
@@ -22,133 +17,161 @@ const LOW_PRIORITY_KEYS = new Set([
 
 /**
  * Detects available toolbar width via ResizeObserver and moves
- * buttons that don't fit into an overflow dropdown.
+ * buttons that don't fit into an overflow dropdown (⋯ menu).
  */
 export function setupToolbarOverflow(toolbar: HTMLElement): () => void {
   const { wrapper, removeDocClickListener } = createOverflowWrapper(toolbar);
   const observer = new ResizeObserver(() => reflow(toolbar, wrapper));
   observer.observe(toolbar);
-
   const unsubLocale = onLocaleChange(() => {
     requestAnimationFrame(() => reflow(toolbar, wrapper));
   });
-
-  return () => {
-    observer.disconnect();
-    removeDocClickListener();
-    unsubLocale();
-  };
+  return () => { observer.disconnect(); removeDocClickListener(); unsubLocale(); };
 }
 
-function createOverflowWrapper(
-  toolbar: HTMLElement,
-): { wrapper: HTMLElement; removeDocClickListener: () => void } {
+function createOverflowWrapper(toolbar: HTMLElement): {
+  wrapper: HTMLElement; removeDocClickListener: () => void;
+} {
   const wrapper = document.createElement('div');
   wrapper.className = 'toolbar-overflow-wrapper';
 
   const trigger = document.createElement('button');
   trigger.className = 'toolbar-overflow-btn';
   trigger.setAttribute('aria-label', t('toolbar.moreOptions'));
-  trigger.textContent = '\u2026'; // ellipsis
-  trigger.addEventListener('click', (e) => {
-    e.stopPropagation();
-    menu.classList.toggle('is-open');
-  });
+  trigger.setAttribute('aria-haspopup', 'true');
+  trigger.setAttribute('aria-expanded', 'false');
+  trigger.textContent = '\u2026';
 
   const menu = document.createElement('div');
   menu.className = 'toolbar-overflow-menu';
+  menu.setAttribute('role', 'menu');
+  menu.hidden = true;
+
+  function closeMenu(): void {
+    menu.hidden = true;
+    trigger.setAttribute('aria-expanded', 'false');
+    clampMenu(menu, toolbar);
+  }
+
+  trigger.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const opening = menu.hidden;
+    menu.hidden = !opening;
+    trigger.setAttribute('aria-expanded', String(opening));
+    if (opening) {
+      clampMenu(menu, toolbar);
+      (menu.querySelector<HTMLElement>('[role="menuitem"]'))?.focus();
+    }
+  });
+
+  trigger.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeMenu(); });
+
+  menu.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') { closeMenu(); trigger.focus(); return; }
+    const items = Array.from(menu.querySelectorAll<HTMLElement>('[role="menuitem"]'));
+    if (!items.length) return;
+    const idx = items.indexOf(document.activeElement as HTMLElement);
+    if (e.key === 'ArrowDown') { e.preventDefault(); items[(idx + 1) % items.length].focus(); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); items[(idx - 1 + items.length) % items.length].focus(); }
+  });
 
   wrapper.appendChild(trigger);
   wrapper.appendChild(menu);
   toolbar.appendChild(wrapper);
 
-  // Close menu on outside click
-  const onDocClick = () => menu.classList.remove('is-open');
+  const onDocClick = (e: MouseEvent) => {
+    if (!wrapper.contains(e.target as Node)) closeMenu();
+  };
   document.addEventListener('click', onDocClick);
 
-  return {
-    wrapper,
-    removeDocClickListener: () => document.removeEventListener('click', onDocClick),
-  };
+  return { wrapper, removeDocClickListener: () => document.removeEventListener('click', onDocClick) };
+}
+
+function clampMenu(menu: HTMLElement, toolbar: HTMLElement): void {
+  menu.style.right = '0';
+  menu.style.left = '';
+  const r = menu.getBoundingClientRect();
+  if (r.right > window.innerWidth) menu.style.right = `${r.right - window.innerWidth + 8}px`;
+  const tr = toolbar.getBoundingClientRect();
+  if (r.bottom > window.innerHeight) {
+    menu.style.top = 'auto';
+    menu.style.bottom = `${tr.height + 4}px`;
+  } else {
+    menu.style.top = '';
+    menu.style.bottom = '';
+  }
 }
 
 function reflow(toolbar: HTMLElement, wrapper: HTMLElement): void {
-  const menu = wrapper.querySelector('.toolbar-overflow-menu');
+  const menu = wrapper.querySelector<HTMLElement>('.toolbar-overflow-menu');
   if (!menu) return;
 
-  // Reset: move all overflow items back to toolbar
-  const overflowed = Array.from(
-    menu.querySelectorAll('.toolbar-btn, .toolbar-separator'),
-  );
-  for (const el of overflowed) {
+  // Restore all overflow items back to toolbar
+  for (const el of Array.from(menu.querySelectorAll<HTMLElement>('[role="menuitem"]'))) {
+    el.removeAttribute('role');
     toolbar.insertBefore(el, wrapper);
   }
   wrapper.style.display = 'none';
+  menu.hidden = true;
+  wrapper.querySelector('button')?.setAttribute('aria-expanded', 'false');
 
-  const toolbarWidth = toolbar.clientWidth;
-  const wrapperWidth = 48; // reserve space for the "…" button
-
+  const WRAPPER_W = 48;
   const children = Array.from(toolbar.children).filter(
     (el) => el !== wrapper && el instanceof HTMLElement,
   ) as HTMLElement[];
 
-  let totalWidth = children.reduce((sum, el) => sum + el.offsetWidth + 4, 0);
-  if (totalWidth + wrapperWidth <= toolbarWidth) return;
+  let total = children.reduce((s, el) => s + el.offsetWidth + 4, 0);
+  if (total + WRAPPER_W <= toolbar.clientWidth) return;
 
   const toOverflow: HTMLElement[] = [];
 
-  // Phase 1: overflow low-priority items first (print, pdf, versions, etc.)
+  // Phase 1: low-priority items first
   for (const el of children) {
-    if (totalWidth + wrapperWidth <= toolbarWidth) break;
-    const key = el.getAttribute('data-i18n-key') || '';
-    if (LOW_PRIORITY_KEYS.has(key)) {
+    if (total + WRAPPER_W <= toolbar.clientWidth) break;
+    if (LOW_PRIORITY.has(el.getAttribute('data-i18n-key') ?? '')) {
       toOverflow.push(el);
-      totalWidth -= el.offsetWidth + 4;
+      total -= el.offsetWidth + 4;
     }
   }
 
-  // Phase 2: overflow neutral items from right to left
-  if (totalWidth + wrapperWidth > toolbarWidth) {
-    const neutral = [...children].reverse().filter(
-      (el) => !toOverflow.includes(el) && priorityScore(el.getAttribute('data-i18n-key') || '') === 1,
-    );
-    for (const el of neutral) {
-      if (totalWidth + wrapperWidth <= toolbarWidth) break;
-      toOverflow.push(el);
-      totalWidth -= el.offsetWidth + 4;
+  // Phase 2: neutral items right-to-left
+  if (total + WRAPPER_W > toolbar.clientWidth) {
+    for (const el of [...children].reverse()) {
+      if (total + WRAPPER_W <= toolbar.clientWidth) break;
+      if (!toOverflow.includes(el) && score(el) === 1) {
+        toOverflow.push(el);
+        total -= el.offsetWidth + 4;
+      }
     }
   }
 
-  // Phase 3: overflow high-priority items from right to left (last resort)
-  if (totalWidth + wrapperWidth > toolbarWidth) {
-    const high = [...children].reverse().filter(
-      (el) => !toOverflow.includes(el) && HIGH_PRIORITY_KEYS.has(el.getAttribute('data-i18n-key') || ''),
-    );
-    for (const el of high) {
-      if (totalWidth + wrapperWidth <= toolbarWidth) break;
-      toOverflow.push(el);
-      totalWidth -= el.offsetWidth + 4;
+  // Phase 3: last resort — anything that isn't NEVER_OVERFLOW
+  if (total + WRAPPER_W > toolbar.clientWidth) {
+    for (const el of [...children].reverse()) {
+      if (total + WRAPPER_W <= toolbar.clientWidth) break;
+      if (!toOverflow.includes(el) && !NEVER_OVERFLOW.has(el.getAttribute('data-i18n-key') ?? '')) {
+        toOverflow.push(el);
+        total -= el.offsetWidth + 4;
+      }
     }
   }
 
-  if (toOverflow.length === 0) return;
+  if (!toOverflow.length) return;
 
-  for (const el of sortByPriority([...toOverflow])) {
+  for (const el of sortByScore(toOverflow)) {
+    el.setAttribute('role', 'menuitem');
     menu.appendChild(el);
   }
   wrapper.style.display = 'block';
 }
 
-function priorityScore(key: string): number {
-  if (LOW_PRIORITY_KEYS.has(key)) return 2;   // overflow first
-  if (HIGH_PRIORITY_KEYS.has(key)) return 0;  // overflow last
-  return 1;                                    // neutral
+function score(el: HTMLElement): number {
+  const k = el.getAttribute('data-i18n-key') ?? '';
+  if (NEVER_OVERFLOW.has(k)) return -1;
+  if (LOW_PRIORITY.has(k)) return 2;
+  return 1;
 }
 
-function sortByPriority(elements: HTMLElement[]): HTMLElement[] {
-  return elements.sort((a, b) => {
-    const aScore = priorityScore(a.getAttribute('data-i18n-key') || '');
-    const bScore = priorityScore(b.getAttribute('data-i18n-key') || '');
-    return bScore - aScore; // highest score overflows first
-  });
+function sortByScore(els: HTMLElement[]): HTMLElement[] {
+  return els.sort((a, b) => score(b) - score(a));
 }

--- a/modules/app/internal/editor/toolbar-selects.ts
+++ b/modules/app/internal/editor/toolbar-selects.ts
@@ -53,6 +53,7 @@ export function buildFontFamilySelect(editor: Editor): HTMLElement {
 export function buildFontSizeSelect(editor: Editor): HTMLElement {
   const wrapper = document.createElement('span');
   wrapper.style.position = 'relative';
+  wrapper.setAttribute('data-i18n-key', 'toolbar.fontSize');
 
   const datalist = document.createElement('datalist');
   datalist.id = 'font-size-options';
@@ -148,6 +149,7 @@ export function buildStyleSelect(editor: Editor): HTMLElement {
   select.className = 'toolbar-select toolbar-select--style';
   select.setAttribute('aria-label', 'Paragraph style');
   select.setAttribute('title', 'Paragraph style');
+  select.setAttribute('data-i18n-key', 'toolbar.stylePicker');
 
   for (const style of STYLES) {
     const opt = document.createElement('option');


### PR DESCRIPTION
## Summary

- **#457 Toolbar overflow**: Narrowed `NEVER_OVERFLOW` set to exactly the required items (Undo, Redo, Style picker, Font size, Bold, Italic, Underline). Added `data-i18n-key` attributes to the style-picker `<select>` and font-size wrapper `<span>` so the overflow logic can identify them. Fixed the ⋯ button: `aria-haspopup="true"`, `aria-expanded` tracking, `role="menu"` on the dropdown, `role="menuitem"` on overflow items, arrow-key navigation, Escape-to-close, and viewport clamping so the menu never clips off-screen.
- **#455 Link popover view/edit**: Added a distinct view mode — when the cursor is on an existing link with no selection, the popover shows the truncated URL (full URL in `title`), plus Edit, Copy, and Remove buttons. Edit mode swaps the view in-place to the URL input. Insert mode auto-focuses the input. Escape closes globally. DOM builders extracted into `link-popover-dom.ts` to keep both files under 200 lines.

## Files changed

- `modules/app/internal/editor/toolbar-overflow.ts` — priority tiers, ARIA, keyboard nav, viewport clamp
- `modules/app/internal/editor/toolbar-selects.ts` — `data-i18n-key` on style picker + font-size wrapper
- `modules/app/internal/editor/link-popover.ts` — view/insert mode logic, global Escape, positioning
- `modules/app/internal/editor/link-popover-dom.ts` — new; DOM builders extracted from link-popover.ts

## Test plan

- [ ] At narrow viewport (< 600px), Undo/Redo/Style/Size/Bold/Italic/Underline remain visible; all others overflow
- [ ] ⋯ button opens menu; arrow keys navigate items; Escape closes and returns focus to trigger
- [ ] Menu does not overflow viewport edge on right or bottom
- [ ] Select text + Cmd/Ctrl+K → insert popover opens, input focused, Enter applies, Escape cancels
- [ ] Click inside an existing link (no selection) → view popover shows URL, Edit/Copy/Remove
- [ ] Edit button swaps to input pre-filled with existing URL
- [ ] Copy button writes URL to clipboard
- [ ] Remove button strips the link mark

🤖 Generated with [Claude Code](https://claude.com/claude-code)