### PR TITLE
feat(kb): inline linking between KB entries via [[ trigger — issue #421

### DIFF
--- a/modules/app-kb/internal/detail-metadata.ts
+++ b/modules/app-kb/internal/detail-metadata.ts
@@ -83,6 +83,19 @@ function renderDatasetMetadata(m: Record<string, unknown>, el: HTMLElement): HTM
   return el;
 }
 
+function wireKbLinks(container: HTMLElement): void {
+  container.querySelectorAll<HTMLAnchorElement>('a.kb-internal-link').forEach((link) => {
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      const entryId = link.dataset.kbEntryId;
+      if (!entryId) return;
+      document.dispatchEvent(
+        new CustomEvent('opendesk:open-kb-entry', { detail: { entryId }, bubbles: true }),
+      );
+    });
+  });
+}
+
 function renderNoteMetadata(m: Record<string, unknown>, el: HTMLElement): HTMLElement {
   const heading = document.createElement('h3');
   heading.textContent = 'Note Content';
@@ -93,6 +106,7 @@ function renderNoteMetadata(m: Record<string, unknown>, el: HTMLElement): HTMLEl
     if (m.format === 'markdown') {
       bodyEl.classList.add('kb-md-content');
       bodyEl.innerHTML = renderSimpleMarkdown(String(m.body));
+      wireKbLinks(bodyEl);
     } else {
       bodyEl.textContent = String(m.body);
     }

--- a/modules/app-kb/internal/form-meta-fields.ts
+++ b/modules/app-kb/internal/form-meta-fields.ts
@@ -1,5 +1,7 @@
 /** Contract: contracts/app-kb/rules.md */
 
+import { attachKbLinkSuggestion } from './kb-link-suggestion.ts';
+
 /** Field definition for dynamic metadata form rendering. */
 export interface MetadataFieldDef {
   key: string;
@@ -115,6 +117,10 @@ export function renderMetaFields(
       textarea.rows = 3;
       textarea.value = String(value);
       if (field.placeholder) textarea.placeholder = field.placeholder;
+      // Attach [[ KB inline link suggestion for note body
+      if (entryType === 'note' && field.key === 'body') {
+        attachKbLinkSuggestion(textarea);
+      }
       container.appendChild(textarea);
     } else if (field.type === 'select' && field.options) {
       const select = document.createElement('select');

--- a/modules/app-kb/internal/kb-browser-view.ts
+++ b/modules/app-kb/internal/kb-browser-view.ts
@@ -164,6 +164,15 @@ export async function mount(container: HTMLElement, _params: Record<string, stri
   // Refresh list after import
   document.addEventListener('kb:import-complete', () => loadEntries());
 
+  // Navigate to an entry when a KB internal link is clicked
+  document.addEventListener('opendesk:open-kb-entry', ((e: Event) => {
+    const { entryId } = (e as CustomEvent<{ entryId: string }>).detail;
+    if (!entryId || !detailPanel) return;
+    import('./kb-api.ts').then(({ fetchEntry }) =>
+      fetchEntry(entryId).then((entry) => openDetail(detailPanel!, entry)).catch(console.error),
+    );
+  }) as EventListener);
+
   wrapper.appendChild(header);
   wrapper.appendChild(filterBar);
   wrapper.appendChild(quickNoteEl);

--- a/modules/app-kb/internal/kb-link-list.ts
+++ b/modules/app-kb/internal/kb-link-list.ts
@@ -1,0 +1,142 @@
+/** Contract: contracts/app-kb/rules.md */
+
+/** A KB entry result item for link suggestions. */
+export interface KbLinkItem {
+  id: string;
+  title: string;
+}
+
+interface KbLinkListState {
+  items: KbLinkItem[];
+  selectedIndex: number;
+  element: HTMLDivElement | null;
+  onSelect: ((item: KbLinkItem) => void) | null;
+}
+
+function createState(): KbLinkListState {
+  return { items: [], selectedIndex: 0, element: null, onSelect: null };
+}
+
+function createDropdownElement(): HTMLDivElement {
+  const el = document.createElement('div');
+  el.className = 'kb-link-dropdown';
+  el.setAttribute('role', 'listbox');
+  el.setAttribute('aria-label', 'KB entry suggestions');
+  return el;
+}
+
+function renderItems(state: KbLinkListState): void {
+  const el = state.element;
+  if (!el) return;
+  el.innerHTML = '';
+
+  if (state.items.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'kb-link-dropdown__empty';
+    empty.textContent = 'No entries found';
+    el.appendChild(empty);
+    return;
+  }
+
+  state.items.forEach((item, index) => {
+    const btn = document.createElement('button');
+    btn.className = 'kb-link-dropdown__item';
+    if (index === state.selectedIndex) btn.classList.add('is-selected');
+    btn.setAttribute('role', 'option');
+    btn.type = 'button';
+
+    const icon = document.createElement('span');
+    icon.className = 'kb-link-dropdown__icon';
+    icon.textContent = '\u{1F517}';
+    icon.setAttribute('aria-hidden', 'true');
+
+    const label = document.createElement('span');
+    label.className = 'kb-link-dropdown__label';
+    label.textContent = item.title;
+
+    btn.appendChild(icon);
+    btn.appendChild(label);
+    btn.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      selectItem(state, index);
+    });
+    el.appendChild(btn);
+  });
+}
+
+function selectItem(state: KbLinkListState, index: number): void {
+  const item = state.items[index];
+  if (item && state.onSelect) state.onSelect(item);
+}
+
+function positionDropdown(el: HTMLDivElement, anchor: { left: number; bottom: number }): void {
+  el.style.left = `${anchor.left}px`;
+  el.style.top = `${anchor.bottom + 4}px`;
+}
+
+/** Create and manage a KB link suggestion dropdown attached to a textarea. */
+export function createKbLinkList(onSelect: (item: KbLinkItem) => void): {
+  show(items: KbLinkItem[], anchor: { left: number; bottom: number }): void;
+  update(items: KbLinkItem[]): void;
+  hide(): void;
+  handleKey(e: KeyboardEvent): boolean;
+  isVisible(): boolean;
+} {
+  const state = createState();
+  state.onSelect = onSelect;
+
+  return {
+    show(items, anchor) {
+      if (!state.element) {
+        state.element = createDropdownElement();
+        document.body.appendChild(state.element);
+      }
+      state.items = items;
+      state.selectedIndex = 0;
+      renderItems(state);
+      positionDropdown(state.element, anchor);
+      state.element.hidden = false;
+    },
+
+    update(items) {
+      state.items = items;
+      state.selectedIndex = 0;
+      if (state.element) renderItems(state);
+    },
+
+    hide() {
+      if (state.element) {
+        state.element.remove();
+        state.element = null;
+      }
+      state.items = [];
+    },
+
+    handleKey(e: KeyboardEvent): boolean {
+      if (!state.element || state.items.length === 0) return false;
+      if (e.key === 'ArrowUp') {
+        state.selectedIndex = (state.selectedIndex + state.items.length - 1) % state.items.length;
+        renderItems(state);
+        return true;
+      }
+      if (e.key === 'ArrowDown') {
+        state.selectedIndex = (state.selectedIndex + 1) % state.items.length;
+        renderItems(state);
+        return true;
+      }
+      if (e.key === 'Enter') {
+        selectItem(state, state.selectedIndex);
+        return true;
+      }
+      if (e.key === 'Escape') {
+        this.hide();
+        return true;
+      }
+      return false;
+    },
+
+    isVisible(): boolean {
+      return state.element !== null;
+    },
+  };
+}

--- a/modules/app-kb/internal/kb-link-suggestion.ts
+++ b/modules/app-kb/internal/kb-link-suggestion.ts
@@ -1,0 +1,106 @@
+/** Contract: contracts/app-kb/rules.md */
+
+import { fetchEntries } from './kb-api.ts';
+import { createKbLinkList } from './kb-link-list.ts';
+
+const TRIGGER = '[[';
+
+/** Extract the current `[[query` from cursor position if active. Returns null if not in a link trigger. */
+function extractQuery(text: string, cursorPos: number): string | null {
+  const before = text.slice(0, cursorPos);
+  const triggerIdx = before.lastIndexOf(TRIGGER);
+  if (triggerIdx === -1) return null;
+  // Ensure no closing `]]` between trigger and cursor
+  const segment = before.slice(triggerIdx + TRIGGER.length);
+  if (segment.includes(']]') || segment.includes('\n')) return null;
+  return segment;
+}
+
+/** Get pixel coordinates for the caret position within a textarea. */
+function getCaretCoords(textarea: HTMLTextAreaElement): { left: number; bottom: number } {
+  const rect = textarea.getBoundingClientRect();
+  // Approximate: use textarea bottom-left as anchor
+  return { left: rect.left + 8, bottom: rect.bottom };
+}
+
+/** Replace the `[[query` text at cursor with the completed link token `[[title|id]]`. */
+function insertLink(textarea: HTMLTextAreaElement, query: string, title: string, id: string): void {
+  const { selectionStart, selectionEnd, value } = textarea;
+  if (selectionStart === null) return;
+
+  const before = value.slice(0, selectionStart);
+  const triggerIdx = before.lastIndexOf(TRIGGER);
+  if (triggerIdx === -1) return;
+
+  const newBefore = before.slice(0, triggerIdx) + `[[${title}|${id}]]`;
+  const after = value.slice(selectionEnd ?? selectionStart);
+  textarea.value = newBefore + after;
+
+  const newCursor = newBefore.length;
+  textarea.setSelectionRange(newCursor, newCursor);
+  textarea.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+/**
+ * Attach `[[` inline link suggestion behaviour to a textarea element.
+ * Returns a cleanup function that removes all listeners.
+ */
+export function attachKbLinkSuggestion(textarea: HTMLTextAreaElement): () => void {
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const list = createKbLinkList((item) => {
+    const query = extractQuery(textarea.value, textarea.selectionStart ?? 0);
+    insertLink(textarea, query ?? '', item.title, item.id);
+    list.hide();
+    textarea.focus();
+  });
+
+  async function fetchAndShow(query: string): Promise<void> {
+    try {
+      const entries = await fetchEntries({ search: query || undefined, limit: 10 });
+      const items = entries.map((e) => ({ id: e.id, title: e.title }));
+      if (list.isVisible()) {
+        list.update(items);
+      } else {
+        list.show(items, getCaretCoords(textarea));
+      }
+    } catch {
+      list.hide();
+    }
+  }
+
+  function onInput(): void {
+    const pos = textarea.selectionStart ?? 0;
+    const query = extractQuery(textarea.value, pos);
+    if (query === null) {
+      list.hide();
+      return;
+    }
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => fetchAndShow(query), 180);
+  }
+
+  function onKeyDown(e: KeyboardEvent): void {
+    if (list.isVisible()) {
+      const handled = list.handleKey(e);
+      if (handled) e.preventDefault();
+    }
+  }
+
+  function onBlur(): void {
+    // Slight delay so mousedown on dropdown fires first
+    setTimeout(() => list.hide(), 150);
+  }
+
+  textarea.addEventListener('input', onInput);
+  textarea.addEventListener('keydown', onKeyDown);
+  textarea.addEventListener('blur', onBlur);
+
+  return () => {
+    textarea.removeEventListener('input', onInput);
+    textarea.removeEventListener('keydown', onKeyDown);
+    textarea.removeEventListener('blur', onBlur);
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+    list.hide();
+  };
+}

--- a/modules/app-kb/internal/quick-note.ts
+++ b/modules/app-kb/internal/quick-note.ts
@@ -1,6 +1,7 @@
 /** Contract: contracts/app-kb/rules.md */
 
 import { createEntryApi } from './kb-api.ts';
+import { attachKbLinkSuggestion } from './kb-link-suggestion.ts';
 
 /**
  * Lightweight inline form for creating notes quickly.
@@ -49,6 +50,9 @@ export function createQuickNote(onCreated: () => void): HTMLElement {
       handleSave(titleInput, bodyArea, saveBtn, onCreated);
     }
   });
+
+  // Attach [[ KB inline link suggestion
+  attachKbLinkSuggestion(bodyArea);
 
   return wrapper;
 }

--- a/modules/app-kb/internal/simple-markdown.ts
+++ b/modules/app-kb/internal/simple-markdown.ts
@@ -43,11 +43,16 @@ function processHeadings(html: string): string {
     .replace(/^# (.+)$/gm, '<h3>$1</h3>');
 }
 
-/** Convert inline formatting: bold, italic, code, links. */
+/** Convert inline formatting: bold, italic, code, links, and KB internal links. */
 function processInline(html: string): string {
   return html
     // inline code (before bold/italic to avoid conflicts)
     .replace(/`([^`]+)`/g, '<code>$1</code>')
+    // KB internal links [[title|id]] — must come before external links
+    .replace(
+      /\[\[([^\]|]+)\|([^\]]+)\]\]/g,
+      '<a class="kb-internal-link" data-kb-entry-id="$2" href="#kb-entry-$2">$1</a>',
+    )
     // bold
     .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
     // italic (single asterisk, not inside bold)

--- a/modules/app/internal/public/kb-extras.css
+++ b/modules/app/internal/public/kb-extras.css
@@ -176,6 +176,79 @@
   text-decoration: underline;
 }
 
+/* --- KB inline link suggestion dropdown --- */
+
+.kb-link-dropdown {
+  position: fixed;
+  z-index: 200;
+  background: var(--surface, #fff);
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px var(--shadow-heavy, rgba(0, 0, 0, 0.12));
+  padding: 0.25rem;
+  min-width: 14rem;
+  max-height: 14rem;
+  overflow-y: auto;
+}
+
+.kb-link-dropdown__item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.4rem 0.625rem;
+  border: none;
+  border-radius: 4px;
+  background: none;
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text, #1f2937);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s;
+}
+
+.kb-link-dropdown__item:hover,
+.kb-link-dropdown__item.is-selected {
+  background: var(--bg, #f3f4f6);
+}
+
+.kb-link-dropdown__icon {
+  flex-shrink: 0;
+  font-size: 0.75rem;
+}
+
+.kb-link-dropdown__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kb-link-dropdown__empty {
+  padding: 0.5rem 0.625rem;
+  font-size: 0.8125rem;
+  color: var(--text-muted, #6b7280);
+  text-align: center;
+}
+
+/* --- KB internal links rendered in note bodies --- */
+
+.kb-internal-link {
+  color: var(--accent, #4f6ef7);
+  text-decoration: none;
+  background: var(--accent-subtle, rgba(79, 110, 247, 0.08));
+  border-radius: 3px;
+  padding: 1px 4px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.kb-internal-link:hover {
+  text-decoration: underline;
+  background: var(--accent-subtle, rgba(79, 110, 247, 0.14));
+}
+
 /* --- Import/Export --- */
 
 .kb-export-menu {


### PR DESCRIPTION
## Summary

- Adds `[[` trigger autocomplete in KB note textareas (quick-note creator and entry edit form)
- Typing `[[` + query debounce-fetches matching entries from `/api/kb/entries?search=...&limit=10` and shows a keyboard-navigable dropdown
- Selecting an entry inserts a `[[title|id]]` token into the textarea
- `simple-markdown.ts` now renders `[[title|id]]` tokens as styled `<a class="kb-internal-link">` elements in note detail view
- Clicking an internal link dispatches `opendesk:open-kb-entry` custom event; `kb-browser-view.ts` listens and opens the detail panel for the linked entry

## New files

- `modules/app-kb/internal/kb-link-list.ts` — dropdown list component (142 lines)
- `modules/app-kb/internal/kb-link-suggestion.ts` — textarea `[[` trigger + debounced fetch logic (106 lines)

## Modified files

- `simple-markdown.ts` — render `[[title|id]]` as `.kb-internal-link` anchor
- `detail-metadata.ts` — wire click events on `.kb-internal-link` via `wireKbLinks()`
- `quick-note.ts` — attach suggestion to body textarea
- `form-meta-fields.ts` — attach suggestion to note body textarea in edit form
- `kb-browser-view.ts` — handle `opendesk:open-kb-entry` event for navigation
- `kb-extras.css` — add dropdown and internal link styles

## Test plan

- [ ] In KB browser with notes filter active, type `[[` in quick note body → dropdown appears with matching entries
- [ ] Arrow keys navigate dropdown, Enter inserts `[[title|id]]` token, Escape dismisses
- [ ] Save a note with a `[[title|id]]` token; view it in the detail panel → renders as a styled clickable link
- [ ] Click a KB internal link in the note body → detail panel opens for the linked entry
- [ ] Edit an existing note entry via the form → `[[` trigger works in the body textarea

🤖 Generated with [Claude Code](https://claude.com/claude-code)