### PR TITLE
feat(parity): office-parity sprint — contracts, skeletons, Yjs offline

### DIFF
--- a/contracts/app-admin/policy.md
+++ b/contracts/app-admin/policy.md
@@ -1,0 +1,109 @@
+# Contract: app-admin/policy
+
+## Purpose
+
+Admin control-plane UI for workspace-wide governance policies: retention, export restrictions, DLP keyword rules, watermark templates, sensitivity labels, and branding. This is a sub-contract of `contracts/app-admin/rules.md`. It adds a "Policy" tab to the existing admin dashboard.
+
+Policy *enforcement* lives in other modules (`erasure`, `audit`, `sharing`, `convert`). This module only renders and edits policy documents; it never enforces them.
+
+## Inputs
+
+- `GET /api/admin/policies` — returns the current `WorkspacePolicy` document for the active workspace
+- `PUT /api/admin/policies` — persists an edited `WorkspacePolicy`
+- User interactions: tab activation, field edits, save, discard, preview
+
+## Outputs
+
+- Rendered "Policy" tab with sections: Retention, Export, DLP, Watermarks, Sensitivity Labels, Branding
+- Client-side validation errors surfaced inline
+- Success/error toasts on save
+
+## Side Effects
+
+- HTTP PUT to `/api/admin/policies` on save
+- Emits `WorkspacePolicyUpdated` event via the backend (not the UI's responsibility to emit; just to display after save)
+
+## Invariants
+
+1. **Render-only.** The UI never evaluates policies against content. Enforcement is a server-side concern.
+2. **One policy document per workspace.** The admin UI edits a single `WorkspacePolicy` per workspace. Multi-policy layering (e.g. per-department overrides) is post-MVP.
+3. **No mock data.** Real API responses only, matching parent `app-admin/rules.md`.
+4. **XSS-safe.** All dynamic fields (keyword lists, watermark text, label names) escaped via `escapeHtml()` before DOM insertion.
+5. **Optimistic concurrency.** The policy document carries an `updated_at` timestamp. PUT requests that lose a concurrent-edit race return 409 and the UI shows a reload prompt.
+6. **Restricted-zone bridges.** When a policy field has enforcement implications in a restricted module (`auth`, `permissions`, `sharing`), the UI MUST render a read-only banner explaining that the field requires a human-maintainer deploy to take effect.
+
+## Policy Shape
+
+```ts
+WorkspacePolicy = {
+  workspace_id: string
+  retention: {
+    documents_days: number | null     // null = forever
+    audit_days: number | null
+    erasure_grace_days: number
+  }
+  export: {
+    allowed_formats: Array<'pdf' | 'docx' | 'odt' | 'xlsx' | 'ods' | 'pptx' | 'odp'>
+    require_approval_over_mb: number | null
+  }
+  dlp: {
+    blocked_keywords: string[]        // case-insensitive substring match, server-side
+    blocked_regex: string[]            // RE2-safe patterns only
+    action: 'warn' | 'block'
+  }
+  watermark: {
+    enabled: boolean
+    text_template: string              // supports {user}, {date}, {doc}
+    opacity: number                    // 0.05..0.5
+  }
+  sensitivity_labels: Array<{
+    id: string
+    name: string
+    color: string                      // hex
+    export_blocked: boolean
+  }>
+  branding: {
+    logo_url: string | null
+    accent_hex: string | null
+    product_name_override: string | null
+  }
+  updated_at: string                   // ISO 8601
+}
+```
+
+## Dependencies
+
+- `app-admin/rules.md` (parent)
+- `@opendesk/app` — `apiFetch`, `escapeHtml`
+- `audit` — policy edits MUST be audited server-side (not the UI's job; flagged here so reviewers see it)
+
+## Boundary Rules
+
+### MUST
+
+- Render every section as an independent panel; each panel saves the full policy document (server MAY diff)
+- Validate numeric ranges client-side before PUT (watermark opacity, retention days ≥ 0)
+- Show a "Last updated by {user} at {time}" header from the `updated_at` field
+- Keep every file under 200 lines (split section panels into separate files)
+
+### MUST NOT
+
+- Evaluate DLP keywords against any content in the browser (server enforces)
+- Enforce retention by deleting anything from the UI
+- Call restricted-zone modules (`auth`, `permissions`, `sharing`) directly
+- Ship default keyword or regex lists that could be mistaken for legal advice
+
+## Verification
+
+1. **Round-trip** — load policy, edit retention, save, reload; assert values persisted.
+2. **Optimistic concurrency** — two tabs edit the same policy, second save receives 409; UI shows reload prompt.
+3. **Validation** — enter opacity=2.0, assert inline error and save disabled.
+4. **Escape** — inject `<img onerror>` into a keyword, assert no script executes and literal characters render.
+5. **Restricted banner** — sensitivity label linked to `permissions` enforcement shows the read-only banner.
+
+## Out of Scope (Post-MVP)
+
+- Per-department / per-team policy overlays
+- Policy versioning and rollback UI (the server audit log covers history; dedicated UI is post-MVP)
+- Policy import/export (JSON round-trip)
+- Policy simulation ("would this policy have blocked the last 100 exports?")

--- a/contracts/app/offline.md
+++ b/contracts/app/offline.md
@@ -36,6 +36,9 @@ Provide offline-first capabilities for OpenDesk: service worker caching of stati
 5. **CRDT merge on reconnect.** Yjs handles document merge automatically via CRDT. No manual conflict resolution is needed. The offline module only manages the connection indicator, not Yjs sync.
 6. **LRU eviction.** API response cache has a size limit. Oldest entries are evicted when the limit is reached.
 7. **Graceful degradation.** If service workers or IndexedDB are unavailable, the app works normally without offline support. No errors thrown.
+8. **Yjs document persistence.** The Yjs `Doc` bound to each open editor MUST be mirrored to IndexedDB via a local persistence provider. Updates applied while offline are written locally before any network send, so a reload during a disconnect does not lose work. On reopen, the local store is replayed into the `Doc` before the Hocuspocus provider connects, so the state vector sent to the server already contains offline edits.
+9. **Reconnect merge contract.** On `provider.on('connect')`, the client MUST NOT clear its local persistence until the provider emits `synced`. The merge order is: (a) replay IndexedDB into `Doc`, (b) open WebSocket, (c) Yjs sync protocol exchanges state vectors, (d) server and client converge via CRDT, (e) local store receives new updates and persists them. No step may be skipped or reordered.
+10. **Per-document IndexedDB database.** Each document MUST use an isolated IndexedDB database keyed by `opendesk-yjs-<documentId>` so that clearing one document's offline state does not affect others. Workspace-level erasure (see `modules/erasure`) MUST be able to enumerate and drop these databases.
 
 ## Dependencies
 
@@ -50,11 +53,12 @@ Provide offline-first capabilities for OpenDesk: service worker caching of stati
 ```
 modules/app/internal/
   public/sw.js                    -- Service worker (plain JS, not bundled)
-  shell/
+  offline/
     sw-register.ts                -- SW registration + update notification
     offline-indicator.ts          -- Connection status UI component
     offline-storage.ts            -- IndexedDB helpers for document cache + state
     sync-manager.ts               -- Mutation queue + background flush
+    yjs-persistence.ts            -- Per-document IndexedDB provider for Yjs docs
   css/
     offline.css                   -- Offline indicator + update banner styles
 ```
@@ -68,3 +72,6 @@ modules/app/internal/
 5. **Mutation queue** -- Create/delete document offline, reconnect. Queued mutations replay.
 6. **LRU eviction** -- Cache many API responses, verify oldest are evicted past limit.
 7. **Graceful degradation** -- Disable service workers in browser, verify app works normally.
+8. **Yjs offline persistence** -- Open doc, disconnect, type N paragraphs, reload page while still disconnected, verify paragraphs are still present in the editor.
+9. **Yjs reconnect merge** -- With two clients A and B online, disconnect A, edit both A (offline) and B (online), reconnect A, verify both sets of edits are present in both clients' `Doc` after `synced`.
+10. **Per-document isolation** -- Edit doc X and Y offline, drop doc X's IndexedDB database, verify doc Y's offline state is untouched.

--- a/contracts/diagrams/rules.md
+++ b/contracts/diagrams/rules.md
@@ -1,0 +1,98 @@
+# Contract: diagrams
+
+## Purpose
+
+Vector diagramming editor (Visio / draw.io parity): compose flowcharts, org charts, network diagrams, BPMN, sequence diagrams, and ER diagrams using a shape library, connectors that auto-route, multi-page canvases, and layered export to SVG, PNG, and PDF. Diagrams are first-class OpenDesk content with their own editor URL (`/diagram/:id`) and Yjs-backed co-authoring.
+
+Diagrams embed into `Documents` and `Slides` as live references (edit once, updates propagate) via the `kb` reference-resolution mechanism — a diagram is a KB entry of type `diagram`.
+
+## Inputs
+
+- User actions: add shape, drag, resize, rotate, connect, edit text, change style, change layer
+- `DiagramDefinition` JSON (persisted as Yjs doc): shapes, connectors, layers, pages, style tokens
+- Shape library: built-in (flowchart, BPMN, network, UML) plus workspace-provided custom libraries
+
+## Outputs
+
+- `DiagramDefinition` persisted to `storage`
+- Rendered SVG for embedding and export; rasterized PNG via server-side renderer; PDF via `convert`
+- KB entry of type `diagram` with render preview for inclusion in other content types
+- `DiagramUpdated` event on save
+
+## Side Effects
+
+- Yjs co-authoring via the existing `collab` infrastructure
+- Writes to `storage`
+- Server-side SVG→PNG rasterization on export (headless renderer; no external fonts fetched)
+- Emits events via `events`; audits via `audit`
+- Registers a KB entry on first save; updates the entry on subsequent saves
+
+## Invariants
+
+1. **Vector-native.** Diagrams are stored as structured shapes and connectors, not as rasterized pixels. PNG is only a derivative.
+2. **Deterministic rendering.** The same `DiagramDefinition` MUST produce byte-identical SVG output given the same shape library version. Server and client renderers share a pinned rendering spec.
+3. **Connectors are logical.** A connector references source and target shape IDs, not coordinates. Moving a shape updates the connector automatically. Dangling connectors (source or target missing) render as red dashed placeholders and surface a validator warning.
+4. **Layer ordering is explicit.** Every shape belongs to exactly one layer; z-order within a layer is explicit. No implicit z-index based on insertion order.
+5. **Style tokens.** Colors, fonts, and stroke widths reference workspace style tokens (shared with Slides themes). Changing a token updates all diagrams consistently.
+6. **Bounded shape counts.** A single diagram page caps at 2,000 shapes (performance guardrail). Multi-page diagrams spread beyond this.
+7. **No external font fetches.** Rendered SVG/PNG uses embedded fonts only; external `@font-face` URLs are stripped on export.
+8. **KB sync.** The diagram's KB entry is updated atomically with the save; the entry carries the SVG preview, not the full definition.
+9. **Accessibility.** Every shape supports an `alt_text` field. Exports include `<title>` and `<desc>` per shape for screen readers.
+
+## Dependencies
+
+- `core`
+- `storage`
+- `collab` — Yjs co-authoring
+- `events`
+- `audit`
+- `kb` — diagrams appear as KB entries of type `diagram`; enables insertion into Documents/Slides via existing pickers
+- `convert` — PDF export
+- `app-admin/policy` — export-format allowlist, size caps
+
+## Boundary Rules
+
+### MUST
+
+- Persist shapes with stable IDs (connectors resolve by ID, never by index)
+- Round-trip SVG export without loss of logical structure (`DiagramDefinition → SVG → DiagramDefinition` via import recovers an equivalent document, up to style-token resolution)
+- Use the same stable-block-ID targeting pattern as `collab` intents for any agent-driven edits
+- Strip external resource URLs on export
+- Keep every file under 200 lines; shape renderers live in per-type files
+
+### MUST NOT
+
+- Store diagrams as flattened SVG blobs (structured JSON only)
+- Fetch external shape libraries at render time (all libraries are workspace-registered and cached)
+- Depend on browser-only APIs in the server-side renderer (use a headless SVG engine or a pinned rasterizer)
+- Embed arbitrary HTML in shapes (use a restricted text-formatting subset shared with Slides)
+
+## Verification
+
+1. **Shape ID stability** — create connector between A and B, delete and recreate A at the same visual position (different ID), assert connector reports dangling.
+2. **Deterministic render** — render the same definition on client and server, assert byte-identical SVG (after whitespace normalization).
+3. **No external fetch** — export diagram referencing `@font-face` URL, monitor renderer network, assert no outbound request.
+4. **Layer order** — create shapes A and B with explicit z-order, assert render respects it regardless of insertion order.
+5. **Token propagation** — change accent style token, re-render existing diagram, assert shapes using that token update.
+6. **Shape cap** — attempt to add the 2,001st shape to a page, assert refused with `CAPACITY`.
+7. **KB sync atomicity** — save diagram, query KB entry, assert preview and revision match within the same transaction.
+8. **Accessibility** — export diagram with alt text, assert `<title>` / `<desc>` present in SVG.
+
+## MVP Scope
+
+Implemented (targeted):
+- [ ] `DiagramDefinition` Zod schema
+- [ ] Yjs-backed co-authoring
+- [ ] Built-in shape libraries: flowchart, BPMN-lite, network, UML class
+- [ ] Auto-routing connectors (orthogonal, straight)
+- [ ] Multi-page diagrams
+- [ ] SVG/PNG/PDF export
+- [ ] KB entry registration
+- [ ] Insertion pickers in Documents and Slides
+
+Post-MVP (deferred):
+- [ ] Full BPMN 2.0 validation
+- [ ] Swimlane auto-layout
+- [ ] Live data binding (diagrams that read from KB datasets)
+- [ ] Animated diagrams
+- [ ] Third-party shape library federation

--- a/contracts/esign/rules.md
+++ b/contracts/esign/rules.md
@@ -1,0 +1,104 @@
+# Contract: esign
+
+## Purpose
+
+Sovereign e-signature workflows: prepare a signing packet, invite signers with ordered or parallel signing, collect signatures via a signing ceremony that proves identity and intent, embed signatures into the PDF, and produce a tamper-evident audit trail that stands up to legal review (eIDAS, E-SIGN Act, PIPEDA).
+
+Signing is cryptographic; identity is pluggable (OIDC, SMS OTP via sovereign provider, or workspace-trusted principal). Long-term validation (LTV) uses timestamps from a workspace-configured TSA.
+
+## Inputs
+
+- `SigningPacket`: { document_id, signers[], order, expiration }
+- Signer invitations delivered via email/webhook (email delivery is scaffolded but not a hard dependency — invites can also surface in-app)
+- Signing-ceremony inputs: identity challenge response, consent affirmation, signed field positions
+- A TSA (Time-Stamping Authority) URL configured at the workspace level
+
+## Outputs
+
+- Signed PDF with embedded PKCS#7 (CAdES-T or PAdES-LTV) signatures
+- `SigningAuditTrail` — an append-only, HMAC-chained log (reusing `audit` infrastructure) of: invite sent, invite opened, identity challenge, field positioned, intent affirmed, signature applied, certificate used, TSA response
+- `esign.Completed` event upon full packet execution
+
+## Side Effects
+
+- Writes to `storage` (signed PDFs, packet state)
+- Writes to `audit` (every ceremony step)
+- Calls the configured TSA over HTTPS at signature time
+- Invokes `pdf-edit` to place signature fields
+- Invokes `notifications` (in-app) and optionally an outbound mailer hook (configurable)
+
+## Invariants
+
+1. **Intent is required.** Every signature requires an affirmative "I agree" action. A checkbox pre-ticked by the author does NOT count. The affirmation text is recorded in the audit trail.
+2. **Identity challenge is required.** At least one identity challenge (OIDC login, OTP, or trusted-principal session) completes successfully before a signature can be applied. The challenge type and result are audited.
+3. **Signatures are cryptographic.** Every signature is a PKCS#7 detached signature over the document's byte range, not an image of a signature. Image-style visual marks are permitted only as a visual representation of the cryptographic signature.
+4. **Tamper evidence.** After signing, any modification to the signed byte range breaks the signature. Subsequent incremental saves (annotations, additional signatures) are accepted; pre-signed bytes are never rewritten.
+5. **Timestamp every signature.** A TSA timestamp is requested for every signature. If the TSA is unreachable and the workspace policy requires TSA, the signature fails; policies that permit deferred timestamping enqueue a retry.
+6. **Certificate source is auditable.** The signing certificate's issuer, subject, fingerprint, and validity window are recorded. Self-signed certificates are permitted only if workspace policy allows them.
+7. **Order enforcement.** Sequential packets do not present the document to signer N+1 until signer N has completed.
+8. **Expiration kills the packet.** After `expiration`, the packet is marked expired, no further signatures are accepted, and the audit trail records the timeout.
+9. **Revocation before completion.** The packet owner can revoke before all signatures are collected. Already-applied signatures remain valid on a truncated packet; the audit trail records revocation and who signed before it.
+10. **No silent re-sends.** Every invite re-send is a new audited event with a new token. Prior tokens are invalidated.
+
+## Dependencies
+
+- `core`
+- `storage` — packets, signed PDFs
+- `audit` — signing audit trail (separate chain per packet)
+- `pdf-edit` — signature field placement
+- `events`
+- `auth` — principal resolution for in-app signers
+- `notifications` — in-app invites
+- `app-admin/policy` — TSA URL, allowed cert issuers, self-signed allowance
+
+## Boundary Rules
+
+### MUST
+
+- Record every ceremony step in the signing audit trail with a monotonic index and HMAC chaining
+- Use PKCS#7 detached signatures embedded in the PDF via incremental save
+- Request a TSA timestamp on every signature (subject to policy)
+- Invalidate old invite tokens on re-send
+- Enforce signer order for sequential packets
+- Capture user-agent, IP, and principal on every ceremony step
+- Generate signing tokens with ≥256 bits of entropy
+
+### MUST NOT
+
+- Apply a signature without an explicit intent affirmation
+- Accept a signature if the identity challenge failed or is missing
+- Re-serialize or rewrite pre-signed byte ranges
+- Depend on a cloud-only TSA — workspaces MUST be able to self-host (e.g., FreeTSA-compatible)
+- Leak invite tokens in referrer headers (signing pages disable Referer)
+- Use weak hash algorithms (SHA-1 or below) anywhere in the signature chain
+- Store private keys for the signer (workspace-held certs are for the workspace itself, e.g., witness-signing)
+
+## Verification
+
+1. **Intent required** — attempt to apply a signature without affirmation, assert 400 and audit log records the block.
+2. **Identity required** — skip identity step in the ceremony, assert signature refused.
+3. **Tamper evidence** — sign PDF, mutate one byte in the signed range, assert signature verification fails.
+4. **TSA timestamp** — sign with TSA configured, extract signature, assert timestamp token present and verifiable.
+5. **Order enforcement** — sequential packet, attempt signer 2 before signer 1, assert refused.
+6. **Expiration** — set expiration to past, attempt to sign, assert refused with `EXPIRED` code.
+7. **Revocation** — revoke mid-packet, attempt to sign, assert refused; already-applied signatures still verify.
+8. **Audit chain integrity** — mutate a row in the signing audit table, run verification, assert tamper detected.
+9. **Token rotation** — re-send invite, assert prior token rejected.
+
+## MVP Scope
+
+Implemented (targeted):
+- [ ] `SigningPacket` CRUD
+- [ ] In-app signing ceremony (identity via OIDC session)
+- [ ] PKCS#7 signature embed via `pdf-edit`
+- [ ] TSA client (RFC 3161)
+- [ ] Per-packet audit chain
+- [ ] Sequential and parallel packets
+- [ ] Expiration and revocation
+
+Post-MVP (deferred):
+- [ ] SMS-OTP identity challenge (requires sovereign SMS provider)
+- [ ] Knowledge-based authentication (KBA) — deliberation needed, high abuse potential
+- [ ] Bulk-send templates
+- [ ] Long-term validation re-timestamping (LTA) worker
+- [ ] Cross-border compliance packs (eIDAS qualified signatures, Swiss ZertES)

--- a/contracts/forms/rules.md
+++ b/contracts/forms/rules.md
@@ -1,0 +1,101 @@
+# Contract: forms
+
+## Purpose
+
+Form builder and response collector: compose typed surveys (single-line, paragraph, choice, checkbox, scale, date, file upload), share a response link, collect responses into a KB dataset, and view aggregated results. Closes the Microsoft Forms / Google Forms gap.
+
+Forms are OpenDesk-native content (like Documents, Sheets, Slides) but structurally simpler — a flat list of typed questions plus display metadata.
+
+## Inputs
+
+- **Author side**:
+  - `FormDefinition` JSON — authored via the form builder UI; persisted as a Yjs document for real-time co-authoring
+  - Question types: `short_text`, `long_text`, `single_choice`, `multi_choice`, `scale`, `date`, `file_upload`, `email`, `number`
+  - Validation rules per question: required, min/max length, regex (RE2-safe), choice constraints
+
+- **Respondent side**:
+  - `FormResponse` submission — JSON payload keyed by question ID, validated against the live `FormDefinition`
+  - Optional auth principal (forms may be anonymous, authenticated-only, or link-guarded)
+
+## Outputs
+
+- `FormDefinition` persisted to `storage` with its own ID space (`frm_...`)
+- `FormResponse` rows persisted to Postgres (`form_responses` table) AND mirrored into a linked KB dataset (bi-directional with `modules/kb`)
+- Aggregated results view: counts, histograms, CSV export
+- Share link with role (`view_results | respond | owner`) via `modules/sharing`
+
+## Side Effects
+
+- Emits `FormPublished`, `FormResponseSubmitted`, `FormClosed` events via `events`
+- Writes to the audit log (`audit`) on every definition change and response submission
+- Creates a KB dataset entry when a form is first published; appends rows as responses arrive
+
+## Invariants
+
+1. **Schema versioning on responses.** Every `FormResponse` records the `FormDefinition.version` it was submitted against. Later schema changes never invalidate past responses.
+2. **Required = server-enforced.** Client-side validation is a UX courtesy; the API rejects responses missing required fields regardless of client behavior.
+3. **Anonymous is opt-in.** A form MUST default to authenticated-only. Anonymous mode is an explicit toggle, logged as a definition change.
+4. **One response per respondent (optional).** When the author sets `single_response = true`, authenticated respondents are keyed by principal and subsequent submissions update their prior response; anonymous forms cannot enforce this and the UI must warn.
+5. **File uploads are S3-backed.** `file_upload` answers store an S3 object reference, never inline bytes. Max file size is workspace-policy-bounded (see `app-admin/policy`).
+6. **KB dataset parity.** The linked KB dataset's column schema MUST match the `FormDefinition`. Column schema migrations use the same version key as responses.
+7. **Closed forms are immutable and write-blocked.** After `close_at` passes or the author closes the form, all POST `/responses` calls return 410.
+8. **Erasure participation.** Responses participate in GDPR erasure via `modules/erasure` — tombstone the response, keep the definition.
+
+## Dependencies
+
+- `core` — shared primitives
+- `storage` — `FormDefinition` blobs and `form_responses` rows
+- `events` — event emission
+- `audit` — mutation audit
+- `kb` — response dataset sync
+- `sharing` — share-link creation and role enforcement
+- `erasure` — participates in cascade erasure
+- `auth` — principal resolution for authenticated submissions
+
+## Boundary Rules
+
+### MUST
+
+- Validate every incoming `FormResponse` against the current `FormDefinition` schema (Zod)
+- Record `definition_version` on every response row
+- Emit `FormResponseSubmitted` inside the same transaction as the row insert
+- Honor `single_response` idempotency keyed by principal ID
+- Reject file uploads above `export.require_approval_over_mb` until approved by policy
+- Cap the number of questions per form at 250 (performance guardrail)
+
+### MUST NOT
+
+- Store file bytes in Postgres (S3 only)
+- Accept submissions after `close_at` (respond with 410)
+- Mutate historic responses when the definition changes
+- Evaluate respondent regex validation server-side using unbounded regex engines (RE2-style only)
+- Return other respondents' answers via the respondent API (only authors/viewers see results)
+
+## Verification
+
+1. **Schema versioning** — publish v1, collect response, publish v2 with altered question, assert v1 response is still readable and the view distinguishes versions.
+2. **Required enforcement** — submit a response missing a required field via raw API, assert 400.
+3. **single_response idempotency** — authenticated user submits twice, assert the first row is updated, not duplicated.
+4. **File size cap** — upload file above policy threshold, assert 413.
+5. **Closed form rejection** — close form, attempt POST, assert 410.
+6. **KB dataset parity** — add a question, publish, assert linked dataset's column schema updates.
+7. **Erasure cascade** — erase a user, assert their responses are tombstoned and aggregate counts reflect the removal.
+8. **Audit coverage** — every definition change and response appears in the audit log with principal attribution.
+
+## MVP Scope
+
+Implemented (targeted):
+- [ ] `FormDefinition` Zod schema + Yjs-backed co-authoring
+- [ ] Nine question types listed above
+- [ ] Public respondent page (anonymous + authenticated)
+- [ ] Aggregated results view with CSV export
+- [ ] KB dataset mirror
+- [ ] Share-link integration
+
+Post-MVP (deferred):
+- [ ] Conditional branching (show-if)
+- [ ] Multi-page forms with progress bar
+- [ ] Response quotas and stop rules
+- [ ] Form templates library
+- [ ] Payment collection
+- [ ] reCAPTCHA-equivalent bot protection (sovereign alternative — deliberation required)

--- a/contracts/pdf-edit/rules.md
+++ b/contracts/pdf-edit/rules.md
@@ -1,0 +1,93 @@
+# Contract: pdf-edit
+
+## Purpose
+
+Native PDF annotation and form-fill editor. Today OpenDesk only *converts* PDFs (via `convert`/Collabora); this module lets users open a PDF, draw annotations (highlight, underline, strike, freehand, text box, stamp), fill AcroForm and XFA fields, redact regions, and save back as a valid PDF without round-tripping through LibreOffice.
+
+This is a complement to — not a replacement for — `convert`. Conversion remains the path for `docx ↔ pdf`; this module is for editing PDFs as PDFs.
+
+## Inputs
+
+- Source PDF bytes from `storage` (uploaded or converted)
+- User actions: annotate, fill field, redact region, sign block placement (delegates the signature ceremony to `esign`)
+- Save command — produces a new PDF derived from the source
+
+## Outputs
+
+- `PdfAnnotationLayer` — a Yjs-backed overlay document that holds annotations as structured objects (not baked into the PDF until save)
+- On save: a new PDF with annotations flattened OR preserved as incremental-save annotations (author choice)
+- Redacted PDF with content removed from the content stream (not just visually obscured)
+
+## Side Effects
+
+- Reads and writes to `storage`
+- Emits `PdfAnnotated`, `PdfRedacted`, `PdfSaved` events
+- Writes audit entries for every redaction (redactions are irreversible and must be provable)
+- May invoke `convert` when the source is not a PDF (e.g., opening a .docx in annotate mode — convert first, then annotate)
+
+## Invariants
+
+1. **Annotations are overlays until save.** Annotations live in a Yjs overlay document co-authored in real time. The underlying PDF bytes are immutable until the user explicitly saves.
+2. **Redactions remove content.** A redaction MUST remove the underlying glyphs/images from the PDF content stream, not merely draw a black box. This is verified by a post-save text-extraction pass that asserts the redacted string is absent.
+3. **Incremental save by default.** The saved PDF uses PDF incremental update (append) so the original signed byte range, if any, remains valid. Flattening is opt-in.
+4. **Signature fields are delegated.** This module places and visualizes signature fields; it does NOT compute signatures. Actual signing is owned by `esign`.
+5. **Form fields preserve metadata.** AcroForm field values survive save. Field name, type, and flags are never mutated without author confirmation.
+6. **No JavaScript execution.** PDF embedded JavaScript is stripped on open and never re-serialized.
+7. **No font exfiltration.** External font URLs referenced by the PDF are never fetched; only embedded fonts render. Missing fonts fall back to a bundled permissive font.
+8. **File size cap.** Sources above the workspace's `export.require_approval_over_mb` threshold require admin approval before opening (policy bridge).
+
+## Dependencies
+
+- `core`
+- `storage` — source and saved PDFs
+- `collab` — Yjs co-authoring of the annotation overlay
+- `events`
+- `audit` — redactions and saves
+- `esign` — signature placement delegates to this module
+- `convert` — non-PDF sources are converted first
+- `app-admin/policy` — size caps and redaction policy
+
+## Boundary Rules
+
+### MUST
+
+- Strip embedded JavaScript from opened PDFs
+- Validate incremental updates preserve the original byte range
+- Audit every redaction with region coordinates and principal
+- Use a pinned, sandbox-safe PDF parser (deliberation required before choosing — see Out of Scope)
+- Verify redacted text is absent via a text-extraction check before returning success
+
+### MUST NOT
+
+- Fetch external resources referenced by the PDF (fonts, images, JS, form submit URLs)
+- Silently alter AcroForm field names or flags
+- Bake annotations during every edit — only at save time
+- Execute any script, Lua, or post-script instructions embedded in the PDF
+- Store PDF bytes in Postgres (S3 only; metadata in Postgres)
+
+## Verification
+
+1. **Redaction removes content** — redact region with known text, save, extract text via independent tool, assert redacted string is absent.
+2. **Incremental save integrity** — open signed PDF, add annotation, save incrementally, assert original signature byte range still validates.
+3. **JavaScript strip** — open PDF with embedded JS, assert serialized output has no `/JavaScript` or `/JS` actions.
+4. **External fetch block** — open PDF with external font URL, monitor network, assert no outbound request.
+5. **Form field preservation** — fill AcroForm field, save, reopen, assert value retained and flags unchanged.
+6. **Overlay isolation** — two users annotate the same PDF, assert overlays merge via CRDT without corrupting source bytes.
+7. **Audit redaction** — perform redaction, query audit log, assert entry with coordinates + principal.
+
+## MVP Scope
+
+Implemented (targeted):
+- [ ] Open PDF, render page by page (canvas)
+- [ ] Annotations: highlight, underline, strike, freehand, text box
+- [ ] AcroForm field fill
+- [ ] Redaction with content-stream removal
+- [ ] Incremental save and flatten-on-save options
+- [ ] Co-authoring of the annotation overlay via Yjs
+
+Post-MVP (deferred):
+- [ ] XFA form support (XFA is being phased out by Adobe; revisit only if customer demand)
+- [ ] OCR of scanned PDFs (defer — consider integration with sovereign OCR stack)
+- [ ] PDF/A-3 export compliance
+- [ ] Annotation templates and stamps library
+- [ ] Collaborative review rounds with accept/reject

--- a/contracts/plugins/rules.md
+++ b/contracts/plugins/rules.md
@@ -1,0 +1,99 @@
+# Contract: plugins
+
+## Purpose
+
+Public extension API for third-party additions to OpenDesk. Exposes a safe surface for hooks (on-save, on-export, on-share, on-KB-update), toolbar buttons, sidebar panels, and custom workflow actions. Execution reuses the Wasm sandbox already built for `workflow` (Extism/Wasmtime), so plugins inherit memory, CPU, and capability limits.
+
+This module exposes the API; it does not implement the sandbox (that lives in `workflow`). Think of `plugins` as the discovery, registration, and host-binding layer; `workflow` is the execution engine.
+
+## Inputs
+
+- `PluginManifest` JSON — declares name, version, entry module (Wasm or ES module for UI plugins), hook subscriptions, toolbar contributions, sidebar panels, required capabilities
+- Host events (hook dispatches) from other modules via `events`
+- User actions: install, uninstall, enable, disable, configure
+
+## Outputs
+
+- `InstalledPlugin` records persisted to Postgres
+- Hook dispatches to registered plugins (fan-out on matching events)
+- Rendered toolbar buttons and sidebar panels in the app shell
+- `PluginInstalled`, `PluginExecuted`, `PluginFailed` events
+
+## Side Effects
+
+- Loads Wasm modules via the `workflow` sandbox at hook-dispatch time
+- Loads UI plugin ES modules dynamically (code-split) in the browser — origin-pinned to the workspace's plugin CDN or same-origin
+- Writes to `audit` on install, uninstall, and every hook invocation (invocation audit is sampled above N/minute to avoid log flood)
+
+## Invariants
+
+1. **Capability-based permissions.** Every hook and every host API call requires a declared capability in the manifest. The server verifies declared capabilities match the actual calls; undeclared calls are refused.
+2. **Wasm sandboxing for server-side plugins.** Server hooks run in the `workflow` Wasm sandbox with per-plugin memory and CPU caps. No network, filesystem, or process access except through host-granted APIs.
+3. **Signed manifests.** Published plugins carry an Ed25519 signature over the manifest by the workspace's trusted publisher set. Unsigned plugins are allowed only in "developer mode", gated by workspace policy.
+4. **UI plugin origin pinning.** Browser ES modules for UI plugins are loaded only from the workspace's configured plugin origin (default: same origin). Cross-origin sources are refused.
+5. **Isolation across workspaces.** A plugin installed in workspace A cannot observe events or state in workspace B. The host API scopes every query and event subscription by workspace_id.
+6. **Timeouts are mandatory.** Hook invocations have a per-plugin timeout (default 2s). Plugins that exceed it are force-terminated and the hook proceeds as if the plugin did not participate.
+7. **Non-blocking failure mode.** Plugin failures MUST NOT block the host operation. A failing on-save hook does not prevent save; the failure is audited and surfaced in the admin UI.
+8. **Versioned host API.** The host API exposed to plugins is versioned (`@opendesk/host@1`). Breaking changes require a new major version; the host supports the last two majors concurrently.
+9. **Capability scope for KB.** KB-touching plugins must declare `kb.read` and/or `kb.write` with corpus restrictions (`knowledge | operational | reference`). Writes honor jurisdiction isolation.
+10. **No privileged escalation via workflows.** A plugin cannot register a workflow action that exceeds its declared capabilities; the workflow registrar enforces capability intersection.
+
+## Dependencies
+
+- `core`
+- `workflow` — Wasm execution engine (required at runtime)
+- `events` — hook dispatch
+- `audit` — install and invocation audit
+- `storage` — manifest and installed-plugin records
+- `app-admin/policy` — developer mode, trusted publishers, plugin origin
+- `kb` — when plugins declare KB capabilities, read/write is brokered via `kb`'s public API
+
+## Boundary Rules
+
+### MUST
+
+- Validate `PluginManifest` against a pinned Zod schema before install
+- Verify Ed25519 signature against the workspace trust store (unless developer mode explicitly allows unsigned)
+- Register the plugin's declared capabilities as a capability set attached to every hook invocation
+- Enforce per-plugin timeouts, memory caps, and CPU caps on every invocation
+- Emit `PluginExecuted` / `PluginFailed` events for every invocation (sampled above threshold)
+- Rate-limit install/uninstall actions per workspace (anti-thrash)
+
+### MUST NOT
+
+- Expose raw database, filesystem, or process APIs to plugins
+- Allow plugin code to read environment variables or secrets
+- Forward plugin network requests without a host-side allowlist
+- Run UI plugins from cross-origin sources without explicit policy approval
+- Persist plugin-provided code inside Postgres blobs — use `storage` (S3) with content-hash integrity
+
+## Verification
+
+1. **Capability enforcement** — plugin declares only `document.read`, attempts `document.write`, assert refused.
+2. **Wasm sandbox limits** — plugin allocates beyond memory cap, assert terminated with `OOM`.
+3. **Unsigned refusal** — install unsigned plugin with developer mode off, assert refused.
+4. **Signed accept** — install plugin signed by trusted publisher, assert installed.
+5. **Origin pinning** — attempt to load UI plugin from cross-origin URL, assert refused.
+6. **Workspace isolation** — plugin installed in A subscribes to document events, create event in B, assert plugin does not see B.
+7. **Timeout enforcement** — plugin loops indefinitely on hook, assert terminated after default timeout.
+8. **Non-blocking failure** — plugin throws on on-save hook, assert save still completes.
+9. **Audit coverage** — install, invoke, uninstall plugin, assert every step audited with principal.
+10. **Host API version** — plugin declares host API v1, host runs v2, assert compatibility shim engaged and deprecation warning logged.
+
+## MVP Scope
+
+Implemented (targeted):
+- [ ] `PluginManifest` Zod schema
+- [ ] Install/uninstall/enable/disable lifecycle
+- [ ] Ed25519 signature verification against a workspace trust store
+- [ ] Hook dispatch via `events` → `workflow` Wasm sandbox
+- [ ] Toolbar-button and sidebar-panel contribution points (UI)
+- [ ] Capability enforcement
+- [ ] Invocation audit
+
+Post-MVP (deferred):
+- [ ] Plugin marketplace / discovery UI
+- [ ] Paid plugin licensing
+- [ ] Plugin update auto-rollout with canary
+- [ ] Cross-plugin messaging (bus between plugins)
+- [ ] Cryptographic plugin isolation beyond Wasm (gVisor-style second layer)

--- a/docs/mvp.md
+++ b/docs/mvp.md
@@ -282,6 +282,83 @@ Full dependency analysis: `decisions/2026-04-06-pillar-sequencing-deliberation.m
 
 ---
 
+---
+
+## Office-Parity Sprint (branch `claude/office-parity-improvements-g2HTi`)
+
+Tracking a sweep of improvements to close feature gaps with Microsoft 365. Non-goal: feature-for-feature cloning. Goal: remove "but Office has X" blockers for regulated-sector adopters. Ordered by impact below, but implemented in the order dependencies allow.
+
+### Landed this sprint (contracts + skeletons)
+
+Contracts written (implementations staged — mostly in-memory stores and stubs so routes/UI can wire against a stable interface):
+
+- `contracts/forms/rules.md` + `modules/forms/` — form builder, respondent page, KB dataset mirror, schema-versioned responses, S3-backed file uploads, close/expire semantics.
+- `contracts/pdf-edit/rules.md` + `modules/pdf-edit/` — native PDF annotation, AcroForm fill, content-stream redaction, incremental save. Signatures delegated to `esign`. JS strip and no external fetches by contract.
+- `contracts/esign/rules.md` + `modules/esign/` — PKCS#7 signing ceremony with HMAC-chained audit trail, RFC 3161 TSA timestamps, sequential/parallel packets, revocation, expiration.
+- `contracts/plugins/rules.md` + `modules/plugins/` — public extension API. Reuses `workflow`'s Wasm sandbox. Capability-based, signed manifests, origin-pinned UI plugins, timeouts mandatory, non-blocking failure.
+- `contracts/diagrams/rules.md` + `modules/diagrams/` — vector diagramming (Visio/draw.io parity). Shapes + connectors by stable ID, KB entry of type `diagram`, deterministic SVG rendering, 2000-shape-per-page cap.
+- `contracts/app-admin/policy.md` + `modules/app-admin/internal/policy/` — workspace policy control plane (retention, export, DLP, watermark, sensitivity labels, branding). UI renders + saves; enforcement lives in other modules.
+
+Offline-sync wiring (partial completion of item 7):
+
+- `contracts/app/offline.md` — extended with Yjs persistence invariants (§8–§10), reconnect merge order, and per-document IndexedDB isolation.
+- `modules/app/internal/offline/yjs-persistence.ts` — per-document IndexedDB provider for Yjs `Doc`s. Replays prior updates into the doc BEFORE Hocuspocus opens a socket so the state-vector sent on sync already contains offline edits. Graceful degradation when IndexedDB is unavailable. Compaction every 200 updates.
+- Wired into `modules/app/internal/editor/editor.ts` init sequence.
+
+### Still to do on this sprint
+
+**Offline-sync (item 7)** — most of the infra is now in place. Remaining:
+
+- [ ] Mirror the Yjs persistence hook into the Sheets editor (`modules/app/internal/editor/sheet.ts` or equivalent) and the Slides editor. Documents is done.
+- [ ] Hook `modules/erasure` into `YjsPersistenceHandle.clear()` so workspace/user erasure drops local caches too.
+- [ ] Playwright test: edit offline, reload while offline, assert content still present; then reconnect and assert server converges.
+- [ ] Yjs reconnect merge stress test with two browser contexts (one offline, one online).
+- [ ] Complete service-worker route caching for `/api/documents/:id/snapshot` (currently cache covers list only).
+
+**Module implementations (MVP-real, replacing skeletons)**
+
+- [ ] `forms` — Postgres-backed store, Yjs co-authored `FormDefinition`, respondent page, KB dataset mirror, share-link integration, audit + erasure cascade.
+- [ ] `pdf-edit` — choose a sandbox-safe PDF parser (requires deliberation; candidates: `pdf-lib` for writes, `pdfjs-dist` for render) and pin it. Content-stream redaction. Ed25519-signed incremental save option.
+- [ ] `esign` — Postgres-backed audit chain, RFC 3161 TSA client, PKCS#7 embed via `pdf-edit`, in-app signing ceremony with OIDC identity.
+- [ ] `plugins` — Postgres-backed registry, Ed25519 signature verification against workspace trust store, Wasm dispatch through `workflow`, UI contribution renderer in `app`.
+- [ ] `diagrams` — Yjs co-authoring, shape libraries (flowchart, BPMN-lite, network, UML class), auto-routing connectors, shared client/server SVG renderer, KB entry sync, insertion pickers in Docs/Slides.
+- [ ] `app-admin/policy` — Postgres-backed `workspace_policies` table, `/api/admin/policies` GET/PUT routes, enforcement bridges in `erasure`, `audit`, `sharing`, `convert`. Full editors for DLP, labels, branding, export rules.
+
+### Deferred — requires human sign-off (restricted zones)
+
+Items blocked by `CONSTITUTION.md` restricted-zone rules. Contracts and schemas can be drafted but implementation requires maintainer approval:
+
+- [ ] **Enterprise auth hardening** (original item 8). Touches `modules/auth/` and likely `migrations/`.
+  - MFA enforcement (TOTP, WebAuthn)
+  - Strict SAML 2.0 profile (signed assertions, audience restriction, replay protection)
+  - Conditional access policies (IP allowlist, device posture, time-of-day)
+  - Sensitivity-label-backed DLP enforcement at `sharing` and `convert` boundaries
+  - Watermark rendering at `convert` export time
+- [ ] **SCIM provisioning** (part of item 9). Touches `modules/auth/` and `migrations/`.
+  - SCIM 2.0 `/Users` and `/Groups` endpoints with bearer-token auth
+  - Org-structure model: department / team scoping under workspace
+  - Seat-tracking and license model
+- [ ] **Policy enforcement in restricted modules** — `modules/sharing` and `modules/permissions` need hooks into `WorkspacePolicy` to actually block shares or downgrade roles. The Admin UI renders policy; enforcement is the restricted part.
+
+### Deferred — separate future sprint (items 1–6)
+
+Kept visible so we do not lose them. Not in this sprint's scope:
+
+- [ ] **1. Outlook-equivalent mail client** — new `modules/mail`: IMAP/SMTP or JMAP, inbox, contacts, rules, mail-to-doc, document-digest emails.
+- [ ] **2. Calendar + scheduling** — new `modules/calendar`: CalDAV/iCal interop, free/busy, meeting invites, recurring events, reminders. Ties into `mail`.
+- [ ] **3. Teams-style chat/channels** — new `modules/chat`: persistent DMs, channels, threaded messages, cross-product @mentions with notification routing (extends existing `notifications`).
+- [ ] **4. Video meetings** — `modules/meetings`: embed Jitsi/LiveKit, recording to S3, transcript pipeline feeding `ai` and `kb`.
+- [ ] **5. Copilot-style AI side panel** — extends `modules/ai` with in-editor context-aware assistant: rewrite, summarize, formula-gen, slide-gen. Uses existing Ollama + pgvector stack.
+- [ ] **6. Native mobile + desktop apps** — React Native (iOS/Android) and Electron shells over the existing web app. Offline Yjs sync rides on the work done this sprint.
+
+### Extras (capacity permitting)
+
+- [ ] **Large-document performance (>100 pages)** — not started this sprint; needs benchmarks before implementation. Open a perf-harness issue and land Yjs compaction metrics before choosing a direction.
+- [ ] **Plugin marketplace UI** — out of scope for this sprint; `plugins` contract supports it. Revisit after first external plugin exists.
+- [ ] **Diagram live-data binding** (shapes that read from KB datasets) — post-MVP in `diagrams`.
+
+---
+
 ## Data Sovereignty Requirements
 
 This is not a feature -- it is a hard constraint that shapes every technical decision.

--- a/modules/app-admin/internal/policy/index.ts
+++ b/modules/app-admin/internal/policy/index.ts
@@ -1,0 +1,6 @@
+/** Contract: contracts/app-admin/policy.md */
+export { buildPolicyPanel } from './policy-panel.ts';
+export { validatePolicy } from './policy-validators.ts';
+export { DEFAULT_POLICY } from './policy-types.ts';
+export type { WorkspacePolicy, SensitivityLabel, ExportFormat } from './policy-types.ts';
+export type { ValidationIssue } from './policy-validators.ts';

--- a/modules/app-admin/internal/policy/policy-panel.ts
+++ b/modules/app-admin/internal/policy/policy-panel.ts
@@ -1,0 +1,146 @@
+/** Contract: contracts/app-admin/policy.md */
+
+import { apiFetch } from '@opendesk/app';
+import { escapeHtml } from '../admin-helpers.ts';
+import { DEFAULT_POLICY, type WorkspacePolicy } from './policy-types.ts';
+import { validatePolicy, type ValidationIssue } from './policy-validators.ts';
+
+/**
+ * Skeleton "Policy" tab for the admin dashboard. Loads the workspace
+ * policy from /api/admin/policies, renders compact section panels, and
+ * saves back via PUT. Returns the root element so the dashboard can mount
+ * it into its tab container.
+ *
+ * This is a read-only scaffold for sections beyond Retention + Watermark +
+ * Branding; full per-section editors land in follow-up PRs.
+ */
+
+export async function buildPolicyPanel(workspaceId: string): Promise<HTMLElement> {
+  const root = document.createElement('section');
+  root.className = 'admin-policy';
+  root.innerHTML = '<h2>Workspace Policy</h2><div class="admin-policy-body"></div>';
+  const body = root.querySelector('.admin-policy-body') as HTMLElement;
+
+  const policy = await loadPolicy(workspaceId);
+  renderSections(body, policy, (next) => savePolicy(workspaceId, next, body));
+
+  return root;
+}
+
+async function loadPolicy(workspaceId: string): Promise<WorkspacePolicy> {
+  try {
+    const res = await apiFetch(`/api/admin/policies?workspace_id=${encodeURIComponent(workspaceId)}`);
+    if (!res.ok) throw new Error(`load failed: ${res.status}`);
+    return (await res.json()) as WorkspacePolicy;
+  } catch {
+    return {
+      workspace_id: workspaceId,
+      updated_at: new Date().toISOString(),
+      ...DEFAULT_POLICY,
+    };
+  }
+}
+
+async function savePolicy(
+  workspaceId: string,
+  next: WorkspacePolicy,
+  body: HTMLElement,
+): Promise<void> {
+  const issues = validatePolicy(next);
+  if (issues.length > 0) {
+    surfaceIssues(body, issues);
+    return;
+  }
+
+  const res = await apiFetch(`/api/admin/policies?workspace_id=${encodeURIComponent(workspaceId)}`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(next),
+  });
+
+  if (res.status === 409) {
+    surfaceIssues(body, [{ path: '', message: 'Policy changed in another tab. Reload and retry.' }]);
+    return;
+  }
+  if (!res.ok) {
+    surfaceIssues(body, [{ path: '', message: `Save failed (${res.status}).` }]);
+    return;
+  }
+
+  surfaceIssues(body, []);
+}
+
+function surfaceIssues(body: HTMLElement, issues: ValidationIssue[]): void {
+  const existing = body.querySelector('.admin-policy-issues');
+  if (existing) existing.remove();
+  if (issues.length === 0) return;
+
+  const list = document.createElement('ul');
+  list.className = 'admin-policy-issues';
+  for (const issue of issues) {
+    const li = document.createElement('li');
+    li.textContent = issue.path ? `${issue.path}: ${issue.message}` : issue.message;
+    list.appendChild(li);
+  }
+  body.prepend(list);
+}
+
+function renderSections(
+  body: HTMLElement,
+  policy: WorkspacePolicy,
+  onSave: (next: WorkspacePolicy) => void,
+): void {
+  body.innerHTML = `
+    <p class="admin-policy-stamp">Last updated ${escapeHtml(policy.updated_at)}</p>
+    <fieldset class="admin-policy-section">
+      <legend>Retention (days)</legend>
+      <label>Documents <input type="number" min="0" name="retention.documents_days" value="${policy.retention.documents_days ?? ''}" placeholder="forever"></label>
+      <label>Audit <input type="number" min="0" name="retention.audit_days" value="${policy.retention.audit_days ?? ''}" placeholder="forever"></label>
+      <label>Erasure grace <input type="number" min="0" name="retention.erasure_grace_days" value="${policy.retention.erasure_grace_days}"></label>
+    </fieldset>
+    <fieldset class="admin-policy-section">
+      <legend>Watermark</legend>
+      <label><input type="checkbox" name="watermark.enabled" ${policy.watermark.enabled ? 'checked' : ''}> Enable</label>
+      <label>Template <input type="text" name="watermark.text_template" value="${escapeHtml(policy.watermark.text_template)}"></label>
+      <label>Opacity <input type="number" step="0.05" min="0.05" max="0.5" name="watermark.opacity" value="${policy.watermark.opacity}"></label>
+    </fieldset>
+    <fieldset class="admin-policy-section admin-policy-readonly">
+      <legend>DLP, labels, branding, export rules</legend>
+      <p>Full editors land in a follow-up PR. For now, manage via the policy API directly.</p>
+    </fieldset>
+    <button class="admin-policy-save" type="button">Save</button>
+  `;
+
+  const saveBtn = body.querySelector('.admin-policy-save') as HTMLButtonElement;
+  saveBtn.addEventListener('click', () => {
+    const next = readFormIntoPolicy(body, policy);
+    onSave(next);
+  });
+}
+
+function readFormIntoPolicy(body: HTMLElement, base: WorkspacePolicy): WorkspacePolicy {
+  const get = (name: string) => body.querySelector<HTMLInputElement>(`[name="${name}"]`);
+  const numOrNull = (v: string): number | null => (v === '' ? null : Number(v));
+
+  const docsDays = get('retention.documents_days');
+  const auditDays = get('retention.audit_days');
+  const graceDays = get('retention.erasure_grace_days');
+  const wmEnabled = get('watermark.enabled');
+  const wmTemplate = get('watermark.text_template');
+  const wmOpacity = get('watermark.opacity');
+
+  return {
+    ...base,
+    retention: {
+      documents_days: numOrNull(docsDays?.value ?? ''),
+      audit_days: numOrNull(auditDays?.value ?? ''),
+      erasure_grace_days: Number(graceDays?.value ?? base.retention.erasure_grace_days),
+    },
+    watermark: {
+      enabled: Boolean(wmEnabled?.checked),
+      text_template: wmTemplate?.value ?? base.watermark.text_template,
+      opacity: Number(wmOpacity?.value ?? base.watermark.opacity),
+    },
+    updated_at: base.updated_at,
+  };
+}

--- a/modules/app-admin/internal/policy/policy-types.ts
+++ b/modules/app-admin/internal/policy/policy-types.ts
@@ -1,0 +1,74 @@
+/** Contract: contracts/app-admin/policy.md */
+
+/**
+ * Client-side type mirror of the server's WorkspacePolicy. The server is
+ * the source of truth; this file re-declares the shape for the admin UI
+ * only. Breaking changes here MUST be coordinated with the server schema.
+ */
+
+export type ExportFormat = 'pdf' | 'docx' | 'odt' | 'xlsx' | 'ods' | 'pptx' | 'odp';
+
+export interface SensitivityLabel {
+  id: string;
+  name: string;
+  color: string;
+  export_blocked: boolean;
+}
+
+export interface WorkspacePolicy {
+  workspace_id: string;
+  retention: {
+    documents_days: number | null;
+    audit_days: number | null;
+    erasure_grace_days: number;
+  };
+  export: {
+    allowed_formats: ExportFormat[];
+    require_approval_over_mb: number | null;
+  };
+  dlp: {
+    blocked_keywords: string[];
+    blocked_regex: string[];
+    action: 'warn' | 'block';
+  };
+  watermark: {
+    enabled: boolean;
+    text_template: string;
+    opacity: number;
+  };
+  sensitivity_labels: SensitivityLabel[];
+  branding: {
+    logo_url: string | null;
+    accent_hex: string | null;
+    product_name_override: string | null;
+  };
+  updated_at: string;
+}
+
+export const DEFAULT_POLICY: Omit<WorkspacePolicy, 'workspace_id' | 'updated_at'> = {
+  retention: {
+    documents_days: null,
+    audit_days: 365,
+    erasure_grace_days: 30,
+  },
+  export: {
+    allowed_formats: ['pdf', 'docx', 'odt', 'xlsx', 'ods', 'pptx', 'odp'],
+    require_approval_over_mb: null,
+  },
+  dlp: {
+    blocked_keywords: [],
+    blocked_regex: [],
+    action: 'warn',
+  },
+  watermark: {
+    enabled: false,
+    text_template: '{user} — {date}',
+    opacity: 0.15,
+  },
+  sensitivity_labels: [],
+  branding: {
+    logo_url: null,
+    accent_hex: null,
+    product_name_override: null,
+  },
+};

--- a/modules/app-admin/internal/policy/policy-validators.ts
+++ b/modules/app-admin/internal/policy/policy-validators.ts
@@ -1,0 +1,62 @@
+/** Contract: contracts/app-admin/policy.md */
+
+import type { WorkspacePolicy } from './policy-types.ts';
+
+export interface ValidationIssue {
+  path: string;
+  message: string;
+}
+
+/**
+ * Client-side validation. The server re-validates every PUT and is the
+ * final authority; this exists purely to disable the Save button and
+ * surface inline errors fast.
+ */
+export function validatePolicy(p: WorkspacePolicy): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  const { retention, export: exp, watermark } = p;
+
+  if (retention.documents_days !== null && retention.documents_days < 0) {
+    issues.push({ path: 'retention.documents_days', message: 'must be ≥ 0 or null (forever)' });
+  }
+  if (retention.audit_days !== null && retention.audit_days < 0) {
+    issues.push({ path: 'retention.audit_days', message: 'must be ≥ 0 or null (forever)' });
+  }
+  if (retention.erasure_grace_days < 0) {
+    issues.push({ path: 'retention.erasure_grace_days', message: 'must be ≥ 0' });
+  }
+
+  if (exp.require_approval_over_mb !== null && exp.require_approval_over_mb <= 0) {
+    issues.push({ path: 'export.require_approval_over_mb', message: 'must be > 0 or null' });
+  }
+
+  if (watermark.opacity < 0.05 || watermark.opacity > 0.5) {
+    issues.push({ path: 'watermark.opacity', message: 'must be between 0.05 and 0.5' });
+  }
+
+  for (let i = 0; i < p.dlp.blocked_regex.length; i++) {
+    const pattern = p.dlp.blocked_regex[i];
+    try {
+      new RegExp(pattern);
+    } catch (err) {
+      issues.push({
+        path: `dlp.blocked_regex[${i}]`,
+        message: `invalid pattern: ${(err as Error).message}`,
+      });
+    }
+  }
+
+  for (let i = 0; i < p.sensitivity_labels.length; i++) {
+    const label = p.sensitivity_labels[i];
+    if (!/^#[0-9a-fA-F]{6}$/.test(label.color)) {
+      issues.push({ path: `sensitivity_labels[${i}].color`, message: 'must be #rrggbb' });
+    }
+  }
+
+  if (p.branding.accent_hex !== null && !/^#[0-9a-fA-F]{6}$/.test(p.branding.accent_hex)) {
+    issues.push({ path: 'branding.accent_hex', message: 'must be #rrggbb or null' });
+  }
+
+  return issues;
+}

--- a/modules/app/internal/editor/editor.ts
+++ b/modules/app/internal/editor/editor.ts
@@ -29,7 +29,7 @@ import { initZoomControl } from './zoom-control.ts';
 import { buildSaveIndicator } from './save-indicator.ts';
 import { initPageSetup, showPageSetupDialog } from './page-setup.ts';
 import { insertHeaderFooter, insertPageNumber, activateZone, setupHeaderFooterClicks } from './header-footer.ts';
-import { registerServiceWorker, buildOfflineIndicator, buildUpdateBanner, initConnectivityListeners } from '../offline/index.ts';
+import { registerServiceWorker, buildOfflineIndicator, buildUpdateBanner, initConnectivityListeners, attachYjsPersistence } from '../offline/index.ts';
 import { mountAppToolbar } from '../shared/app-toolbar.ts';
 import { initEditorCollab } from './editor-collab.ts';
 import { initAiAssist } from './ai-assist.ts';
@@ -79,6 +79,10 @@ async function init() {
   onLocaleChange(() => updateStaticText(statusEl));
 
   const ydoc = new Y.Doc();
+  // Replay any offline edits persisted in IndexedDB into `ydoc` BEFORE the
+  // Hocuspocus provider opens a socket, so the state vector sent on sync
+  // already contains offline work (contracts/app/offline.md §8–§10).
+  const persistence = await attachYjsPersistence(ydoc, documentId);
   const commentStore = new CommentStore(ydoc);
   const wsUrl = `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/collab`;
   // Offline UI
@@ -206,7 +210,7 @@ async function init() {
   initFocusModeButton();
 
   console.log('[boot] init-complete');
-  Object.assign(window, { editor, provider, ydoc, commentStore });
+  Object.assign(window, { editor, provider, ydoc, commentStore, persistence });
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/modules/app/internal/offline/index.ts
+++ b/modules/app/internal/offline/index.ts
@@ -26,3 +26,5 @@ export {
 } from './offline-storage.ts';
 export type { CachedDocEntry } from './offline-storage.ts';
 export { queueMutation, getQueueSize, flushQueue, onQueueChange } from './sync-manager.ts';
+export { attachYjsPersistence } from './yjs-persistence.ts';
+export type { YjsPersistenceHandle } from './yjs-persistence.ts';

--- a/modules/app/internal/offline/yjs-persistence.ts
+++ b/modules/app/internal/offline/yjs-persistence.ts
@@ -1,0 +1,179 @@
+/** Contract: contracts/app/offline.md */
+
+/**
+ * Per-document IndexedDB persistence for Yjs `Doc`s.
+ *
+ * Contract invariants honored here:
+ *   - Each document uses an isolated database keyed by
+ *     `opendesk-yjs-<documentId>` so that clearing one document's
+ *     offline state does not affect others.
+ *   - Updates are persisted BEFORE the network layer has a chance to
+ *     broadcast them (subscribed via `ydoc.on('update', ...)`).
+ *   - On attach we replay all stored updates into the `Doc` before the
+ *     caller opens the Hocuspocus provider, so the state vector sent on
+ *     sync already contains offline edits.
+ *   - We never clear local state on `connect`; we only clear on explicit
+ *     erasure or on a successful compaction. CRDT merge guarantees the
+ *     server absorbs the offline edits via the standard Yjs protocol.
+ *
+ * Graceful degradation: if IndexedDB is unavailable, `attach` resolves
+ * without throwing and the caller proceeds as if persistence is disabled.
+ */
+
+import * as Y from 'yjs';
+
+const STORE = 'updates';
+const META_STORE = 'meta';
+const DB_VERSION = 1;
+const COMPACTION_THRESHOLD = 200; // updates before we collapse rows
+
+function dbName(documentId: string): string {
+  return `opendesk-yjs-${documentId}`;
+}
+
+function indexedDbUnavailable(): boolean {
+  return typeof indexedDB === 'undefined';
+}
+
+function openDb(documentId: string): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(dbName(documentId), DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        db.createObjectStore(STORE, { keyPath: 'id', autoIncrement: true });
+      }
+      if (!db.objectStoreNames.contains(META_STORE)) {
+        db.createObjectStore(META_STORE, { keyPath: 'key' });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function readAllUpdates(db: IDBDatabase): Promise<Array<{ id: number; update: Uint8Array }>> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readonly');
+    const req = tx.objectStore(STORE).getAll();
+    req.onsuccess = () => resolve(req.result as Array<{ id: number; update: Uint8Array }>);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function appendUpdate(db: IDBDatabase, update: Uint8Array): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    tx.objectStore(STORE).add({ update });
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+function replaceWithMerged(db: IDBDatabase, merged: Uint8Array): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    const store = tx.objectStore(STORE);
+    store.clear();
+    store.add({ update: merged });
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export interface YjsPersistenceHandle {
+  /** Disconnect the update listener (e.g. on editor teardown). */
+  detach(): void;
+  /** Drop this document's local store — used by erasure. */
+  clear(): Promise<void>;
+  /** Merge all stored updates into a single row. */
+  compact(): Promise<void>;
+}
+
+/**
+ * Attach a Yjs `Doc` to its per-document IndexedDB store.
+ * Replays stored updates into `ydoc` before returning so callers can open
+ * a network provider on the hydrated doc.
+ */
+export async function attachYjsPersistence(
+  ydoc: Y.Doc,
+  documentId: string,
+): Promise<YjsPersistenceHandle> {
+  const noop: YjsPersistenceHandle = {
+    detach: () => {},
+    clear: async () => {},
+    compact: async () => {},
+  };
+
+  if (indexedDbUnavailable()) return noop;
+
+  let db: IDBDatabase;
+  try {
+    db = await openDb(documentId);
+  } catch {
+    return noop;
+  }
+
+  // Replay stored updates into the doc before anyone can subscribe to
+  // network sync. Apply inside a single transaction origin so the local
+  // replay is not re-broadcast as fresh edits.
+  try {
+    const rows = await readAllUpdates(db);
+    const origin = 'opendesk-yjs-persistence:replay';
+    Y.transact(
+      ydoc,
+      () => {
+        for (const row of rows) {
+          Y.applyUpdate(ydoc, row.update, origin);
+        }
+      },
+      origin,
+      false,
+    );
+  } catch {
+    // replay failed; proceed without persistence rather than blocking the editor
+    db.close();
+    return noop;
+  }
+
+  let pending = 0;
+
+  const onUpdate = (update: Uint8Array, origin: unknown): void => {
+    // Skip updates we just replayed from disk.
+    if (origin === 'opendesk-yjs-persistence:replay') return;
+    appendUpdate(db, update).catch(() => {
+      // Persistence is best-effort; the server still has the update via
+      // the Hocuspocus sync path. Log and keep going.
+    });
+    pending += 1;
+    if (pending >= COMPACTION_THRESHOLD) {
+      pending = 0;
+      compactInternal(ydoc, db).catch(() => {});
+    }
+  };
+
+  ydoc.on('update', onUpdate);
+
+  return {
+    detach: () => {
+      ydoc.off('update', onUpdate);
+      db.close();
+    },
+    clear: async () => {
+      ydoc.off('update', onUpdate);
+      db.close();
+      await new Promise<void>((resolve, reject) => {
+        const req = indexedDB.deleteDatabase(dbName(documentId));
+        req.onsuccess = () => resolve();
+        req.onerror = () => reject(req.error);
+        req.onblocked = () => resolve();
+      });
+    },
+    compact: () => compactInternal(ydoc, db),
+  };
+}
+
+async function compactInternal(ydoc: Y.Doc, db: IDBDatabase): Promise<void> {
+  const merged = Y.encodeStateAsUpdate(ydoc);
+  await replaceWithMerged(db, merged);
+}

--- a/modules/diagrams/contract.ts
+++ b/modules/diagrams/contract.ts
@@ -1,0 +1,95 @@
+/** Contract: contracts/diagrams/rules.md */
+import { z } from 'zod';
+
+export const ShapeKindSchema = z.enum([
+  'rect',
+  'ellipse',
+  'diamond',
+  'triangle',
+  'cylinder',
+  'actor',
+  'bpmn_task',
+  'bpmn_gateway',
+  'bpmn_event',
+  'uml_class',
+  'text',
+]);
+
+export type ShapeKind = z.infer<typeof ShapeKindSchema>;
+
+export const PointSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+});
+
+export type Point = z.infer<typeof PointSchema>;
+
+export const ShapeSchema = z.object({
+  id: z.string().min(1),
+  kind: ShapeKindSchema,
+  layer_id: z.string().min(1),
+  page: z.number().int().min(0),
+  x: z.number(),
+  y: z.number(),
+  w: z.number().positive(),
+  h: z.number().positive(),
+  rotation: z.number().default(0),
+  text: z.string().default(''),
+  alt_text: z.string().default(''),
+  style_token: z.string().default('default'),
+  z: z.number().int().default(0),
+});
+
+export type Shape = z.infer<typeof ShapeSchema>;
+
+export const ConnectorRoutingSchema = z.enum(['orthogonal', 'straight', 'curved']);
+export type ConnectorRouting = z.infer<typeof ConnectorRoutingSchema>;
+
+export const ConnectorSchema = z.object({
+  id: z.string().min(1),
+  source_shape_id: z.string().min(1),
+  target_shape_id: z.string().min(1),
+  layer_id: z.string().min(1),
+  page: z.number().int().min(0),
+  routing: ConnectorRoutingSchema.default('orthogonal'),
+  label: z.string().default(''),
+  style_token: z.string().default('default'),
+});
+
+export type Connector = z.infer<typeof ConnectorSchema>;
+
+export const LayerSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  visible: z.boolean().default(true),
+  locked: z.boolean().default(false),
+  order: z.number().int().default(0),
+});
+
+export type Layer = z.infer<typeof LayerSchema>;
+
+export const MAX_SHAPES_PER_PAGE = 2000;
+
+export const DiagramDefinitionSchema = z.object({
+  id: z.string().min(1),
+  workspace_id: z.string().min(1),
+  title: z.string().min(1),
+  pages: z.number().int().min(1),
+  layers: z.array(LayerSchema).min(1),
+  shapes: z.array(ShapeSchema),
+  connectors: z.array(ConnectorSchema),
+  updated_at: z.string(),
+});
+
+export type DiagramDefinition = z.infer<typeof DiagramDefinitionSchema>;
+
+export interface DiagramStore {
+  create(input: Omit<DiagramDefinition, 'updated_at'>): Promise<DiagramDefinition>;
+  get(id: string): Promise<DiagramDefinition | null>;
+  update(id: string, patch: Partial<Omit<DiagramDefinition, 'id' | 'workspace_id'>>): Promise<DiagramDefinition>;
+  renderSvg(id: string): Promise<string>;
+}
+
+export interface DiagramsModule {
+  store: DiagramStore;
+}

--- a/modules/diagrams/index.ts
+++ b/modules/diagrams/index.ts
@@ -1,0 +1,26 @@
+/** Contract: contracts/diagrams/rules.md */
+export {
+  ShapeKindSchema,
+  PointSchema,
+  ShapeSchema,
+  ConnectorRoutingSchema,
+  ConnectorSchema,
+  LayerSchema,
+  DiagramDefinitionSchema,
+  MAX_SHAPES_PER_PAGE,
+} from './contract.ts';
+
+export type {
+  ShapeKind,
+  Point,
+  Shape,
+  ConnectorRouting,
+  Connector,
+  Layer,
+  DiagramDefinition,
+  DiagramStore,
+  DiagramsModule,
+} from './contract.ts';
+
+export { createMemoryDiagramStore } from './internal/memory-store.ts';
+export { validateConnectors } from './internal/validate.ts';

--- a/modules/diagrams/internal/memory-store.ts
+++ b/modules/diagrams/internal/memory-store.ts
@@ -1,0 +1,70 @@
+/** Contract: contracts/diagrams/rules.md */
+
+/**
+ * Skeleton in-memory DiagramStore.
+ * Real impl will:
+ *   - Persist `DiagramDefinition` as a Yjs doc via `collab`
+ *   - Register a KB entry of type `diagram` on save
+ *   - Render SVG via a shared client/server renderer that emits
+ *     byte-identical output for the same definition + shape library
+ *     version
+ *   - Enforce MAX_SHAPES_PER_PAGE
+ */
+
+import {
+  DiagramDefinitionSchema,
+  MAX_SHAPES_PER_PAGE,
+  type DiagramDefinition,
+  type DiagramStore,
+} from '../contract.ts';
+
+function enforceShapeCap(def: DiagramDefinition): void {
+  const perPage = new Map<number, number>();
+  for (const shape of def.shapes) {
+    perPage.set(shape.page, (perPage.get(shape.page) ?? 0) + 1);
+  }
+  for (const [page, count] of perPage) {
+    if (count > MAX_SHAPES_PER_PAGE) {
+      const err = new Error(`page ${page} exceeds shape cap (${count} > ${MAX_SHAPES_PER_PAGE})`);
+      (err as Error & { code?: string }).code = 'CAPACITY';
+      throw err;
+    }
+  }
+}
+
+export function createMemoryDiagramStore(): DiagramStore {
+  const defs = new Map<string, DiagramDefinition>();
+
+  return {
+    async create(input) {
+      const def: DiagramDefinition = DiagramDefinitionSchema.parse({
+        ...input,
+        updated_at: new Date().toISOString(),
+      });
+      enforceShapeCap(def);
+      defs.set(def.id, def);
+      return def;
+    },
+
+    async get(id) {
+      return defs.get(id) ?? null;
+    },
+
+    async update(id, patch) {
+      const prev = defs.get(id);
+      if (!prev) throw new Error(`diagram not found: ${id}`);
+      const next: DiagramDefinition = DiagramDefinitionSchema.parse({
+        ...prev,
+        ...patch,
+        updated_at: new Date().toISOString(),
+      });
+      enforceShapeCap(next);
+      defs.set(id, next);
+      return next;
+    },
+
+    async renderSvg(_id) {
+      throw new Error('diagrams: SVG renderer not implemented (skeleton)');
+    },
+  };
+}

--- a/modules/diagrams/internal/validate.ts
+++ b/modules/diagrams/internal/validate.ts
@@ -1,0 +1,14 @@
+/** Contract: contracts/diagrams/rules.md */
+
+import type { Connector, DiagramDefinition } from '../contract.ts';
+
+/**
+ * Return the subset of connectors whose source or target shape is missing.
+ * These render as red dashed placeholders in the editor.
+ */
+export function validateConnectors(def: DiagramDefinition): Connector[] {
+  const shapeIds = new Set(def.shapes.map((s) => s.id));
+  return def.connectors.filter(
+    (c) => !shapeIds.has(c.source_shape_id) || !shapeIds.has(c.target_shape_id),
+  );
+}

--- a/modules/esign/contract.ts
+++ b/modules/esign/contract.ts
@@ -1,0 +1,78 @@
+/** Contract: contracts/esign/rules.md */
+import { z } from 'zod';
+
+export const SignerSchema = z.object({
+  id: z.string().min(1),
+  email: z.string().email(),
+  principal_id: z.string().nullable(),
+  role: z.enum(['signer', 'witness', 'cc']).default('signer'),
+  order: z.number().int().min(0),
+});
+
+export type Signer = z.infer<typeof SignerSchema>;
+
+export const PacketStatusSchema = z.enum([
+  'draft',
+  'awaiting_signers',
+  'completed',
+  'revoked',
+  'expired',
+]);
+
+export type PacketStatus = z.infer<typeof PacketStatusSchema>;
+
+export const SigningPacketSchema = z.object({
+  id: z.string().min(1),
+  workspace_id: z.string().min(1),
+  document_id: z.string().min(1),
+  signers: z.array(SignerSchema).min(1),
+  sequential: z.boolean().default(true),
+  expiration: z.string().nullable(),
+  status: PacketStatusSchema,
+  created_by: z.string().min(1),
+  created_at: z.string(),
+});
+
+export type SigningPacket = z.infer<typeof SigningPacketSchema>;
+
+export const CeremonyStepTypeSchema = z.enum([
+  'invite_sent',
+  'invite_opened',
+  'identity_challenge',
+  'intent_affirmed',
+  'signature_applied',
+  'tsa_timestamp',
+  'packet_completed',
+  'packet_revoked',
+  'packet_expired',
+]);
+
+export type CeremonyStepType = z.infer<typeof CeremonyStepTypeSchema>;
+
+export const CeremonyStepSchema = z.object({
+  id: z.string().min(1),
+  packet_id: z.string().min(1),
+  signer_id: z.string().nullable(),
+  type: CeremonyStepTypeSchema,
+  ip: z.string().nullable(),
+  user_agent: z.string().nullable(),
+  payload: z.record(z.unknown()).default({}),
+  created_at: z.string(),
+  prev_hmac: z.string().nullable(),
+  row_hmac: z.string(),
+});
+
+export type CeremonyStep = z.infer<typeof CeremonyStepSchema>;
+
+export interface EsignStore {
+  createPacket(input: Omit<SigningPacket, 'id' | 'status' | 'created_at'>): Promise<SigningPacket>;
+  getPacket(id: string): Promise<SigningPacket | null>;
+  recordCeremonyStep(input: Omit<CeremonyStep, 'id' | 'created_at' | 'prev_hmac' | 'row_hmac'>): Promise<CeremonyStep>;
+  getAuditTrail(packetId: string): Promise<CeremonyStep[]>;
+  markCompleted(id: string): Promise<void>;
+  revoke(id: string, by: string): Promise<void>;
+}
+
+export interface EsignModule {
+  store: EsignStore;
+}

--- a/modules/esign/index.ts
+++ b/modules/esign/index.ts
@@ -1,0 +1,20 @@
+/** Contract: contracts/esign/rules.md */
+export {
+  SignerSchema,
+  PacketStatusSchema,
+  SigningPacketSchema,
+  CeremonyStepTypeSchema,
+  CeremonyStepSchema,
+} from './contract.ts';
+
+export type {
+  Signer,
+  PacketStatus,
+  SigningPacket,
+  CeremonyStepType,
+  CeremonyStep,
+  EsignStore,
+  EsignModule,
+} from './contract.ts';
+
+export { createMemoryEsignStore } from './internal/memory-store.ts';

--- a/modules/esign/internal/memory-store.ts
+++ b/modules/esign/internal/memory-store.ts
@@ -1,0 +1,103 @@
+/** Contract: contracts/esign/rules.md */
+
+/**
+ * Skeleton in-memory EsignStore. Hmac chaining is implemented with a
+ * shared-secret placeholder; production will draw the HMAC key from the
+ * same KMS path the `audit` module uses.
+ *
+ * The real implementation must:
+ *   - Persist to Postgres with a per-packet hash chain table
+ *   - Call a configured RFC 3161 TSA on every signature_applied step
+ *   - Embed PKCS#7 signatures in the PDF via `pdf-edit`
+ *   - Reject signature_applied steps without a preceding
+ *     identity_challenge AND intent_affirmed within the same signer scope
+ */
+
+import { createHmac, randomUUID } from 'node:crypto';
+import {
+  SigningPacketSchema,
+  CeremonyStepSchema,
+  type CeremonyStep,
+  type EsignStore,
+  type SigningPacket,
+} from '../contract.ts';
+
+const PLACEHOLDER_KEY = Buffer.from('esign-skeleton-hmac-key', 'utf8');
+
+function computeRowHmac(prev: string | null, payload: object): string {
+  const h = createHmac('sha256', PLACEHOLDER_KEY);
+  h.update(prev ?? '');
+  h.update('|');
+  h.update(JSON.stringify(payload));
+  return h.digest('hex');
+}
+
+export function createMemoryEsignStore(): EsignStore {
+  const packets = new Map<string, SigningPacket>();
+  const trails = new Map<string, CeremonyStep[]>();
+
+  return {
+    async createPacket(input) {
+      const packet: SigningPacket = SigningPacketSchema.parse({
+        id: randomUUID(),
+        status: 'draft',
+        created_at: new Date().toISOString(),
+        ...input,
+      });
+      packets.set(packet.id, packet);
+      trails.set(packet.id, []);
+      return packet;
+    },
+
+    async getPacket(id) {
+      return packets.get(id) ?? null;
+    },
+
+    async recordCeremonyStep(input) {
+      const trail = trails.get(input.packet_id);
+      if (!trail) throw new Error(`packet not found: ${input.packet_id}`);
+
+      const prev = trail.at(-1)?.row_hmac ?? null;
+      const id = randomUUID();
+      const created_at = new Date().toISOString();
+      const payload = {
+        id,
+        packet_id: input.packet_id,
+        signer_id: input.signer_id,
+        type: input.type,
+        ip: input.ip,
+        user_agent: input.user_agent,
+        payload_data: input.payload,
+        created_at,
+      };
+      const row_hmac = computeRowHmac(prev, payload);
+
+      const step: CeremonyStep = CeremonyStepSchema.parse({
+        ...input,
+        id,
+        created_at,
+        prev_hmac: prev,
+        row_hmac,
+      });
+
+      trail.push(step);
+      return step;
+    },
+
+    async getAuditTrail(packetId) {
+      return trails.get(packetId) ?? [];
+    },
+
+    async markCompleted(id) {
+      const packet = packets.get(id);
+      if (!packet) throw new Error(`packet not found: ${id}`);
+      packets.set(id, { ...packet, status: 'completed' });
+    },
+
+    async revoke(id, _by) {
+      const packet = packets.get(id);
+      if (!packet) throw new Error(`packet not found: ${id}`);
+      packets.set(id, { ...packet, status: 'revoked' });
+    },
+  };
+}

--- a/modules/forms/contract.ts
+++ b/modules/forms/contract.ts
@@ -1,0 +1,69 @@
+/** Contract: contracts/forms/rules.md */
+import { z } from 'zod';
+
+export const QuestionTypeSchema = z.enum([
+  'short_text',
+  'long_text',
+  'single_choice',
+  'multi_choice',
+  'scale',
+  'date',
+  'file_upload',
+  'email',
+  'number',
+]);
+
+export type QuestionType = z.infer<typeof QuestionTypeSchema>;
+
+export const QuestionSchema = z.object({
+  id: z.string().min(1),
+  type: QuestionTypeSchema,
+  label: z.string().min(1),
+  description: z.string().optional(),
+  required: z.boolean().default(false),
+  choices: z.array(z.string()).optional(),
+  min: z.number().optional(),
+  max: z.number().optional(),
+  regex: z.string().optional(),
+});
+
+export type Question = z.infer<typeof QuestionSchema>;
+
+export const FormDefinitionSchema = z.object({
+  id: z.string().min(1),
+  workspace_id: z.string().min(1),
+  version: z.number().int().min(1),
+  title: z.string().min(1),
+  description: z.string().optional(),
+  questions: z.array(QuestionSchema).max(250),
+  anonymous: z.boolean().default(false),
+  single_response: z.boolean().default(false),
+  close_at: z.string().nullable(),
+  updated_at: z.string(),
+});
+
+export type FormDefinition = z.infer<typeof FormDefinitionSchema>;
+
+export const FormResponseSchema = z.object({
+  id: z.string().min(1),
+  form_id: z.string().min(1),
+  definition_version: z.number().int().min(1),
+  principal_id: z.string().nullable(),
+  answers: z.record(z.unknown()),
+  submitted_at: z.string(),
+});
+
+export type FormResponse = z.infer<typeof FormResponseSchema>;
+
+export interface FormStore {
+  createDefinition(input: Omit<FormDefinition, 'updated_at'>): Promise<FormDefinition>;
+  getDefinition(id: string): Promise<FormDefinition | null>;
+  updateDefinition(id: string, patch: Partial<Omit<FormDefinition, 'id' | 'workspace_id'>>): Promise<FormDefinition>;
+  submitResponse(input: Omit<FormResponse, 'id' | 'submitted_at'>): Promise<FormResponse>;
+  listResponses(formId: string, limit?: number, offset?: number): Promise<FormResponse[]>;
+  closeForm(id: string): Promise<void>;
+}
+
+export interface FormsModule {
+  store: FormStore;
+}

--- a/modules/forms/index.ts
+++ b/modules/forms/index.ts
@@ -1,0 +1,18 @@
+/** Contract: contracts/forms/rules.md */
+export {
+  QuestionTypeSchema,
+  QuestionSchema,
+  FormDefinitionSchema,
+  FormResponseSchema,
+} from './contract.ts';
+
+export type {
+  QuestionType,
+  Question,
+  FormDefinition,
+  FormResponse,
+  FormStore,
+  FormsModule,
+} from './contract.ts';
+
+export { createMemoryFormStore } from './internal/memory-store.ts';

--- a/modules/forms/internal/memory-store.ts
+++ b/modules/forms/internal/memory-store.ts
@@ -1,0 +1,90 @@
+/** Contract: contracts/forms/rules.md */
+
+/**
+ * In-memory FormStore used for early wiring and tests.
+ * A Postgres-backed implementation will replace this; the public
+ * interface (FormStore) is stable.
+ *
+ * Skeleton only — does not enforce every invariant in the contract.
+ * Production invariants (idempotent single_response, file-size caps,
+ * erasure cascade, audit emission) are implemented against the
+ * eventual pg-store.
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  FormDefinitionSchema,
+  FormResponseSchema,
+  type FormDefinition,
+  type FormResponse,
+  type FormStore,
+} from '../contract.ts';
+
+export function createMemoryFormStore(): FormStore {
+  const definitions = new Map<string, FormDefinition>();
+  const responses = new Map<string, FormResponse[]>();
+  const closed = new Set<string>();
+
+  return {
+    async createDefinition(input) {
+      const def: FormDefinition = FormDefinitionSchema.parse({
+        ...input,
+        updated_at: new Date().toISOString(),
+      });
+      definitions.set(def.id, def);
+      responses.set(def.id, []);
+      return def;
+    },
+
+    async getDefinition(id) {
+      return definitions.get(id) ?? null;
+    },
+
+    async updateDefinition(id, patch) {
+      const prev = definitions.get(id);
+      if (!prev) throw new Error(`form not found: ${id}`);
+      const next: FormDefinition = FormDefinitionSchema.parse({
+        ...prev,
+        ...patch,
+        version: prev.version + 1,
+        updated_at: new Date().toISOString(),
+      });
+      definitions.set(id, next);
+      return next;
+    },
+
+    async submitResponse(input) {
+      if (closed.has(input.form_id)) {
+        const err = new Error('form closed');
+        (err as Error & { code?: string }).code = 'FORM_CLOSED';
+        throw err;
+      }
+      const def = definitions.get(input.form_id);
+      if (!def) throw new Error(`form not found: ${input.form_id}`);
+      if (def.close_at && new Date(def.close_at).getTime() <= Date.now()) {
+        closed.add(input.form_id);
+        const err = new Error('form closed');
+        (err as Error & { code?: string }).code = 'FORM_CLOSED';
+        throw err;
+      }
+      const row: FormResponse = FormResponseSchema.parse({
+        id: randomUUID(),
+        submitted_at: new Date().toISOString(),
+        ...input,
+      });
+      const bucket = responses.get(input.form_id) ?? [];
+      bucket.push(row);
+      responses.set(input.form_id, bucket);
+      return row;
+    },
+
+    async listResponses(formId, limit = 100, offset = 0) {
+      const bucket = responses.get(formId) ?? [];
+      return bucket.slice(offset, offset + limit);
+    },
+
+    async closeForm(id) {
+      closed.add(id);
+    },
+  };
+}

--- a/modules/pdf-edit/contract.ts
+++ b/modules/pdf-edit/contract.ts
@@ -1,0 +1,70 @@
+/** Contract: contracts/pdf-edit/rules.md */
+import { z } from 'zod';
+
+export const AnnotationTypeSchema = z.enum([
+  'highlight',
+  'underline',
+  'strike',
+  'freehand',
+  'text_box',
+  'stamp',
+  'signature_field',
+]);
+
+export type AnnotationType = z.infer<typeof AnnotationTypeSchema>;
+
+export const RectSchema = z.object({
+  page: z.number().int().min(0),
+  x: z.number(),
+  y: z.number(),
+  w: z.number(),
+  h: z.number(),
+});
+
+export type Rect = z.infer<typeof RectSchema>;
+
+export const AnnotationSchema = z.object({
+  id: z.string().min(1),
+  type: AnnotationTypeSchema,
+  rect: RectSchema,
+  author_id: z.string().min(1),
+  color: z.string().optional(),
+  text: z.string().optional(),
+  path: z.array(z.tuple([z.number(), z.number()])).optional(),
+  created_at: z.string(),
+});
+
+export type Annotation = z.infer<typeof AnnotationSchema>;
+
+export const RedactionSchema = z.object({
+  id: z.string().min(1),
+  rect: RectSchema,
+  author_id: z.string().min(1),
+  reason: z.string().optional(),
+  created_at: z.string(),
+});
+
+export type Redaction = z.infer<typeof RedactionSchema>;
+
+export const PdfAnnotationLayerSchema = z.object({
+  document_id: z.string().min(1),
+  pdf_storage_key: z.string().min(1),
+  annotations: z.array(AnnotationSchema),
+  redactions: z.array(RedactionSchema),
+  form_fields: z.record(z.union([z.string(), z.number(), z.boolean(), z.null()])),
+  updated_at: z.string(),
+});
+
+export type PdfAnnotationLayer = z.infer<typeof PdfAnnotationLayerSchema>;
+
+export interface PdfEditor {
+  openLayer(documentId: string): Promise<PdfAnnotationLayer>;
+  applyAnnotation(documentId: string, annotation: Annotation): Promise<void>;
+  applyRedaction(documentId: string, redaction: Redaction): Promise<void>;
+  fillField(documentId: string, fieldName: string, value: string | number | boolean | null): Promise<void>;
+  save(documentId: string, opts: { flatten: boolean }): Promise<{ storage_key: string }>;
+}
+
+export interface PdfEditModule {
+  editor: PdfEditor;
+}

--- a/modules/pdf-edit/index.ts
+++ b/modules/pdf-edit/index.ts
@@ -1,0 +1,20 @@
+/** Contract: contracts/pdf-edit/rules.md */
+export {
+  AnnotationTypeSchema,
+  RectSchema,
+  AnnotationSchema,
+  RedactionSchema,
+  PdfAnnotationLayerSchema,
+} from './contract.ts';
+
+export type {
+  AnnotationType,
+  Rect,
+  Annotation,
+  Redaction,
+  PdfAnnotationLayer,
+  PdfEditor,
+  PdfEditModule,
+} from './contract.ts';
+
+export { createStubPdfEditor } from './internal/stub-editor.ts';

--- a/modules/pdf-edit/internal/stub-editor.ts
+++ b/modules/pdf-edit/internal/stub-editor.ts
@@ -1,0 +1,68 @@
+/** Contract: contracts/pdf-edit/rules.md */
+
+/**
+ * Skeleton PdfEditor — stores the annotation layer in-memory and returns
+ * a pointer to the original PDF on save. The real implementation will:
+ *   - Parse the PDF via a sandboxed parser (pinned, deliberation required)
+ *   - Apply incremental saves so pre-existing signatures survive
+ *   - Remove content from the content stream for redactions (not cosmetic)
+ *   - Strip embedded JavaScript on open
+ *   - Delegate signature ceremonies to `esign`
+ */
+
+import {
+  PdfAnnotationLayerSchema,
+  type Annotation,
+  type PdfAnnotationLayer,
+  type PdfEditor,
+  type Redaction,
+} from '../contract.ts';
+
+const NOT_IMPLEMENTED = 'pdf-edit: not implemented (skeleton)';
+
+export function createStubPdfEditor(): PdfEditor {
+  const layers = new Map<string, PdfAnnotationLayer>();
+
+  function getOrInit(documentId: string): PdfAnnotationLayer {
+    const existing = layers.get(documentId);
+    if (existing) return existing;
+    const fresh: PdfAnnotationLayer = PdfAnnotationLayerSchema.parse({
+      document_id: documentId,
+      pdf_storage_key: `stub/${documentId}.pdf`,
+      annotations: [],
+      redactions: [],
+      form_fields: {},
+      updated_at: new Date().toISOString(),
+    });
+    layers.set(documentId, fresh);
+    return fresh;
+  }
+
+  return {
+    async openLayer(documentId) {
+      return getOrInit(documentId);
+    },
+
+    async applyAnnotation(documentId, annotation: Annotation) {
+      const layer = getOrInit(documentId);
+      layer.annotations.push(annotation);
+      layer.updated_at = new Date().toISOString();
+    },
+
+    async applyRedaction(documentId, redaction: Redaction) {
+      const layer = getOrInit(documentId);
+      layer.redactions.push(redaction);
+      layer.updated_at = new Date().toISOString();
+    },
+
+    async fillField(documentId, fieldName, value) {
+      const layer = getOrInit(documentId);
+      layer.form_fields[fieldName] = value;
+      layer.updated_at = new Date().toISOString();
+    },
+
+    async save(_documentId, _opts) {
+      throw new Error(NOT_IMPLEMENTED);
+    },
+  };
+}

--- a/modules/plugins/contract.ts
+++ b/modules/plugins/contract.ts
@@ -1,0 +1,83 @@
+/** Contract: contracts/plugins/rules.md */
+import { z } from 'zod';
+
+export const CapabilitySchema = z.enum([
+  'document.read',
+  'document.write',
+  'sheet.read',
+  'sheet.write',
+  'slide.read',
+  'slide.write',
+  'kb.read',
+  'kb.write',
+  'workflow.invoke',
+  'net.fetch',
+]);
+
+export type Capability = z.infer<typeof CapabilitySchema>;
+
+export const HookSchema = z.enum([
+  'on_save',
+  'on_export',
+  'on_share',
+  'on_kb_update',
+  'on_form_response',
+]);
+
+export type Hook = z.infer<typeof HookSchema>;
+
+export const UiContributionSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('toolbar_button'),
+    id: z.string().min(1),
+    target: z.enum(['document', 'sheet', 'slide', 'diagram']),
+    label: z.string().min(1),
+    icon: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal('sidebar_panel'),
+    id: z.string().min(1),
+    target: z.enum(['document', 'sheet', 'slide', 'diagram', 'global']),
+    title: z.string().min(1),
+  }),
+]);
+
+export type UiContribution = z.infer<typeof UiContributionSchema>;
+
+export const PluginManifestSchema = z.object({
+  name: z.string().min(1),
+  version: z.string().min(1),
+  host_api: z.string().min(1),
+  entry_wasm: z.string().optional(),
+  entry_ui: z.string().optional(),
+  hooks: z.array(HookSchema).default([]),
+  capabilities: z.array(CapabilitySchema).default([]),
+  ui: z.array(UiContributionSchema).default([]),
+  publisher: z.string().min(1),
+  signature: z.string().min(1).optional(),
+});
+
+export type PluginManifest = z.infer<typeof PluginManifestSchema>;
+
+export const InstalledPluginSchema = z.object({
+  id: z.string().min(1),
+  workspace_id: z.string().min(1),
+  manifest: PluginManifestSchema,
+  enabled: z.boolean(),
+  installed_by: z.string().min(1),
+  installed_at: z.string(),
+});
+
+export type InstalledPlugin = z.infer<typeof InstalledPluginSchema>;
+
+export interface PluginRegistry {
+  install(workspaceId: string, manifest: PluginManifest, installedBy: string): Promise<InstalledPlugin>;
+  uninstall(workspaceId: string, pluginId: string): Promise<void>;
+  setEnabled(workspaceId: string, pluginId: string, enabled: boolean): Promise<void>;
+  listInstalled(workspaceId: string): Promise<InstalledPlugin[]>;
+  forHook(workspaceId: string, hook: Hook): Promise<InstalledPlugin[]>;
+}
+
+export interface PluginsModule {
+  registry: PluginRegistry;
+}

--- a/modules/plugins/index.ts
+++ b/modules/plugins/index.ts
@@ -1,0 +1,20 @@
+/** Contract: contracts/plugins/rules.md */
+export {
+  CapabilitySchema,
+  HookSchema,
+  UiContributionSchema,
+  PluginManifestSchema,
+  InstalledPluginSchema,
+} from './contract.ts';
+
+export type {
+  Capability,
+  Hook,
+  UiContribution,
+  PluginManifest,
+  InstalledPlugin,
+  PluginRegistry,
+  PluginsModule,
+} from './contract.ts';
+
+export { createMemoryPluginRegistry } from './internal/memory-registry.ts';

--- a/modules/plugins/internal/memory-registry.ts
+++ b/modules/plugins/internal/memory-registry.ts
@@ -1,0 +1,72 @@
+/** Contract: contracts/plugins/rules.md */
+
+/**
+ * Skeleton PluginRegistry. Production will:
+ *   - Verify Ed25519 signatures against the workspace trust store
+ *   - Persist to Postgres (`installed_plugins` table)
+ *   - Intersect declared capabilities with workspace policy before install
+ *   - Dispatch hooks via the `workflow` Wasm sandbox with per-plugin
+ *     memory/CPU/time budgets
+ *   - Emit `PluginInstalled` / `PluginExecuted` / `PluginFailed` events
+ *     (sampled for executions above N/minute)
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  PluginManifestSchema,
+  type Hook,
+  type InstalledPlugin,
+  type PluginManifest,
+  type PluginRegistry,
+} from '../contract.ts';
+
+export function createMemoryPluginRegistry(): PluginRegistry {
+  const byWorkspace = new Map<string, InstalledPlugin[]>();
+
+  function list(workspaceId: string): InstalledPlugin[] {
+    return byWorkspace.get(workspaceId) ?? [];
+  }
+
+  return {
+    async install(workspaceId, manifest: PluginManifest, installedBy) {
+      const parsed = PluginManifestSchema.parse(manifest);
+      const existing = list(workspaceId);
+      const installed: InstalledPlugin = {
+        id: randomUUID(),
+        workspace_id: workspaceId,
+        manifest: parsed,
+        enabled: true,
+        installed_by: installedBy,
+        installed_at: new Date().toISOString(),
+      };
+      byWorkspace.set(workspaceId, [...existing, installed]);
+      return installed;
+    },
+
+    async uninstall(workspaceId, pluginId) {
+      byWorkspace.set(
+        workspaceId,
+        list(workspaceId).filter((p) => p.id !== pluginId),
+      );
+    },
+
+    async setEnabled(workspaceId, pluginId, enabled) {
+      byWorkspace.set(
+        workspaceId,
+        list(workspaceId).map((p) =>
+          p.id === pluginId ? { ...p, enabled } : p,
+        ),
+      );
+    },
+
+    async listInstalled(workspaceId) {
+      return list(workspaceId);
+    },
+
+    async forHook(workspaceId: string, hook: Hook) {
+      return list(workspaceId).filter(
+        (p) => p.enabled && p.manifest.hooks.includes(hook),
+      );
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Closes feature gaps from the office-parity review (items 7, 9, 10 + extras) with contracts-first scaffolding for five new modules, an admin policy sub-contract, and one real runtime landing: per-document Yjs IndexedDB persistence for offline-first editing.

Items 1–6 (mail, calendar, chat, video, AI copilot, native apps) are deferred to a separate sprint; item 8 (enterprise auth hardening, SCIM) is blocked by `CONSTITUTION.md` restricted-zone rules and flagged for human-maintainer sign-off. Full punch list lives in the new "Office-Parity Sprint" section of `docs/mvp.md`.

## What landed

### Contracts (7)

- `contracts/forms/rules.md` — form builder with schema-versioned responses and KB dataset mirror
- `contracts/pdf-edit/rules.md` — native PDF annotate/fill/redact, JS strip on open, incremental save, signatures delegated to `esign`
- `contracts/esign/rules.md` — PKCS#7 ceremony with HMAC-chained audit trail, RFC 3161 timestamps, sequential/parallel packets
- `contracts/plugins/rules.md` — extension API riding on `workflow`'s Wasm sandbox; capability-gated, signed manifests, origin-pinned UI
- `contracts/diagrams/rules.md` — Visio/draw.io parity with KB entry sync and deterministic SVG rendering
- `contracts/app-admin/policy.md` — workspace policy control plane (retention, DLP, watermark, labels, branding); UI renders, enforcement lives in `erasure`/`audit`/`sharing`/`convert`
- `contracts/app/offline.md` — extended with Yjs persistence invariants (§8–§10), reconnect merge order, per-document IndexedDB isolation

### Skeletons

Zod schemas, in-memory stores, and barrel exports for each new module plus the admin policy panel. Behavioral invariants flagged in comments where the skeleton does not yet enforce them.

### Offline-first (real landing)

- `modules/app/internal/offline/yjs-persistence.ts` — per-document IndexedDB provider for Yjs `Doc`. Replays stored updates **before** Hocuspocus opens its socket so offline edits ride the standard sync state-vector exchange. Graceful degradation when IndexedDB is unavailable. Compaction every 200 updates.
- Wired into `modules/app/internal/editor/editor.ts` init sequence.

## Out of scope (tracked in roadmap)

- **Items 1–6** — separate sprint. Listed in `docs/mvp.md` so we don't lose them.
- **Item 8** — `modules/auth/`, `migrations/`, `package.json` are restricted zones. Contracts-only work there requires maintainer sign-off.
- **Large-document performance** — needs a perf harness before implementation.

## Test plan

- [ ] CI: lint, typecheck, vitest, contract tests pass against the new modules
- [ ] Manual: open a document, confirm it loads as before (Yjs persistence is additive — no behavioral change online)
- [ ] Manual offline: open doc, DevTools → Application → Service Workers → Offline, type a paragraph, reload (still offline), confirm paragraph is still in the editor
- [ ] Manual reconnect merge: with two browser contexts A + B both online, take A offline, edit in both, bring A back online, confirm both edit sets converge in both contexts after `synced`
- [ ] Confirm `opendesk-yjs-<documentId>` databases appear in DevTools → Application → IndexedDB and clear cleanly via `persistence.clear()` (exposed on `window` for debugging)
- [ ] Sanity: existing Playwright suite still green (no regressions in editor boot path)

## Follow-ups (next PRs)

- Mirror the Yjs persistence hook into the Sheets and Slides editors (Documents only this PR)
- Hook `modules/erasure` into `YjsPersistenceHandle.clear()` for workspace/user erasure
- Replace in-memory stores in `forms`/`esign`/`plugins`/`diagrams` with Postgres-backed implementations (each its own PR, schemas land via `migrations/` review)
- `app-admin/policy` enforcement bridges into `erasure`/`audit`/`sharing`/`convert`

https://claude.ai/code/session_01TQCMCAoJJTkQJCuEe1Wp3C