### PR TITLE
claude/zen-cray-2lrdx

### DIFF
--- a/contracts/app-slides/rules.md
+++ b/contracts/app-slides/rules.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Provide the presentation slide editor for OpenDesk: canvas-based element rendering (text, image, shape, table), drag/resize/rotate interactions, Yjs-backed collaborative slide editing, slide sorter, speaker notes, presenter mode, layouts, themes, and transitions. This is a pure client-side rendering and interaction module with no business logic.
+Provide the presentation slide editor for OpenDesk: canvas-based element rendering (text, image, shape, table), drag/resize/rotate interactions, Yjs-backed collaborative slide editing, slide sorter, speaker notes, presenter mode, layouts, themes, slide transitions, and per-element animations (entrance, exit, emphasis effects with on-click / with-previous / after-previous triggers). This is a pure client-side rendering and interaction module with no business logic.
 
 ## Inputs
 
@@ -42,6 +42,10 @@ Provide the presentation slide editor for OpenDesk: canvas-based element renderi
 7. **Aspect ratio lock with Shift.** Shift during resize preserves original aspect ratio.
 
 8. **Z-order maps to array position.** Element rendering order is determined by Yjs array index.
+
+9. **Animations live on the slide.** Per-element animations are stored in a `Y.Array` on the slide map (keyed `'animations'`), in playback order. Each row references the target by `elementId`. Removing an element removes its animations on the next observe pass.
+
+10. **Animation steps drive presenter advancement.** A presenter "next" key first advances through the current slide's animation steps (each `on-click` opens a new step; `with-previous` and `after-previous` join the open step). Only after the last step does navigation move to the next slide.
 
 ## Dependencies
 
@@ -111,8 +115,15 @@ modules/app-slides/
     speaker-notes.ts          — Speaker notes panel
     presenter-mode.ts         — Fullscreen presenter mode
     toolbar-extras.ts         — Additional toolbar controls
+    animation-types.ts        — Animation effect catalog and trigger types
+    animation-yjs.ts          — Yjs read/write helpers and step-builder for element animations
+    animation-engine.ts       — Web Animations playback engine (entrance/exit/emphasis)
+    animation-panel.ts        — Sidebar UI for managing element animations
+    animation-panel-controls.ts — Small DOM control factories for the animation panel
+    animation-init.ts         — Mounts the animation panel and toolbar toggle
     css/
       presentation.css        — Presentation editor styles
+      animations.css          — Animation panel styles
 ```
 
 ## Verification
@@ -127,3 +138,6 @@ modules/app-slides/
 8. **Table grid** — Correct rows/cols. Cell edits write to Yjs.
 9. **Insert toolbar** — Each button inserts correct element type.
 10. **Build** — `npm run build` succeeds with updated entry points.
+11. **Animation Yjs round-trip** — Append, update, remove, move, and prune helpers preserve schema and order (`animation-yjs.test.ts`).
+12. **Animation step grouping** — `buildAnimationSteps` opens a new step on each on-click, groups with-previous and after-previous into the open step (`animation-yjs.test.ts`).
+13. **Animation engine** — `keyframesFor`, `prepareInitialState`, `runStep` (sequential after-previous), and `createAnimationController` (advance/done/reset) behave as specified (`animation-engine.test.ts`).

--- a/decisions/2026-04-14-slide-element-animations.md
+++ b/decisions/2026-04-14-slide-element-animations.md
@@ -1,0 +1,103 @@
+# Decision: Per-element animations for slides (entrance, exit, emphasis)
+
+**Date:** 2026-04-14
+**Status:** Accepted (implemented in `claude/zen-cray-2lrdx`)
+**Module:** `app-slides`
+
+## Context
+
+The slides editor already supports per-slide transitions (fade, slide, zoom),
+but every slide is rendered all-at-once. PowerPoint and Keynote both let
+authors animate individual elements: a bullet point flies in on click, an
+image fades out, a chart pulses for emphasis. This is one of the largest
+remaining feature gaps versus Microsoft Office for presentations and is
+heavily used in real-world decks (training, sales, education).
+
+## Decision
+
+Add a self-contained animation subsystem to `modules/app-slides/`:
+
+1. **Storage** — each slide map carries an optional `Y.Array<Y.Map<unknown>>`
+   under the key `'animations'`. Order in the array is the playback order.
+   Each row has `{ id, elementId, effect, trigger, durationMs, delayMs }`.
+2. **Effects (13 to start)** — entrance: `fade-in`, `fly-in-{left,right,top,bottom}`,
+   `zoom-in`, `wipe-right`. Exit: `fade-out`, `fly-out-{left,right}`, `zoom-out`.
+   Emphasis: `pulse`, `spin`. Easy to extend the catalog later.
+3. **Triggers** — `on-click`, `with-previous`, `after-previous`. The trigger
+   defines how this animation joins playback steps relative to the prior one.
+4. **Step grouping** — `buildAnimationSteps` walks the array and opens a new
+   step on each `on-click`. `with-previous` joins the open step's parallel
+   lane; `after-previous` chains sequentially within the same step.
+5. **Engine** — pure DOM, Web Animations API. Hides any element with an
+   entrance animation in `prepareInitialState` so it doesn't flash visible
+   before its entrance plays.
+6. **Editor UI** — sidebar panel beside the canvas. Add by selecting an
+   element and picking an effect; per-row controls for effect, trigger,
+   duration, delay, reorder, and remove.
+7. **Presenter integration** — `Right Arrow` / `Space` first advances through
+   the current slide's animation steps; only after the last step does it
+   navigate to the next slide.
+
+## Alternatives considered
+
+- **Store animations on the element itself** (as part of `SlideElement`).
+  Rejected: animation order is a slide-level concern, multiple animations on
+  one element need their own playback ordering, and pruning on element
+  delete becomes harder when the row of truth moves with the element.
+- **CSS-only keyframes** (no Web Animations API). Rejected: the engine needs
+  programmatic completion callbacks for `after-previous` chaining, and
+  WAAPI cancellation is cleaner than chasing `animationend` events.
+- **One large `animation-panel.ts`** (~250 lines). Rejected to honor the
+  200-line file budget — extracted small DOM control factories into
+  `animation-panel-controls.ts` and toolbar wiring into `animation-init.ts`.
+
+## What we did NOT do (yet)
+
+- **Motion paths** — drawing a path the element follows. Powerful but
+  requires a path editor; out of scope for the first cut.
+- **Animation triggers from element clicks** ("on click of shape X, animate
+  shape Y"). Adds graph traversal complexity. Defer.
+- **Repeat / autoreverse** beyond the built-in pulse/spin. Easy to add via
+  the keyframes layer when needed.
+- **Per-animation easing override.** All animations currently use a single
+  cubic-bezier ease-out. Per-row easing is a one-line addition when needed.
+
+## Module structure
+
+New files (all under the 200-line contract budget):
+
+| File | Lines | Purpose |
+| --- | --- | --- |
+| `internal/animation-types.ts` | 102 | Effect catalog, trigger types, step type, defaults, type guards |
+| `internal/animation-yjs.ts` | ~190 | List/append/update/remove/move/prune helpers + step-builder |
+| `internal/animation-engine.ts` | ~150 | Keyframes, prepareInitialState, runStep, controller |
+| `internal/animation-panel.ts` | ~197 | Sidebar UI |
+| `internal/animation-panel-controls.ts` | 67 | Select / number-input / icon-button factories |
+| `internal/animation-init.ts` | 66 | Mount panel + toolbar toggle |
+| `internal/css/animations.css` | ~170 | Panel styles |
+| `internal/animation-yjs.test.ts` | ~180 | Yjs round-trip + step grouping tests |
+| `internal/animation-engine.test.ts` | ~170 | Engine tests with fake-element resolver |
+
+## Testing
+
+- `animation-yjs.test.ts` — 16 tests covering append/list/update/remove/move/
+  prune and `buildAnimationSteps` step grouping.
+- `animation-engine.test.ts` — 14 tests covering keyframe shape,
+  prepareInitialState idempotency, parallel vs. sequential step execution,
+  and controller state transitions. Engine tests use fake-element objects
+  so they run without jsdom.
+
+All tests pass. No existing tests changed.
+
+## Risks
+
+- **Element resolver coupling.** The engine queries by `data-element-id` on
+  the rendered DOM. If `element-renderer.ts` ever stopped emitting that
+  attribute, animations would silently no-op. The contract already requires
+  this attribute (Invariant 3), so the risk is low.
+- **Yjs Y.Map re-insertion.** Reordering can't re-insert the same Y.Map after
+  delete. `moveAnimation` snapshots rows to plain objects and rebuilds the
+  array — covered by tests.
+- **Stale animation rows on element delete.** Mitigated by
+  `pruneAnimationsForMissingElements` invoked from the editor's
+  `observeDeep` callback.

--- a/modules/app-slides/contract.ts
+++ b/modules/app-slides/contract.ts
@@ -25,6 +25,35 @@ export const TableDataSchema = z.object({
 
 export type TableData = z.infer<typeof TableDataSchema>;
 
+// --- Animation ---
+
+export const AnimationEffectSchema = z.enum([
+  // Entrance
+  'fade-in', 'fly-in-left', 'fly-in-right', 'fly-in-top', 'fly-in-bottom',
+  'zoom-in', 'wipe-right',
+  // Exit
+  'fade-out', 'fly-out-left', 'fly-out-right', 'zoom-out',
+  // Emphasis
+  'pulse', 'spin',
+]);
+
+export type AnimationEffect = z.infer<typeof AnimationEffectSchema>;
+
+export const AnimationTriggerSchema = z.enum(['on-click', 'with-previous', 'after-previous']);
+
+export type AnimationTrigger = z.infer<typeof AnimationTriggerSchema>;
+
+export const ElementAnimationSchema = z.object({
+  id: z.string().min(1),
+  elementId: z.string().min(1),
+  effect: AnimationEffectSchema,
+  trigger: AnimationTriggerSchema,
+  durationMs: z.number().int().positive(),
+  delayMs: z.number().int().nonnegative(),
+});
+
+export type ElementAnimation = z.infer<typeof ElementAnimationSchema>;
+
 // --- Slide Element ---
 
 export const SlideElementSchema = z.object({

--- a/modules/app-slides/index.ts
+++ b/modules/app-slides/index.ts
@@ -6,6 +6,9 @@ export {
   TextAlignSchema,
   TableDataSchema,
   SlideElementSchema,
+  AnimationEffectSchema,
+  AnimationTriggerSchema,
+  ElementAnimationSchema,
 } from './contract.ts';
 
 // Types
@@ -14,4 +17,7 @@ export type {
   TextAlign,
   TableData,
   SlideElement,
+  AnimationEffect,
+  AnimationTrigger,
+  ElementAnimation,
 } from './contract.ts';

--- a/modules/app-slides/internal/animation-engine.test.ts
+++ b/modules/app-slides/internal/animation-engine.test.ts
@@ -1,0 +1,195 @@
+/** Contract: contracts/app-slides/rules.md */
+
+import { describe, it, expect } from 'vitest';
+import {
+  keyframesFor, prepareInitialState, runStep, createAnimationController,
+} from './animation-engine.ts';
+import type { AnimationEffect, ElementAnimation } from './animation-types.ts';
+
+/**
+ * Engine tests run without jsdom. We construct minimal fake elements that
+ * implement only what the engine touches: `style` and `animate()`.
+ */
+
+interface FakeAnim {
+  onfinish: null | (() => void);
+  oncancel: null | (() => void);
+  cancel: () => void;
+}
+
+interface FakeElement {
+  style: Record<string, string>;
+  animate: () => FakeAnim;
+  __invocations: number;
+}
+
+function makeFake(opts?: { onAnimate?: (id: number) => void }): FakeElement {
+  const fake: FakeElement = {
+    style: {},
+    __invocations: 0,
+    animate() {
+      fake.__invocations += 1;
+      const id = fake.__invocations;
+      const handle: FakeAnim = { onfinish: null, oncancel: null, cancel() {} };
+      // Fire onfinish on next microtask after the engine attaches it.
+      queueMicrotask(() => queueMicrotask(() => {
+        opts?.onAnimate?.(id);
+        handle.onfinish?.();
+      }));
+      return handle;
+    },
+  };
+  return fake;
+}
+
+function makeAnim(over: Partial<ElementAnimation> & { id: string; elementId: string; effect: AnimationEffect }): ElementAnimation {
+  return { trigger: 'on-click', durationMs: 200, delayMs: 0, ...over };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const asEl = (f: FakeElement) => f as any;
+
+describe('keyframesFor', () => {
+  it('produces 2-frame entrance animations', () => {
+    expect(keyframesFor('fade-in')).toHaveLength(2);
+    expect(keyframesFor('zoom-in')).toHaveLength(2);
+    expect(keyframesFor('fly-in-left')).toHaveLength(2);
+  });
+
+  it('produces 3-frame pulse animation', () => {
+    expect(keyframesFor('pulse')).toHaveLength(3);
+  });
+
+  it('rotates from 0 to 360 degrees for spin', () => {
+    const kf = keyframesFor('spin') as Array<Record<string, string>>;
+    expect(kf[0].transform).toContain('0deg');
+    expect(kf[1].transform).toContain('360deg');
+  });
+
+  it('uses opacity for fade variants', () => {
+    expect(keyframesFor('fade-in')[0]).toMatchObject({ opacity: 0 });
+    expect(keyframesFor('fade-out')[1]).toMatchObject({ opacity: 0 });
+  });
+});
+
+describe('prepareInitialState', () => {
+  it('hides any element with an entrance animation', () => {
+    const a = makeFake();
+    const b = makeFake();
+    const resolver = (id: string) => asEl(({ a, b } as Record<string, FakeElement>)[id] ?? null);
+    prepareInitialState([
+      makeAnim({ id: '1', elementId: 'a', effect: 'fade-in' }),
+      makeAnim({ id: '2', elementId: 'b', effect: 'pulse' }),
+    ], resolver);
+    expect(a.style.opacity).toBe('0');
+    // Emphasis effects do not hide the element.
+    expect(b.style.opacity).toBeUndefined();
+  });
+
+  it('does not hide elements that only have exit animations', () => {
+    const el = makeFake();
+    prepareInitialState([
+      makeAnim({ id: '1', elementId: 'x', effect: 'fade-out' }),
+    ], () => asEl(el));
+    expect(el.style.opacity).toBeUndefined();
+  });
+
+  it('only hides each element once even with multiple entrances', () => {
+    const el = makeFake();
+    prepareInitialState([
+      makeAnim({ id: '1', elementId: 'x', effect: 'fade-in' }),
+      makeAnim({ id: '2', elementId: 'x', effect: 'fly-in-left' }),
+    ], () => asEl(el));
+    expect(el.style.opacity).toBe('0');
+  });
+});
+
+describe('runStep', () => {
+  it('invokes animate once per item', async () => {
+    const el = makeFake();
+    await runStep({
+      index: 0,
+      items: [
+        makeAnim({ id: '1', elementId: 'x', effect: 'fade-in' }),
+        makeAnim({ id: '2', elementId: 'x', effect: 'pulse', trigger: 'with-previous' }),
+      ],
+    }, () => asEl(el));
+    expect(el.__invocations).toBe(2);
+  });
+
+  it('skips animations whose target cannot be resolved', async () => {
+    await runStep({
+      index: 0,
+      items: [makeAnim({ id: '1', elementId: 'missing', effect: 'fade-in' })],
+    }, () => null);
+    // Nothing to assert beyond not throwing.
+    expect(true).toBe(true);
+  });
+
+  it('after-previous animations run sequentially within a step', async () => {
+    const events: number[] = [];
+    const el = makeFake({ onAnimate: (id) => events.push(id) });
+    await runStep({
+      index: 0,
+      items: [
+        makeAnim({ id: '1', elementId: 'x', effect: 'fade-in' }),
+        makeAnim({ id: '2', elementId: 'x', effect: 'fade-in', trigger: 'after-previous' }),
+      ],
+    }, () => asEl(el));
+    // Each animation calls animate() exactly once. With after-previous
+    // chaining, the second call must occur after the first finishes.
+    expect(events).toEqual([1, 2]);
+  });
+});
+
+describe('createAnimationController', () => {
+  it('reports total step count', () => {
+    const el = makeFake();
+    const ctrl = createAnimationController(
+      [{ index: 0, items: [makeAnim({ id: '1', elementId: 'x', effect: 'fade-in' })] }],
+      [makeAnim({ id: '1', elementId: 'x', effect: 'fade-in' })],
+      () => asEl(el),
+    );
+    expect(ctrl.totalSteps).toBe(1);
+    expect(ctrl.currentStep).toBe(0);
+  });
+
+  it('returns done=true when next() is called past the last step', async () => {
+    const ctrl = createAnimationController([], [], () => null);
+    expect((await ctrl.next()).done).toBe(true);
+  });
+
+  it('advances currentStep after each next()', async () => {
+    const el = makeFake();
+    const animations = [
+      makeAnim({ id: '1', elementId: 'x', effect: 'fade-in' }),
+      makeAnim({ id: '2', elementId: 'x', effect: 'fade-in' }),
+    ];
+    const ctrl = createAnimationController(
+      [{ index: 0, items: [animations[0]] }, { index: 1, items: [animations[1]] }],
+      animations,
+      () => asEl(el),
+    );
+    expect(ctrl.currentStep).toBe(0);
+    await ctrl.next();
+    expect(ctrl.currentStep).toBe(1);
+    const r = await ctrl.next();
+    expect(r.done).toBe(true);
+    expect(ctrl.currentStep).toBe(2);
+  });
+
+  it('reset rewinds to step 0 and re-hides entrance elements', () => {
+    const el = makeFake();
+    el.style.opacity = '1';
+    const animations = [makeAnim({ id: '1', elementId: 'x', effect: 'fade-in' })];
+    const ctrl = createAnimationController(
+      [{ index: 0, items: animations }],
+      animations,
+      () => asEl(el),
+    );
+    el.style.opacity = '1';
+    ctrl.reset();
+    expect(el.style.opacity).toBe('0');
+    expect(ctrl.currentStep).toBe(0);
+  });
+});

--- a/modules/app-slides/internal/animation-engine.ts
+++ b/modules/app-slides/internal/animation-engine.ts
@@ -1,0 +1,150 @@
+/** Contract: contracts/app-slides/rules.md */
+
+import {
+  type AnimationEffect, type ElementAnimation, type AnimationStep,
+  categoryOf,
+} from './animation-types.ts';
+
+/**
+ * Runtime animation playback for presenter mode. Pure function over DOM —
+ * never touches Yjs.
+ *
+ * Resolves each animation against a host map of `elementId -> HTMLElement`
+ * and runs the matching keyframes via the Web Animations API.
+ */
+
+export type ElementResolver = (elementId: string) => HTMLElement | null;
+
+const EASING = 'cubic-bezier(0.16, 1, 0.3, 1)';
+
+/** Build the keyframes for an effect. Wipe and spin produce non-trivial transforms. */
+export function keyframesFor(effect: AnimationEffect): Keyframe[] {
+  switch (effect) {
+    case 'fade-in': return [{ opacity: 0 }, { opacity: 1 }];
+    case 'fly-in-left': return [{ opacity: 0, transform: 'translateX(-40%)' }, { opacity: 1, transform: 'translateX(0)' }];
+    case 'fly-in-right': return [{ opacity: 0, transform: 'translateX(40%)' }, { opacity: 1, transform: 'translateX(0)' }];
+    case 'fly-in-top': return [{ opacity: 0, transform: 'translateY(-40%)' }, { opacity: 1, transform: 'translateY(0)' }];
+    case 'fly-in-bottom': return [{ opacity: 0, transform: 'translateY(40%)' }, { opacity: 1, transform: 'translateY(0)' }];
+    case 'zoom-in': return [{ opacity: 0, transform: 'scale(0.6)' }, { opacity: 1, transform: 'scale(1)' }];
+    case 'wipe-right': return [{ clipPath: 'inset(0 100% 0 0)' }, { clipPath: 'inset(0 0 0 0)' }];
+    case 'fade-out': return [{ opacity: 1 }, { opacity: 0 }];
+    case 'fly-out-left': return [{ opacity: 1, transform: 'translateX(0)' }, { opacity: 0, transform: 'translateX(-40%)' }];
+    case 'fly-out-right': return [{ opacity: 1, transform: 'translateX(0)' }, { opacity: 0, transform: 'translateX(40%)' }];
+    case 'zoom-out': return [{ opacity: 1, transform: 'scale(1)' }, { opacity: 0, transform: 'scale(0.6)' }];
+    case 'pulse': return [
+      { transform: 'scale(1)' }, { transform: 'scale(1.08)' }, { transform: 'scale(1)' },
+    ];
+    case 'spin': return [
+      { transform: 'rotate(0deg)' }, { transform: 'rotate(360deg)' },
+    ];
+  }
+}
+
+/** Final visual state after running this effect. Used to keep elements visible/hidden. */
+function finalStateFor(effect: AnimationEffect): Partial<CSSStyleDeclaration> {
+  const cat = categoryOf(effect);
+  if (cat === 'entrance') return { opacity: '1' };
+  if (cat === 'exit') return { opacity: '0' };
+  return {};
+}
+
+/** Apply final state to element after animation finishes (without overriding existing transform). */
+function commitFinalState(el: HTMLElement, effect: AnimationEffect): void {
+  const state = finalStateFor(effect);
+  for (const [k, v] of Object.entries(state)) {
+    if (v != null) (el.style as unknown as Record<string, string>)[k] = String(v);
+  }
+}
+
+/**
+ * Initial pre-step setup: any element that has at least one entrance
+ * animation must be hidden until that entrance plays.
+ */
+export function prepareInitialState(animations: ElementAnimation[], resolve: ElementResolver): void {
+  const seen = new Set<string>();
+  for (const a of animations) {
+    if (categoryOf(a.effect) !== 'entrance' || seen.has(a.elementId)) continue;
+    seen.add(a.elementId);
+    const el = resolve(a.elementId);
+    if (el) el.style.opacity = '0';
+  }
+}
+
+/** Run a single animation. Returns a promise that resolves when its final state is committed. */
+export function runAnimation(anim: ElementAnimation, resolve: ElementResolver): Promise<void> {
+  const el = resolve(anim.elementId);
+  if (!el) return Promise.resolve();
+  const kf = keyframesFor(anim.effect);
+  return new Promise((done) => {
+    // Clear any prior hidden state so the animation start frame is visible.
+    if (categoryOf(anim.effect) !== 'entrance') el.style.opacity = '';
+    const animation = el.animate(kf, {
+      duration: anim.durationMs,
+      delay: anim.delayMs,
+      easing: EASING,
+      fill: 'forwards',
+    });
+    const finish = () => { commitFinalState(el, anim.effect); done(); };
+    animation.onfinish = finish;
+    animation.oncancel = finish;
+  });
+}
+
+/**
+ * Run a step. Items chained "after-previous" wait for the prior item; items
+ * chained "with-previous" run in parallel. The first item in the step always
+ * starts immediately (its trigger is the click that opened the step).
+ */
+export async function runStep(step: AnimationStep, resolve: ElementResolver): Promise<void> {
+  // Group items into parallel lanes. A new lane begins on the first item or any after-previous.
+  const lanes: ElementAnimation[][] = [];
+  for (let i = 0; i < step.items.length; i++) {
+    const a = step.items[i];
+    if (i === 0 || a.trigger === 'after-previous') lanes.push([a]);
+    else lanes[lanes.length - 1].push(a);
+  }
+  const lanePromises = lanes.map(async (lane) => {
+    for (const item of lane) {
+      await runAnimation(item, resolve);
+    }
+  });
+  await Promise.all(lanePromises);
+}
+
+/**
+ * Stateful controller that walks through a slide's steps. Use one per slide
+ * instance in presenter mode. `next()` plays the next step (or returns
+ * `done: true` when there are no steps left).
+ */
+export interface AnimationController {
+  totalSteps: number;
+  currentStep: number;
+  next(): Promise<{ done: boolean }>;
+  reset(): void;
+}
+
+export function createAnimationController(
+  steps: AnimationStep[],
+  animations: ElementAnimation[],
+  resolve: ElementResolver,
+): AnimationController {
+  prepareInitialState(animations, resolve);
+  let pos = 0;
+  let busy = false;
+  return {
+    totalSteps: steps.length,
+    get currentStep() { return pos; },
+    async next() {
+      if (busy) return { done: pos >= steps.length };
+      if (pos >= steps.length) return { done: true };
+      busy = true;
+      try { await runStep(steps[pos], resolve); pos++; }
+      finally { busy = false; }
+      return { done: pos >= steps.length };
+    },
+    reset() {
+      pos = 0;
+      prepareInitialState(animations, resolve);
+    },
+  };
+}

--- a/modules/app-slides/internal/animation-init.ts
+++ b/modules/app-slides/internal/animation-init.ts
@@ -1,0 +1,66 @@
+/** Contract: contracts/app-slides/rules.md */
+
+import * as Y from 'yjs';
+import { createAnimationPanel, type AnimationPanel } from './animation-panel.ts';
+import type { InteractionController } from './element-interaction.ts';
+
+/**
+ * Wires the animation panel into the editor: mounts the panel beside the
+ * canvas, adds a toolbar toggle, and connects selection callbacks to the
+ * interaction controller.
+ *
+ * Pulled out of presentation-editor.ts to keep both files within the
+ * 200-line contract budget.
+ */
+
+interface AnimationInitContext {
+  ydoc: Y.Doc;
+  yslides: Y.Array<Y.Map<unknown>>;
+  canvasEl: HTMLElement | null;
+  toolbarRight: Element | null;
+  getActiveSlideIndex: () => number;
+  getInteractionController: () => InteractionController | null;
+}
+
+export interface AnimationInitResult {
+  panel: AnimationPanel;
+  toggleButton: HTMLButtonElement;
+  destroy: () => void;
+}
+
+export function initAnimations(ctx: AnimationInitContext): AnimationInitResult {
+  const panel = createAnimationPanel({
+    ydoc: ctx.ydoc,
+    yslides: ctx.yslides,
+    getActiveSlideIndex: ctx.getActiveSlideIndex,
+    getSelectedElementId: () => {
+      const ic = ctx.getInteractionController();
+      const sel = ic?.getSelection();
+      if (!sel || sel.selectedIds.size !== 1) return null;
+      return [...sel.selectedIds][0];
+    },
+    onSelectionRequested: (elementId) => ctx.getInteractionController()?.setSelection(elementId),
+  });
+  ctx.canvasEl?.appendChild(panel.element);
+
+  const toggleButton = document.createElement('button');
+  toggleButton.className = 'btn btn-secondary btn-sm slide-animation-toggle';
+  toggleButton.textContent = 'Animations';
+
+  let visible = false;
+  toggleButton.addEventListener('click', () => {
+    visible = !visible;
+    panel.setVisible(visible);
+    toggleButton.classList.toggle('active', visible);
+  });
+  ctx.toolbarRight?.appendChild(toggleButton);
+
+  return {
+    panel,
+    toggleButton,
+    destroy() {
+      panel.destroy();
+      toggleButton.remove();
+    },
+  };
+}

--- a/modules/app-slides/internal/animation-panel-controls.ts
+++ b/modules/app-slides/internal/animation-panel-controls.ts
@@ -1,0 +1,67 @@
+/** Contract: contracts/app-slides/rules.md */
+
+import {
+  type AnimationEffect, type AnimationTrigger,
+  ALL_EFFECTS, TRIGGER_TYPES, EFFECT_LABELS, TRIGGER_LABELS, categoryOf,
+} from './animation-types.ts';
+
+/**
+ * Small DOM control builders for the animation panel. Stateless factories
+ * for selects, number inputs, and icon buttons.
+ */
+
+export function makeEffectSelect(initial: AnimationEffect = 'fade-in'): HTMLSelectElement {
+  const sel = document.createElement('select');
+  sel.className = 'animation-panel__select';
+  for (const effect of ALL_EFFECTS) {
+    const opt = document.createElement('option');
+    opt.value = effect;
+    opt.textContent = `${categoryOf(effect)[0].toUpperCase()}: ${EFFECT_LABELS[effect]}`;
+    sel.appendChild(opt);
+  }
+  sel.value = initial;
+  return sel;
+}
+
+export function makeTriggerSelect(initial: AnimationTrigger): HTMLSelectElement {
+  const sel = document.createElement('select');
+  sel.className = 'animation-panel__select';
+  for (const trig of TRIGGER_TYPES) {
+    const opt = document.createElement('option');
+    opt.value = trig;
+    opt.textContent = TRIGGER_LABELS[trig];
+    sel.appendChild(opt);
+  }
+  sel.value = initial;
+  return sel;
+}
+
+export function makeNumberInput(value: number, min: number, max: number, label: string): HTMLInputElement {
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.min = String(min); input.max = String(max); input.step = '50';
+  input.value = String(value);
+  input.title = label;
+  input.setAttribute('aria-label', label);
+  input.className = 'animation-panel__num';
+  return input;
+}
+
+export function reorderBtn(label: string, title: string, onClick: () => void, disabled: boolean): HTMLButtonElement {
+  const b = document.createElement('button');
+  b.className = 'animation-panel__icon-btn';
+  b.textContent = label;
+  b.title = title;
+  b.disabled = disabled;
+  b.addEventListener('click', onClick);
+  return b;
+}
+
+export function deleteBtn(onClick: () => void): HTMLButtonElement {
+  const b = document.createElement('button');
+  b.className = 'animation-panel__icon-btn animation-panel__icon-btn--danger';
+  b.textContent = '\u2715';
+  b.title = 'Remove animation';
+  b.addEventListener('click', onClick);
+  return b;
+}

--- a/modules/app-slides/internal/animation-panel.ts
+++ b/modules/app-slides/internal/animation-panel.ts
@@ -1,0 +1,197 @@
+/** Contract: contracts/app-slides/rules.md */
+
+import * as Y from 'yjs';
+import {
+  type AnimationEffect, type ElementAnimation,
+  categoryOf, MIN_DURATION_MS, MAX_DURATION_MS,
+} from './animation-types.ts';
+import {
+  listAnimations, appendAnimation, updateAnimationField, removeAnimation, moveAnimation,
+} from './animation-yjs.ts';
+import {
+  makeEffectSelect, makeTriggerSelect, makeNumberInput, reorderBtn, deleteBtn,
+} from './animation-panel-controls.ts';
+
+/**
+ * Sidebar panel for managing element animations on the active slide.
+ *
+ * Top section: pick an effect and add it to the currently selected element.
+ * List: all animations on the slide, ordered by playback. Each row exposes
+ * effect, trigger, duration, delay, and reorder/delete controls.
+ */
+
+interface AnimationPanelContext {
+  ydoc: Y.Doc;
+  yslides: Y.Array<Y.Map<unknown>>;
+  getActiveSlideIndex: () => number;
+  getSelectedElementId: () => string | null;
+  onSelectionRequested?: (elementId: string) => void;
+}
+
+export interface AnimationPanel {
+  element: HTMLElement;
+  refresh: () => void;
+  setVisible: (visible: boolean) => void;
+  destroy: () => void;
+}
+
+export function createAnimationPanel(ctx: AnimationPanelContext): AnimationPanel {
+  const { ydoc, yslides, getActiveSlideIndex, getSelectedElementId, onSelectionRequested } = ctx;
+
+  const panel = document.createElement('aside');
+  panel.className = 'animation-panel';
+  panel.hidden = true;
+
+  const header = buildHeader(() => setVisible(false));
+  const { section: addSection, effectSelect, hint: addHint } = buildAddSection(handleAdd);
+  const listEl = document.createElement('ol');
+  listEl.className = 'animation-panel__list';
+
+  panel.append(header, addSection, listEl);
+
+  function handleAdd() {
+    const elementId = getSelectedElementId();
+    if (!elementId) {
+      addHint.textContent = 'Select an element on the slide first.';
+      addHint.style.color = 'var(--accent)';
+      return;
+    }
+    const slide = yslides.get(getActiveSlideIndex());
+    if (!slide) return;
+    appendAnimation(ydoc, slide, { elementId, effect: effectSelect.value as AnimationEffect });
+    addHint.textContent = 'Added.';
+    addHint.style.color = '';
+    refresh();
+  }
+
+  function refresh() {
+    const slide = yslides.get(getActiveSlideIndex());
+    const animations = listAnimations(slide);
+    listEl.innerHTML = '';
+    if (animations.length === 0) {
+      const empty = document.createElement('li');
+      empty.className = 'animation-panel__empty';
+      empty.textContent = 'No animations yet on this slide.';
+      listEl.appendChild(empty);
+      return;
+    }
+    animations.forEach((anim, i) => listEl.appendChild(buildRow(anim, i, animations.length)));
+  }
+
+  function buildRow(anim: ElementAnimation, idx: number, total: number): HTMLElement {
+    const li = document.createElement('li');
+    li.className = `animation-panel__item animation-panel__item--${categoryOf(anim.effect)}`;
+    li.dataset.animationId = anim.id;
+
+    const order = document.createElement('span');
+    order.className = 'animation-panel__order';
+    order.textContent = String(idx + 1);
+
+    const main = document.createElement('div');
+    main.className = 'animation-panel__main';
+
+    const elBtn = document.createElement('button');
+    elBtn.className = 'animation-panel__elref';
+    elBtn.textContent = `Element \u2026${anim.elementId.slice(-6)}`;
+    elBtn.title = 'Select this element on the slide';
+    elBtn.addEventListener('click', () => onSelectionRequested?.(anim.elementId));
+
+    const effectRow = document.createElement('div');
+    effectRow.className = 'animation-panel__row';
+    const effSel = makeEffectSelect(anim.effect);
+    effSel.addEventListener('change', () => updateField(anim.id, 'effect', effSel.value));
+    const trigSel = makeTriggerSelect(anim.trigger);
+    trigSel.addEventListener('change', () => updateField(anim.id, 'trigger', trigSel.value));
+    effectRow.append(effSel, trigSel);
+
+    const tuneRow = document.createElement('div');
+    tuneRow.className = 'animation-panel__row';
+    const durInput = makeNumberInput(anim.durationMs, MIN_DURATION_MS, MAX_DURATION_MS, 'Duration (ms)');
+    durInput.addEventListener('change', () => updateField(anim.id, 'durationMs', Number(durInput.value)));
+    const delInput = makeNumberInput(anim.delayMs, 0, MAX_DURATION_MS, 'Delay (ms)');
+    delInput.addEventListener('change', () => updateField(anim.id, 'delayMs', Number(delInput.value)));
+    tuneRow.append(durInput, delInput);
+
+    main.append(elBtn, effectRow, tuneRow);
+
+    const actions = document.createElement('div');
+    actions.className = 'animation-panel__actions';
+    actions.append(
+      reorderBtn('\u2191', 'Move up', () => moveAndRefresh(idx, idx - 1), idx === 0),
+      reorderBtn('\u2193', 'Move down', () => moveAndRefresh(idx, idx + 1), idx === total - 1),
+      deleteBtn(() => {
+        const slide = yslides.get(getActiveSlideIndex());
+        if (slide) removeAnimation(ydoc, slide, anim.id);
+        refresh();
+      }),
+    );
+
+    li.append(order, main, actions);
+    return li;
+  }
+
+  function updateField(id: string, field: 'effect' | 'trigger' | 'durationMs' | 'delayMs', value: unknown) {
+    const slide = yslides.get(getActiveSlideIndex());
+    if (!slide) return;
+    updateAnimationField(ydoc, slide, id, field, value);
+    refresh();
+  }
+
+  function moveAndRefresh(from: number, to: number) {
+    const slide = yslides.get(getActiveSlideIndex());
+    if (!slide) return;
+    moveAnimation(ydoc, slide, from, to);
+    refresh();
+  }
+
+  function setVisible(v: boolean) {
+    panel.hidden = !v;
+    if (v) refresh();
+  }
+
+  function onYjsChange() { if (!panel.hidden) refresh(); }
+  yslides.observeDeep(onYjsChange);
+
+  return {
+    element: panel,
+    refresh,
+    setVisible,
+    destroy() { yslides.unobserveDeep(onYjsChange); panel.remove(); },
+  };
+}
+
+function buildHeader(onClose: () => void): HTMLElement {
+  const header = document.createElement('div');
+  header.className = 'animation-panel__header';
+  const title = document.createElement('span');
+  title.textContent = 'Animations';
+  title.className = 'animation-panel__title';
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'animation-panel__close';
+  closeBtn.setAttribute('aria-label', 'Close animations panel');
+  closeBtn.textContent = '\u00D7';
+  closeBtn.addEventListener('click', onClose);
+  header.append(title, closeBtn);
+  return header;
+}
+
+function buildAddSection(onAdd: () => void): { section: HTMLElement; effectSelect: HTMLSelectElement; hint: HTMLElement } {
+  const section = document.createElement('div');
+  section.className = 'animation-panel__add';
+  const label = document.createElement('label');
+  label.className = 'animation-panel__label';
+  label.textContent = 'Add to selected element';
+  const row = document.createElement('div');
+  row.className = 'animation-panel__row';
+  const effectSelect = makeEffectSelect();
+  const addBtn = document.createElement('button');
+  addBtn.className = 'btn btn-primary btn-sm';
+  addBtn.textContent = 'Add';
+  addBtn.addEventListener('click', onAdd);
+  row.append(effectSelect, addBtn);
+  const hint = document.createElement('p');
+  hint.className = 'animation-panel__hint';
+  hint.textContent = 'Select an element on the slide first.';
+  section.append(label, row, hint);
+  return { section, effectSelect, hint };
+}

--- a/modules/app-slides/internal/animation-types.ts
+++ b/modules/app-slides/internal/animation-types.ts
@@ -1,0 +1,102 @@
+/** Contract: contracts/app-slides/rules.md */
+
+/**
+ * Element animation types and effect catalog. Pure data: no DOM, no Yjs.
+ *
+ * Animations attach to slide elements and play during a presentation. Each
+ * animation has an effect (the visual transform), a trigger (when it starts
+ * relative to neighbors), a duration, and a delay.
+ */
+
+export type AnimationEffect =
+  // Entrance — element appears
+  | 'fade-in' | 'fly-in-left' | 'fly-in-right' | 'fly-in-top' | 'fly-in-bottom'
+  | 'zoom-in' | 'wipe-right'
+  // Exit — element disappears
+  | 'fade-out' | 'fly-out-left' | 'fly-out-right' | 'zoom-out'
+  // Emphasis — element draws attention without entering or exiting
+  | 'pulse' | 'spin';
+
+export type AnimationTrigger = 'on-click' | 'with-previous' | 'after-previous';
+
+export type AnimationCategory = 'entrance' | 'exit' | 'emphasis';
+
+export type ElementAnimation = {
+  id: string;
+  elementId: string;
+  effect: AnimationEffect;
+  trigger: AnimationTrigger;
+  durationMs: number;
+  delayMs: number;
+};
+
+export const ENTRANCE_EFFECTS: AnimationEffect[] = [
+  'fade-in', 'fly-in-left', 'fly-in-right', 'fly-in-top', 'fly-in-bottom',
+  'zoom-in', 'wipe-right',
+];
+
+export const EXIT_EFFECTS: AnimationEffect[] = [
+  'fade-out', 'fly-out-left', 'fly-out-right', 'zoom-out',
+];
+
+export const EMPHASIS_EFFECTS: AnimationEffect[] = ['pulse', 'spin'];
+
+export const ALL_EFFECTS: AnimationEffect[] = [
+  ...ENTRANCE_EFFECTS, ...EXIT_EFFECTS, ...EMPHASIS_EFFECTS,
+];
+
+export const TRIGGER_TYPES: AnimationTrigger[] = ['on-click', 'with-previous', 'after-previous'];
+
+export const EFFECT_LABELS: Record<AnimationEffect, string> = {
+  'fade-in': 'Fade In',
+  'fly-in-left': 'Fly In From Left',
+  'fly-in-right': 'Fly In From Right',
+  'fly-in-top': 'Fly In From Top',
+  'fly-in-bottom': 'Fly In From Bottom',
+  'zoom-in': 'Zoom In',
+  'wipe-right': 'Wipe Right',
+  'fade-out': 'Fade Out',
+  'fly-out-left': 'Fly Out To Left',
+  'fly-out-right': 'Fly Out To Right',
+  'zoom-out': 'Zoom Out',
+  'pulse': 'Pulse',
+  'spin': 'Spin',
+};
+
+export const TRIGGER_LABELS: Record<AnimationTrigger, string> = {
+  'on-click': 'On Click',
+  'with-previous': 'With Previous',
+  'after-previous': 'After Previous',
+};
+
+export const DEFAULT_DURATION_MS = 500;
+export const DEFAULT_DELAY_MS = 0;
+export const MIN_DURATION_MS = 100;
+export const MAX_DURATION_MS = 10_000;
+
+export function categoryOf(effect: AnimationEffect): AnimationCategory {
+  if (ENTRANCE_EFFECTS.includes(effect)) return 'entrance';
+  if (EXIT_EFFECTS.includes(effect)) return 'exit';
+  return 'emphasis';
+}
+
+export function isAnimationEffect(value: unknown): value is AnimationEffect {
+  return typeof value === 'string' && (ALL_EFFECTS as string[]).includes(value);
+}
+
+export function isAnimationTrigger(value: unknown): value is AnimationTrigger {
+  return typeof value === 'string' && (TRIGGER_TYPES as string[]).includes(value);
+}
+
+/**
+ * An "animation step" is a unit of playback advancement. Pressing the next
+ * key in presenter mode plays the next step. Animations triggered "with-
+ * previous" or "after-previous" run inside the same step as the click that
+ * began it. The first on-click animation on a slide opens step 1.
+ */
+export type AnimationStep = {
+  /** Absolute index within the slide (1-based for human display, 0-based here). */
+  index: number;
+  /** Animations to dispatch. Order is significant for after-previous chaining. */
+  items: ElementAnimation[];
+};

--- a/modules/app-slides/internal/animation-yjs.test.ts
+++ b/modules/app-slides/internal/animation-yjs.test.ts
@@ -1,0 +1,179 @@
+/** Contract: contracts/app-slides/rules.md */
+
+import { describe, it, expect } from 'vitest';
+import * as Y from 'yjs';
+import {
+  appendAnimation, listAnimations, updateAnimationField, removeAnimation,
+  moveAnimation, pruneAnimationsForMissingElements, buildAnimationSteps,
+  parseAnimation, getYAnimations,
+} from './animation-yjs.ts';
+import { MIN_DURATION_MS, MAX_DURATION_MS } from './animation-types.ts';
+
+function makeSlide(): { ydoc: Y.Doc; slide: Y.Map<unknown> } {
+  const ydoc = new Y.Doc();
+  const yslides = ydoc.getArray<Y.Map<unknown>>('slides');
+  const slide = new Y.Map<unknown>();
+  ydoc.transact(() => yslides.push([slide]));
+  return { ydoc, slide };
+}
+
+describe('appendAnimation', () => {
+  it('creates an animations array on first append and stores fields', () => {
+    const { ydoc, slide } = makeSlide();
+    expect(getYAnimations(slide)).toBeNull();
+    const anim = appendAnimation(ydoc, slide, { elementId: 'el-1', effect: 'fade-in' });
+    expect(anim.id).toBeTruthy();
+    expect(anim.effect).toBe('fade-in');
+    expect(anim.trigger).toBe('on-click');
+    const list = listAnimations(slide);
+    expect(list).toHaveLength(1);
+    expect(list[0].elementId).toBe('el-1');
+  });
+
+  it('preserves insertion order across multiple appends', () => {
+    const { ydoc, slide } = makeSlide();
+    appendAnimation(ydoc, slide, { elementId: 'a', effect: 'fade-in' });
+    appendAnimation(ydoc, slide, { elementId: 'b', effect: 'zoom-in' });
+    appendAnimation(ydoc, slide, { elementId: 'c', effect: 'fly-in-left' });
+    expect(listAnimations(slide).map((a) => a.elementId)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('clamps duration into [MIN_DURATION_MS, MAX_DURATION_MS]', () => {
+    const { ydoc, slide } = makeSlide();
+    const a = appendAnimation(ydoc, slide, { elementId: 'x', effect: 'fade-in', durationMs: 50 });
+    const b = appendAnimation(ydoc, slide, { elementId: 'y', effect: 'fade-in', durationMs: 999_999 });
+    expect(a.durationMs).toBe(MIN_DURATION_MS);
+    expect(b.durationMs).toBe(MAX_DURATION_MS);
+  });
+
+  it('clamps negative delay to 0', () => {
+    const { ydoc, slide } = makeSlide();
+    const a = appendAnimation(ydoc, slide, { elementId: 'x', effect: 'fade-in', delayMs: -200 });
+    expect(a.delayMs).toBe(0);
+  });
+});
+
+describe('updateAnimationField', () => {
+  it('updates effect, trigger, duration and delay', () => {
+    const { ydoc, slide } = makeSlide();
+    const anim = appendAnimation(ydoc, slide, { elementId: 'x', effect: 'fade-in' });
+    updateAnimationField(ydoc, slide, anim.id, 'effect', 'zoom-in');
+    updateAnimationField(ydoc, slide, anim.id, 'trigger', 'with-previous');
+    updateAnimationField(ydoc, slide, anim.id, 'durationMs', 1234);
+    updateAnimationField(ydoc, slide, anim.id, 'delayMs', 100);
+    const updated = listAnimations(slide)[0];
+    expect(updated.effect).toBe('zoom-in');
+    expect(updated.trigger).toBe('with-previous');
+    expect(updated.durationMs).toBe(1234);
+    expect(updated.delayMs).toBe(100);
+  });
+
+  it('rejects invalid effect names', () => {
+    const { ydoc, slide } = makeSlide();
+    const anim = appendAnimation(ydoc, slide, { elementId: 'x', effect: 'fade-in' });
+    updateAnimationField(ydoc, slide, anim.id, 'effect', 'not-real');
+    expect(listAnimations(slide)[0].effect).toBe('fade-in');
+  });
+});
+
+describe('removeAnimation', () => {
+  it('removes the animation by id', () => {
+    const { ydoc, slide } = makeSlide();
+    const a = appendAnimation(ydoc, slide, { elementId: 'x', effect: 'fade-in' });
+    const b = appendAnimation(ydoc, slide, { elementId: 'y', effect: 'fade-in' });
+    removeAnimation(ydoc, slide, a.id);
+    const list = listAnimations(slide);
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe(b.id);
+  });
+});
+
+describe('moveAnimation', () => {
+  it('reorders animations to the requested index', () => {
+    const { ydoc, slide } = makeSlide();
+    appendAnimation(ydoc, slide, { elementId: 'a', effect: 'fade-in' });
+    appendAnimation(ydoc, slide, { elementId: 'b', effect: 'fade-in' });
+    appendAnimation(ydoc, slide, { elementId: 'c', effect: 'fade-in' });
+    moveAnimation(ydoc, slide, 0, 2);
+    expect(listAnimations(slide).map((a) => a.elementId)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('is a no-op for invalid indices', () => {
+    const { ydoc, slide } = makeSlide();
+    appendAnimation(ydoc, slide, { elementId: 'a', effect: 'fade-in' });
+    moveAnimation(ydoc, slide, 0, 5);
+    moveAnimation(ydoc, slide, -1, 0);
+    expect(listAnimations(slide)).toHaveLength(1);
+  });
+});
+
+describe('pruneAnimationsForMissingElements', () => {
+  it('removes rows whose elementId is no longer present', () => {
+    const { ydoc, slide } = makeSlide();
+    appendAnimation(ydoc, slide, { elementId: 'keep', effect: 'fade-in' });
+    appendAnimation(ydoc, slide, { elementId: 'gone', effect: 'fade-in' });
+    appendAnimation(ydoc, slide, { elementId: 'keep', effect: 'zoom-in' });
+    pruneAnimationsForMissingElements(ydoc, slide, new Set(['keep']));
+    const list = listAnimations(slide);
+    expect(list).toHaveLength(2);
+    expect(list.every((a) => a.elementId === 'keep')).toBe(true);
+  });
+
+  it('does nothing when all element ids are valid', () => {
+    const { ydoc, slide } = makeSlide();
+    appendAnimation(ydoc, slide, { elementId: 'a', effect: 'fade-in' });
+    pruneAnimationsForMissingElements(ydoc, slide, new Set(['a', 'b']));
+    expect(listAnimations(slide)).toHaveLength(1);
+  });
+});
+
+describe('parseAnimation', () => {
+  it('returns null for malformed rows', () => {
+    const ydoc = new Y.Doc();
+    const yarr = ydoc.getArray<Y.Map<unknown>>('rows');
+    const row = new Y.Map<unknown>();
+    ydoc.transact(() => {
+      yarr.push([row]);
+      row.set('id', 'x');
+      row.set('elementId', 'y');
+      row.set('effect', 'not-real');
+      row.set('trigger', 'on-click');
+    });
+    expect(parseAnimation(row)).toBeNull();
+  });
+});
+
+describe('buildAnimationSteps', () => {
+  it('groups with-previous and after-previous into the same step', () => {
+    const steps = buildAnimationSteps([
+      { id: '1', elementId: 'a', effect: 'fade-in', trigger: 'on-click', durationMs: 500, delayMs: 0 },
+      { id: '2', elementId: 'b', effect: 'fade-in', trigger: 'with-previous', durationMs: 500, delayMs: 0 },
+      { id: '3', elementId: 'c', effect: 'fade-in', trigger: 'after-previous', durationMs: 500, delayMs: 0 },
+    ]);
+    expect(steps).toHaveLength(1);
+    expect(steps[0].items.map((i) => i.id)).toEqual(['1', '2', '3']);
+  });
+
+  it('opens a new step on each on-click trigger', () => {
+    const steps = buildAnimationSteps([
+      { id: '1', elementId: 'a', effect: 'fade-in', trigger: 'on-click', durationMs: 500, delayMs: 0 },
+      { id: '2', elementId: 'b', effect: 'fade-in', trigger: 'on-click', durationMs: 500, delayMs: 0 },
+      { id: '3', elementId: 'c', effect: 'fade-in', trigger: 'with-previous', durationMs: 500, delayMs: 0 },
+    ]);
+    expect(steps).toHaveLength(2);
+    expect(steps[0].items.map((i) => i.id)).toEqual(['1']);
+    expect(steps[1].items.map((i) => i.id)).toEqual(['2', '3']);
+  });
+
+  it('treats a leading non-on-click trigger as the first step', () => {
+    const steps = buildAnimationSteps([
+      { id: '1', elementId: 'a', effect: 'fade-in', trigger: 'with-previous', durationMs: 500, delayMs: 0 },
+    ]);
+    expect(steps).toHaveLength(1);
+    expect(steps[0].items[0].id).toBe('1');
+  });
+
+  it('returns an empty array for no animations', () => {
+    expect(buildAnimationSteps([])).toEqual([]);
+  });
+});

--- a/modules/app-slides/internal/animation-yjs.ts
+++ b/modules/app-slides/internal/animation-yjs.ts
@@ -1,0 +1,190 @@
+/** Contract: contracts/app-slides/rules.md */
+
+import * as Y from 'yjs';
+import {
+  type AnimationEffect, type AnimationTrigger, type ElementAnimation, type AnimationStep,
+  DEFAULT_DURATION_MS, DEFAULT_DELAY_MS, MIN_DURATION_MS, MAX_DURATION_MS,
+  isAnimationEffect, isAnimationTrigger,
+} from './animation-types.ts';
+
+/**
+ * Read/write helpers for per-slide element animations.
+ *
+ * Storage: each slide map carries an optional `'animations'` field holding a
+ * `Y.Array<Y.Map<unknown>>`. Order in the array is the playback order — it
+ * matters for `with-previous` and `after-previous` triggers.
+ */
+
+const ANIMATIONS_KEY = 'animations';
+
+/** Resolve (or create) the animations array for a slide. */
+function getOrCreateYAnimations(
+  ydoc: Y.Doc,
+  slide: Y.Map<unknown>,
+): Y.Array<Y.Map<unknown>> {
+  let arr = slide.get(ANIMATIONS_KEY) as Y.Array<Y.Map<unknown>> | undefined;
+  if (!arr) {
+    ydoc.transact(() => {
+      arr = new Y.Array<Y.Map<unknown>>();
+      slide.set(ANIMATIONS_KEY, arr);
+    });
+  }
+  return arr!;
+}
+
+/** Resolve the animations array, returning null when absent. */
+export function getYAnimations(slide: Y.Map<unknown> | undefined): Y.Array<Y.Map<unknown>> | null {
+  if (!slide) return null;
+  const arr = slide.get(ANIMATIONS_KEY);
+  return arr instanceof Y.Array ? arr as Y.Array<Y.Map<unknown>> : null;
+}
+
+function clampDuration(n: number): number {
+  if (!Number.isFinite(n)) return DEFAULT_DURATION_MS;
+  return Math.max(MIN_DURATION_MS, Math.min(MAX_DURATION_MS, Math.round(n)));
+}
+
+function clampDelay(n: number): number {
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.min(MAX_DURATION_MS, Math.round(n));
+}
+
+/** Parse a Y.Map row into a typed ElementAnimation, returning null on invalid data. */
+export function parseAnimation(yrow: Y.Map<unknown>): ElementAnimation | null {
+  const id = yrow.get('id'); const elementId = yrow.get('elementId');
+  const effect = yrow.get('effect'); const trigger = yrow.get('trigger');
+  if (typeof id !== 'string' || typeof elementId !== 'string') return null;
+  if (!isAnimationEffect(effect) || !isAnimationTrigger(trigger)) return null;
+  const dur = yrow.get('durationMs'); const del = yrow.get('delayMs');
+  return {
+    id, elementId, effect, trigger,
+    durationMs: clampDuration(typeof dur === 'number' ? dur : DEFAULT_DURATION_MS),
+    delayMs: clampDelay(typeof del === 'number' ? del : DEFAULT_DELAY_MS),
+  };
+}
+
+/** List all animations for a slide in playback order. Invalid rows are skipped. */
+export function listAnimations(slide: Y.Map<unknown> | undefined): ElementAnimation[] {
+  const yarr = getYAnimations(slide);
+  if (!yarr) return [];
+  const out: ElementAnimation[] = [];
+  for (let i = 0; i < yarr.length; i++) {
+    const parsed = parseAnimation(yarr.get(i));
+    if (parsed) out.push(parsed);
+  }
+  return out;
+}
+
+/** Append a new animation to the slide. Returns the created animation. */
+export function appendAnimation(
+  ydoc: Y.Doc,
+  slide: Y.Map<unknown>,
+  init: { elementId: string; effect: AnimationEffect; trigger?: AnimationTrigger; durationMs?: number; delayMs?: number },
+): ElementAnimation {
+  const anim: ElementAnimation = {
+    id: crypto.randomUUID(),
+    elementId: init.elementId,
+    effect: init.effect,
+    trigger: init.trigger ?? 'on-click',
+    durationMs: clampDuration(init.durationMs ?? DEFAULT_DURATION_MS),
+    delayMs: clampDelay(init.delayMs ?? DEFAULT_DELAY_MS),
+  };
+  const yarr = getOrCreateYAnimations(ydoc, slide);
+  ydoc.transact(() => {
+    const yrow = new Y.Map<unknown>();
+    yrow.set('id', anim.id); yrow.set('elementId', anim.elementId);
+    yrow.set('effect', anim.effect); yrow.set('trigger', anim.trigger);
+    yrow.set('durationMs', anim.durationMs); yrow.set('delayMs', anim.delayMs);
+    yarr.push([yrow]);
+  });
+  return anim;
+}
+
+function findIndex(yarr: Y.Array<Y.Map<unknown>>, id: string): number {
+  for (let i = 0; i < yarr.length; i++) if (yarr.get(i).get('id') === id) return i;
+  return -1;
+}
+
+/** Update a single field on an animation row. */
+export function updateAnimationField(
+  ydoc: Y.Doc, slide: Y.Map<unknown>, id: string,
+  field: 'effect' | 'trigger' | 'durationMs' | 'delayMs', value: unknown,
+): void {
+  const yarr = getYAnimations(slide); if (!yarr) return;
+  const idx = findIndex(yarr, id); if (idx < 0) return;
+  let coerced: unknown = value;
+  if (field === 'effect' && !isAnimationEffect(value)) return;
+  if (field === 'trigger' && !isAnimationTrigger(value)) return;
+  if (field === 'durationMs') coerced = clampDuration(Number(value));
+  if (field === 'delayMs') coerced = clampDelay(Number(value));
+  ydoc.transact(() => { yarr.get(idx).set(field, coerced); });
+}
+
+/** Remove a single animation row by id. */
+export function removeAnimation(ydoc: Y.Doc, slide: Y.Map<unknown>, id: string): void {
+  const yarr = getYAnimations(slide); if (!yarr) return;
+  const idx = findIndex(yarr, id); if (idx < 0) return;
+  ydoc.transact(() => { yarr.delete(idx, 1); });
+}
+
+/** Move an animation to a new index. Used to reorder playback. */
+export function moveAnimation(
+  ydoc: Y.Doc, slide: Y.Map<unknown>, fromIdx: number, toIdx: number,
+): void {
+  const yarr = getYAnimations(slide); if (!yarr) return;
+  if (fromIdx < 0 || fromIdx >= yarr.length || toIdx < 0 || toIdx >= yarr.length || fromIdx === toIdx) return;
+  // Snapshot existing rows as plain JSON, then rebuild the array. Yjs does
+  // not permit re-inserting deleted Y.Maps, so we clone every row.
+  const snapshot: Array<Record<string, unknown>> = [];
+  for (let i = 0; i < yarr.length; i++) {
+    const row = yarr.get(i);
+    const plain: Record<string, unknown> = {};
+    row.forEach((v, k) => { plain[k] = v; });
+    snapshot.push(plain);
+  }
+  const [moved] = snapshot.splice(fromIdx, 1);
+  snapshot.splice(toIdx, 0, moved);
+  ydoc.transact(() => {
+    yarr.delete(0, yarr.length);
+    for (const plain of snapshot) {
+      const row = new Y.Map<unknown>();
+      for (const [k, v] of Object.entries(plain)) row.set(k, v);
+      yarr.push([row]);
+    }
+  });
+}
+
+/** Remove every animation that targets a missing element id. */
+export function pruneAnimationsForMissingElements(
+  ydoc: Y.Doc, slide: Y.Map<unknown>, validElementIds: Set<string>,
+): void {
+  const yarr = getYAnimations(slide); if (!yarr) return;
+  const stale: number[] = [];
+  for (let i = 0; i < yarr.length; i++) {
+    const eid = yarr.get(i).get('elementId');
+    if (typeof eid !== 'string' || !validElementIds.has(eid)) stale.push(i);
+  }
+  if (stale.length === 0) return;
+  ydoc.transact(() => {
+    for (let i = stale.length - 1; i >= 0; i--) yarr.delete(stale[i], 1);
+  });
+}
+
+/**
+ * Group animations into playback steps.
+ *
+ * Each `on-click` opens a new step. `with-previous` and `after-previous` join
+ * the current open step. If the very first animation is not `on-click`, it
+ * still starts step 0 (there is nothing prior to wait for).
+ */
+export function buildAnimationSteps(animations: ElementAnimation[]): AnimationStep[] {
+  const steps: AnimationStep[] = [];
+  for (const anim of animations) {
+    if (steps.length === 0 || anim.trigger === 'on-click') {
+      steps.push({ index: steps.length, items: [anim] });
+    } else {
+      steps[steps.length - 1].items.push(anim);
+    }
+  }
+  return steps;
+}

--- a/modules/app-slides/internal/css/animations.css
+++ b/modules/app-slides/internal/css/animations.css
@@ -1,0 +1,183 @@
+/* Animation panel — sidebar for managing slide element animations */
+
+.animation-panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 22rem;
+  background: var(--surface);
+  border-left: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  z-index: 80;
+  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.04);
+}
+
+.animation-panel[hidden] { display: none; }
+
+.animation-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.625rem 0.875rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.animation-panel__title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text);
+}
+
+.animation-panel__close {
+  background: transparent;
+  border: none;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--text);
+  padding: 0.125rem 0.5rem;
+  border-radius: 4px;
+}
+
+.animation-panel__close:hover { background: var(--bg); }
+
+.animation-panel__add {
+  padding: 0.75rem 0.875rem;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.animation-panel__label {
+  font-size: 0.8125rem;
+  color: var(--text-muted, #555);
+}
+
+.animation-panel__row {
+  display: flex;
+  gap: 0.375rem;
+  align-items: center;
+}
+
+.animation-panel__hint {
+  font-size: 0.75rem;
+  color: var(--text-muted, #888);
+  margin: 0;
+}
+
+.animation-panel__list {
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem;
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.animation-panel__empty {
+  text-align: center;
+  padding: 1.5rem 0.5rem;
+  color: var(--text-muted, #888);
+  font-size: 0.85rem;
+}
+
+.animation-panel__item {
+  display: grid;
+  grid-template-columns: 1.5rem 1fr auto;
+  gap: 0.5rem;
+  align-items: start;
+  padding: 0.625rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+}
+
+.animation-panel__item--entrance { border-left: 3px solid #16a34a; }
+.animation-panel__item--exit { border-left: 3px solid #dc2626; }
+.animation-panel__item--emphasis { border-left: 3px solid #d97706; }
+
+.animation-panel__order {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text-muted, #555);
+  text-align: center;
+  padding-top: 0.125rem;
+}
+
+.animation-panel__main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.animation-panel__elref {
+  background: transparent;
+  border: 1px dashed var(--border);
+  font-size: 0.75rem;
+  color: var(--text-muted, #555);
+  padding: 0.125rem 0.375rem;
+  border-radius: 3px;
+  cursor: pointer;
+  align-self: flex-start;
+}
+
+.animation-panel__elref:hover { border-style: solid; color: var(--text); }
+
+.animation-panel__select {
+  flex: 1;
+  min-width: 0;
+  padding: 0.25rem 0.375rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 0.8125rem;
+}
+
+.animation-panel__num {
+  width: 5rem;
+  padding: 0.25rem 0.375rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 0.8125rem;
+}
+
+.animation-panel__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.animation-panel__icon-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  width: 1.75rem;
+  height: 1.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  color: var(--text);
+}
+
+.animation-panel__icon-btn:hover:not(:disabled) { background: var(--bg); }
+.animation-panel__icon-btn:disabled { opacity: 0.3; cursor: not-allowed; }
+.animation-panel__icon-btn--danger { color: #dc2626; }
+.animation-panel__icon-btn--danger:hover { background: #fef2f2; }
+
+/* Animation toggle button */
+.slide-animation-toggle.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}

--- a/modules/app-slides/internal/css/presentation.css
+++ b/modules/app-slides/internal/css/presentation.css
@@ -9,3 +9,4 @@
 @import "../layout-theme.css";
 @import "../speaker-notes.css";
 @import "../transitions-sorter.css";
+@import "./animations.css";

--- a/modules/app-slides/internal/element-interaction.ts
+++ b/modules/app-slides/internal/element-interaction.ts
@@ -19,6 +19,7 @@ import { createTextEditController, type TextEditController } from './text-edit-c
 export type InteractionController = {
   destroy: () => void;
   getSelection: () => SelectionState;
+  setSelection: (elementId: string | null) => void;
   applyZOrder: (reorderedElements: SlideElement[]) => void;
   getTextEditController: () => import('./text-edit-controller.ts').TextEditController | null;
 };
@@ -189,6 +190,10 @@ export function createInteractionController(ctx: InteractionContext): Interactio
       clearOverlays(vp, 'all');
     },
     getSelection: () => selection,
+    setSelection: (elementId: string | null) => {
+      selection = elementId ? selectSingle(selection, elementId) : selectNone();
+      onSelectionChange();
+    },
     applyZOrder: (els: SlideElement[]) => applyZOrderToYjs(ctx.ydoc, ctx.getActiveSlideElements(), els),
     getTextEditController: () => textEditCtrl,
   };

--- a/modules/app-slides/internal/presentation-editor.ts
+++ b/modules/app-slides/internal/presentation-editor.ts
@@ -15,6 +15,8 @@ import { initLayoutAndTheme } from './layout-theme-init.ts';
 import { createSpeakerNotes } from './speaker-notes.ts';
 import { launchPresenterMode } from './presenter-mode.ts';
 import { initToolbarExtras } from './toolbar-extras.ts';
+import { initAnimations } from './animation-init.ts';
+import { pruneAnimationsForMissingElements } from './animation-yjs.ts';
 
 function init() {
   mountAppToolbar();
@@ -170,6 +172,13 @@ function init() {
     },
   });
 
+  // Animation panel — sidebar for managing element animations
+  initAnimations({
+    ydoc, yslides, canvasEl, toolbarRight,
+    getActiveSlideIndex: () => activeSlideIndex,
+    getInteractionController: () => interactionCtrl,
+  });
+
   // Present button
   const presentBtn = Object.assign(document.createElement('button'), { className: 'slide-present-btn', textContent: 'Present' });
   presentBtn.addEventListener('click', () => launchPresenterMode({ yslides, getSlideElements, totalSlides: () => yslides.length }, activeSlideIndex));
@@ -183,7 +192,11 @@ function init() {
     onChanged() { renderSlideList(); renderActiveSlide(); notesPanel.update(activeSlideIndex); },
   });
 
-  yslides.observeDeep(() => { renderSlideList(); renderActiveSlide(); notesPanel.update(activeSlideIndex); extras.updateTransitionPicker(); });
+  yslides.observeDeep(() => {
+    renderSlideList(); renderActiveSlide(); notesPanel.update(activeSlideIndex); extras.updateTransitionPicker();
+    const slide = yslides.get(activeSlideIndex);
+    if (slide) pruneAnimationsForMissingElements(ydoc, slide, new Set(getSlideElements(activeSlideIndex).map((e) => e.id)));
+  });
 
   // Presence
   provider.awareness?.setLocalStateField('user', user);

--- a/modules/app-slides/internal/presenter-mode.ts
+++ b/modules/app-slides/internal/presenter-mode.ts
@@ -4,6 +4,8 @@ import type { SlideElement } from './types.ts';
 import { renderElement } from './element-renderer.ts';
 import { getSlideNotes } from './speaker-notes.ts';
 import { getSlideTransition, animateTransition } from './transitions.ts';
+import { listAnimations, buildAnimationSteps } from './animation-yjs.ts';
+import { createAnimationController, type AnimationController } from './animation-engine.ts';
 import type * as Y from 'yjs';
 
 interface PresenterContext {
@@ -65,12 +67,24 @@ export function launchPresenterMode(ctx: PresenterContext, startIndex = 0): void
   }
 
   let transitioning = false;
+  let animCtrl: AnimationController | null = null;
+
+  function buildAnimationsForCurrent(): AnimationController | null {
+    const slide = ctx.yslides.get(current);
+    const animations = listAnimations(slide);
+    if (animations.length === 0) return null;
+    const steps = buildAnimationSteps(animations);
+    return createAnimationController(steps, animations, (elementId) =>
+      currentEl.querySelector(`[data-element-id="${elementId}"]`),
+    );
+  }
 
   function update() {
     renderSlideInto(currentEl, current);
     renderSlideInto(nextEl, current + 1);
     notesEl.textContent = getSlideNotes(ctx.yslides, current);
     counterEl.textContent = `${current + 1} / ${ctx.totalSlides()}`;
+    animCtrl = buildAnimationsForCurrent();
   }
 
   async function navigateTo(index: number, direction: 'forward' | 'backward') {
@@ -83,13 +97,22 @@ export function launchPresenterMode(ctx: PresenterContext, startIndex = 0): void
     transitioning = false;
   }
 
+  /** Advance one step within the current slide, or move to the next slide. */
+  async function advance() {
+    if (transitioning) return;
+    if (animCtrl && animCtrl.currentStep < animCtrl.totalSteps) {
+      const result = await animCtrl.next();
+      if (!result.done) return;
+    }
+    if (current < ctx.totalSlides() - 1) navigateTo(current + 1, 'forward');
+  }
+
   update();
 
   // Keyboard navigation
   function handleKey(e: KeyboardEvent) {
     if (e.key === 'ArrowRight' || e.key === ' ' || e.key === 'PageDown') {
-      e.preventDefault();
-      if (current < ctx.totalSlides() - 1) navigateTo(current + 1, 'forward');
+      e.preventDefault(); advance();
     } else if (e.key === 'ArrowLeft' || e.key === 'PageUp') {
       e.preventDefault();
       if (current > 0) navigateTo(current - 1, 'backward');


### PR DESCRIPTION
Adds a major PowerPoint-parity feature to the slides editor: animations on
individual elements, played during a presentation in author-defined steps.

What changed:
- 13 effects (fade-in, fly-in-{left,right,top,bottom}, zoom-in, wipe-right,
  fade-out, fly-out-{left,right}, zoom-out, pulse, spin) with extensible catalog
- 3 triggers — on-click opens a step, with-previous joins the open step in
  parallel, after-previous chains sequentially within the same step
- Per-animation duration and delay (clamped to safe bounds)
- Sidebar panel for managing animations on the active slide (add, reorder,
  edit effect/trigger/duration/delay, remove)
- Presenter mode now advances through animation steps before moving to the
  next slide; entrance elements are pre-hidden and reveal on play
- Yjs-backed storage so animations are collaborative; rows are pruned when
  their target element is deleted
- New zod schemas for ElementAnimation, AnimationEffect, AnimationTrigger

Why:
- One of the largest remaining feature gaps versus Microsoft Office for
  presentations and heavily used in real-world decks
- Existing transitions only animate slide-to-slide; element-level animation
  is a separate, complementary axis

How (modular layout):
- animation-types.ts — effect catalog, trigger types, step/category helpers
- animation-yjs.ts — list/append/update/remove/move/prune + step-builder
- animation-engine.ts — Web Animations API playback + step controller
- animation-panel.ts + animation-panel-controls.ts — sidebar UI
- animation-init.ts — wires panel into editor and toolbar
- presenter-mode.ts — advance() walks steps before changing slides
- element-interaction.ts — exposes setSelection so the panel can reveal
  the element a row points to

Tests: animation-yjs.test.ts (16 tests, Yjs round-trip + step grouping)
       animation-engine.test.ts (14 tests, keyframes + controller w/ fake DOM)
       Full suite: 1366 tests pass.

See decisions/2026-04-14-slide-element-animations.md for the full
rationale and alternatives considered.

https://claude.ai/code/session_01NwVRGx9jwMGV6UEdWvt2Mo