### PR TITLE
feat(ux): responsive sidebar resize + mobile layout (#447 #417)

### DIFF
--- a/modules/app/internal/editor/editor-panels.ts
+++ b/modules/app/internal/editor/editor-panels.ts
@@ -15,6 +15,7 @@ import { openCitationPicker, createBibliography, buildReferenceLibrary } from '.
 import { setupPromoteToKB } from './promote-to-kb.ts';
 import { buildFootnotePanel } from './footnote-panel.ts';
 import { buildSpecialCharsPanel, toggleSpecialCharsPanel } from './special-chars.ts';
+import { initSidebarResize } from './sidebar-resize.ts';
 
 export interface PanelDeps {
   editor: Editor;
@@ -44,9 +45,11 @@ export function initEditorPanels(deps: PanelDeps): void {
 
   const commentSidebar = buildCommentSidebar(editor, commentStore, documentId, user);
   document.body.appendChild(commentSidebar);
+  initSidebarResize(commentSidebar);
 
   const suggestionSidebar = buildSuggestionSidebar(editor);
   document.body.appendChild(suggestionSidebar);
+  initSidebarResize(suggestionSidebar);
 
   const tocPanel = buildTocPanel(editor);
   document.body.appendChild(tocPanel);
@@ -58,12 +61,14 @@ export function initEditorPanels(deps: PanelDeps): void {
 
   const versionSidebar = buildVersionSidebar();
   document.body.appendChild(versionSidebar);
+  initSidebarResize(versionSidebar);
   document.addEventListener('opendesk:toggle-versions', () => {
     toggleVersionSidebar(versionSidebar);
   });
 
   const workflowPanel = buildWorkflowPanel();
   document.body.appendChild(workflowPanel);
+  initSidebarResize(workflowPanel);
   document.addEventListener('opendesk:toggle-workflows', () => {
     toggleWorkflowPanel(workflowPanel);
   });

--- a/modules/app/internal/editor/sidebar-resize.ts
+++ b/modules/app/internal/editor/sidebar-resize.ts
@@ -1,0 +1,37 @@
+/** Contract: contracts/app/rules.md */
+
+const STORAGE_KEY = 'opendesk-sidebar-width';
+const MIN_WIDTH = 260;
+const MAX_WIDTH = () => Math.round(window.innerWidth * 0.5);
+
+export function initSidebarResize(panel: HTMLElement): void {
+  const saved = localStorage.getItem(STORAGE_KEY);
+  if (saved) panel.style.width = `${saved}px`;
+
+  const handle = document.createElement('div');
+  handle.className = 'sidebar-resize-handle';
+  panel.prepend(handle);
+
+  let startX = 0;
+  let startWidth = 0;
+
+  handle.addEventListener('mousedown', (e: MouseEvent) => {
+    startX = e.clientX;
+    startWidth = panel.offsetWidth;
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+    e.preventDefault();
+  });
+
+  function onMove(e: MouseEvent): void {
+    const delta = startX - e.clientX; // sidebar is on the right
+    const newWidth = Math.min(Math.max(startWidth + delta, MIN_WIDTH), MAX_WIDTH());
+    panel.style.width = `${newWidth}px`;
+  }
+
+  function onUp(): void {
+    localStorage.setItem(STORAGE_KEY, String(panel.offsetWidth));
+    document.removeEventListener('mousemove', onMove);
+    document.removeEventListener('mouseup', onUp);
+  }
+}

--- a/modules/app/internal/public/mobile.css
+++ b/modules/app/internal/public/mobile.css
@@ -26,8 +26,20 @@
 .comment-sheet-backdrop.is-visible { display: block; }
 .comment-sheet-handle { display: none; }
 
+/* Tablet: 768–1199px */
+@media (max-width: 1199px) {
+  .comment-sidebar,
+  .suggestion-sidebar,
+  .version-sidebar,
+  .workflow-sidebar { width: clamp(260px, 30vw, 360px); }
+  .doc-list-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
 /* Mobile: < 768px */
 @media (max-width: 768px) {
+  .doc-list-grid { grid-template-columns: 1fr; }
+  .workspace-sidebar { display: none; }
+  .shell-content { padding: 0.5rem; }
   .toolbar-btn, .export-btn, .search-panel__btn, .search-panel__toggle,
   .comment-action-btn, .comment-sidebar-close, .btn {
     min-width: 2.75rem; min-height: 2.75rem;
@@ -42,9 +54,32 @@
   .toolbar { padding: 0.5rem 0.75rem; gap: 0.5rem; }
   .toolbar-left, .toolbar-right { gap: 0.375rem; }
   .editor-wrapper { padding: 0; }
-  body:has(.comment-sidebar-open) .editor-wrapper { margin-right: 0; }
+  body:has(.comment-sidebar-open) .editor-wrapper,
+  body:has(.suggestion-sidebar-open) .editor-wrapper,
+  body:has(.version-sidebar-open) .editor-wrapper,
+  body:has(.workflow-sidebar-open) .editor-wrapper,
+  body:has(.toc-panel-open) .editor-wrapper { margin-right: 0; }
   #editor { max-width: 100%; border-radius: 0; border-left: none; border-right: none; }
+  .editor-page { margin: 0; border-radius: 0; width: 100%; }
+  #ruler-h { display: none; }
   .editor-content { padding: 1rem; }
+  /* Non-comment sidebars: slide-in overlay on mobile */
+  .suggestion-sidebar,
+  .version-sidebar,
+  .workflow-sidebar {
+    position: fixed;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    width: 100% !important;
+    max-width: 340px;
+    z-index: 200;
+    transform: translateX(100%);
+  }
+  .suggestion-sidebar-open,
+  .version-sidebar-open,
+  .workflow-sidebar-open { transform: translateX(0); }
+  .sidebar-resize-handle { display: none; }
   .search-panel { right: 0; left: 0; top: 0; border-radius: 0 0 8px 8px; min-width: 0; }
   .template-modal { width: 100%; max-width: 100%; max-height: 100vh; border-radius: 0; height: 100vh; }
   .doc-list-wrapper { padding: 1rem 0.5rem; }

--- a/modules/app/internal/public/sidebar.css
+++ b/modules/app/internal/public/sidebar.css
@@ -7,7 +7,7 @@
   position: fixed;
   top: 0;
   right: 0;
-  width: 320px;
+  width: clamp(280px, 25vw, 420px);
   height: 100vh;
   background: var(--surface);
   border-left: 1px solid var(--border);
@@ -71,6 +71,34 @@
 .version-sidebar-list {
   flex: 1;
   overflow-y: auto;
+}
+
+/* Editor content shifts right when a sidebar is open */
+body:has(.comment-sidebar-open) .editor-wrapper,
+body:has(.suggestion-sidebar-open) .editor-wrapper,
+body:has(.version-sidebar-open) .editor-wrapper,
+body:has(.workflow-sidebar-open) .editor-wrapper,
+body:has(.toc-panel-open) .editor-wrapper {
+  margin-right: clamp(280px, 25vw, 420px);
+  transition: margin-right 0.2s ease;
+}
+
+/* Resize handle — left edge of each sidebar panel */
+/* Panels already have position:fixed so the handle's position:absolute works */
+.sidebar-resize-handle {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  cursor: col-resize;
+  background: transparent;
+  z-index: 1;
+}
+
+.sidebar-resize-handle:hover {
+  background: var(--primary, #4f6ef7);
+  opacity: 0.4;
 }
 
 /* Scrollbar — sidebar panels */


### PR DESCRIPTION
## Summary

- **#447 — Sidebar responsive + user-resizable**: sidebar width changed from fixed `320px` to `clamp(280px, 25vw, 420px)`; editor-wrapper shifts right via `body:has()` selectors when any sidebar is open; new `sidebar-resize.ts` drag-handle module with `localStorage` persistence; `initSidebarResize()` wired to all four panels in `editor-panels.ts`
- **#417 — Mobile responsive**: tablet breakpoint (≤1199px) adds 2-col dashboard grid and narrower sidebar widths; mobile (≤768px) collapses to 1-col grid, hides workspace sidebar, makes editor full-width, hides ruler, and switches non-comment sidebars to fixed overlays; margin-right reset on `.editor-wrapper` now covers all open-sidebar states

## What changed

- `modules/app/internal/public/sidebar.css` — responsive `clamp()` width, `body:has()` editor margin rules, resize handle CSS
- `modules/app/internal/editor/sidebar-resize.ts` — new 37-line drag handle module
- `modules/app/internal/editor/editor-panels.ts` — imports and wires `initSidebarResize` to all panels
- `modules/app/internal/public/mobile.css` — tablet block, dashboard grid rules, editor-page/ruler/sidebar overlay rules

## Test plan

- [ ] Desktop (≥1200px): sidebar width is between 280–420px, scales with viewport
- [ ] Desktop: opening any sidebar shifts editor content left smoothly
- [ ] Desktop: drag the resize handle to resize a sidebar; refresh and confirm width persists
- [ ] Tablet (768–1199px): sidebar narrower (30vw), dashboard shows 2-col grid
- [ ] Mobile (≤768px): dashboard is single column, workspace sidebar hidden
- [ ] Mobile: editor is full-width, ruler hidden, editor page has no margin/border-radius
- [ ] Mobile: opening suggestion/version/workflow sidebar slides in as overlay (not sheet)
- [ ] Mobile: comment sidebar still uses bottom-sheet behaviour (existing)
- [ ] Resize handle does not appear on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)