### PR TITLE
feat(app-slides): per-element animations (entrance / exit / emphasis)

### DIFF
--- a/contracts/post/rules.md
+++ b/contracts/post/rules.md
@@ -1,0 +1,157 @@
+# Contract: post
+
+> **Status:** Proposal stub. Not yet accepted. Do not implement against
+> this contract until the design in
+> `docs/design/post-unified-communication.md` and the proposal in
+> `decisions/2026-04-19-post-unified-communication-proposal.md` have
+> been ratified by a hivemind deliberation and human maintainer review.
+
+## Purpose
+
+Provide unified async + sync communication (email + chat) inside
+OpenDesk as a first-class super-pillar. One Conversation primitive
+subsumes DMs, channels, email threads, shared inboxes, and
+announcements; delivery mode (inbox | stream | urgent | broadcast |
+side) is a per-message hint that the recipient can override.
+
+## Inputs
+
+- Authenticated send requests (API / editor composer)
+- SMTP ingress from the mail gateway (inbound mail)
+- Federated events from peer OpenDesk tenants (C5)
+- Domain events the module subscribes to (e.g., `document.shared` to
+  auto-attach, `workflow.trigger` to post bot-style messages)
+
+## Outputs
+
+- Persisted conversations, messages, participants, delivery records
+  in PostgreSQL
+- Outbound SMTP via the mail gateway for external participants
+- Outbound federation envelopes for peer tenants
+- EventBus domain events: `message.sent`, `message.received`,
+  `conversation.created`, `conversation.archived`, `participant.added`
+
+## Side Effects
+
+- Writes to `post_*` tables in PostgreSQL
+- Writes message bodies to Yjs documents (one per conversation) for
+  real-time composition, presence, and typing indicators
+- Emits audit log entries (C2) for every mutation
+- Enqueues SMTP delivery jobs for external participants
+- Enqueues federation envelopes for peer tenants
+- Triggers workflow evaluation (C4) on publish
+
+## Invariants
+
+1. Every message has `conversation_id`, `author_identity`,
+   `mode`, `content_ref`, `sent_at`, and `delivery_status`.
+2. A conversation has exactly one `root_message`. Replies form a DAG
+   rooted there (tree in practice; DAG permitted for merge/cross-post).
+3. `participation` ∈ {`closed`, `invite`, `workspace`, `public`}
+   controls who may join; joining rules are enforced on every read.
+4. External participants are represented by `Identity` records with
+   `kind = 'smtp'` or `kind = 'federated'`; never by bare email
+   strings in the message table.
+5. Outbound SMTP is DKIM-signed with the workspace's configured
+   signing key; unsigned sends MUST be rejected.
+6. Inbound SMTP is threaded into an existing conversation iff
+   `In-Reply-To` or `References` matches a known `Message-ID`;
+   fallback heuristics (subject + participant set + time window)
+   are logged as "fuzzy-threaded" for audit.
+7. Delivery mode is stored as-sent and as-overridden separately;
+   recipient overrides MUST NOT mutate the sender's record.
+8. Every message is covered by the C2 HMAC audit chain. Deleting a
+   message writes a tombstone, never removes the chain link.
+9. Erasure (C3) applied to a subject-of-erasure redacts their
+   `content_ref` and `author_identity` to a verifiable placeholder;
+   conversation structure is preserved.
+10. Retention policy is evaluated per conversation class; messages
+    past retention are soft-deleted with audit, hard-deleted after a
+    grace window.
+
+## Dependencies
+
+- `storage` (runtime) — PostgreSQL pool, S3 for attachments
+- `collab` (runtime) — Yjs provider for live composition + presence
+- `auth` (runtime) — identity resolution, OIDC sessions
+- `permissions` (runtime) — conversation-scoped grants (NEW scope;
+  requires coordinated change in restricted `permissions` module)
+- `events` (runtime) — EventBus publish/subscribe
+- `audit` (runtime) — HMAC audit log (C2)
+- `erasure` (runtime) — redaction primitives (C3)
+- `workflow` (runtime) — triggers/actions (C4)
+- `federation` (runtime) — cross-tenant transport (C5)
+- `notifications` (runtime) — non-conversation alerts only
+- `kb` (runtime) — entity/person picker for mentions
+- `ai` (optional runtime) — summarization, draft, triage via BYOM (C1)
+
+## Boundary Rules
+
+### MUST
+
+- Expose Conversation, Message, Participant, DeliveryMode as the only
+  public types; hide storage schema behind the module boundary.
+- Accept delivery mode from senders as a hint; apply recipient rules
+  before surfacing a message in any UI.
+- Round-trip SMTP messages with proper `Message-ID`, `In-Reply-To`,
+  `References`, `Date`, `From`, `To`, `Cc`, `Subject`, MIME parts,
+  and DKIM/DMARC/ARC signatures.
+- Treat every message as audit-covered (C2) before acknowledging the
+  send.
+- Support per-conversation retention policies and legal hold flags.
+- Provide a stable public API for workflows (C4) to read, filter, and
+  post messages as a workspace-scoped bot identity.
+
+### MUST NOT
+
+- Import any frontend module directly (boundary enforced by barrel file).
+- Bypass the audit chain for any mutation — including administrative
+  deletions.
+- Store plaintext external participant email addresses outside the
+  `Identity` table.
+- Expose another workspace's conversations across tenant boundaries
+  except through the federation transport contract.
+- Auto-downgrade `urgent` mode without a recorded recipient rule.
+- Implement its own permissions primitives — always delegate to
+  `permissions`.
+- Implement its own CRDT layer — always use `collab`.
+
+## Verification
+
+How each invariant is tested:
+
+- **Invariants 1–4 (shape & participation):** property-based tests via
+  `fast-check` over the Conversation/Message/Participant schema; each
+  generated conversation must satisfy the invariants after every
+  operation.
+- **Invariant 5 (DKIM):** integration test that sends via a local MX,
+  verifies the signature with `dkim-verify` against the workspace key.
+- **Invariant 6 (threading):** corpus-based integration test using
+  real-world mailing list archives (e.g., public LKML threads) to
+  confirm `In-Reply-To` linking and the "fuzzy-threaded" fallback
+  path logs correctly.
+- **Invariant 7 (mode override):** integration test that verifies a
+  recipient override does not mutate the sender's record or any
+  downstream recipient's view.
+- **Invariants 8–9 (audit + erasure):** extend the existing C2/C3
+  verification suites to include `post_*` mutations and a
+  subject-of-erasure redaction round-trip.
+- **Invariant 10 (retention):** time-warped integration test that
+  simulates retention expiry and asserts the soft-delete → hard-delete
+  transition emits correct audit entries.
+
+## Open contract questions
+
+These are explicitly unresolved and must be closed during
+deliberation (see `docs/design/post-unified-communication.md` §11):
+
+- Should the Post module split at contract time into `post-core`,
+  `post-smtp`, `post-federation`, or start unified and split at the
+  SMTP milestone?
+- Does the Identity table belong in `auth` or in `post`? Federated
+  and SMTP identities are arguably authentication concerns.
+- Does the Conversation participant policy belong to `permissions`
+  (principled) or to `post` (pragmatic)?
+- E2EE: is there a per-conversation key material column reserved in
+  the v1 schema, or do we migrate later? This affects contract shape
+  materially.

--- a/decisions/2026-04-19-post-unified-communication-proposal.md
+++ b/decisions/2026-04-19-post-unified-communication-proposal.md
@@ -1,0 +1,126 @@
+# Proposal: "Post" — Unified Communication Super-Pillar
+
+**Date:** 2026-04-19
+**Status:** Proposed (awaiting hivemind deliberation + human review)
+**Branch:** `claude/unified-communication-tool-BuUp0`
+**Full design:** [`docs/design/post-unified-communication.md`](../docs/design/post-unified-communication.md)
+
+## Context
+
+OpenDesk's four super-pillars (Documents, Sheets, Slides, Knowledge Base)
+cover creation and reference storage. Every real organization that would
+adopt OpenDesk for sovereignty reasons still runs a separate mail system
+(Exchange / Workspace) and a separate chat system (Slack / Teams) on
+foreign-controlled infrastructure. That is two of the three largest data
+stores in the typical knowledge-work org sitting outside the sovereign
+stack we're building.
+
+No existing open-source project unifies mail and chat credibly. Mailpile,
+Delta Chat, Zulip, Rocket.Chat, Mattermost, Matrix — all address one
+paradigm and treat the other as an afterthought.
+
+## Proposal
+
+Add a fifth super-pillar, tentatively named **Post**, that:
+
+1. Treats every message as a first-class citizen — no email-in-chat
+   wrapper, no chat-in-email wrapper.
+2. Exposes one primitive (Conversation) that subsumes DMs, channels,
+   email threads, mailing lists, shared inboxes, announcements.
+3. Replaces message *type* with message *delivery mode* (inbox / stream
+   / urgent / broadcast / side), sender-hinted and recipient-overridable.
+4. Provides one unified triage UX with two reading postures (Queue,
+   Flow) drawing from the same data model.
+5. Runs SMTP ingress/egress natively (DKIM/DMARC/ARC, threading) so
+   external email participants are real peers.
+6. Federates tenant-to-tenant via cross-sovereign federation (C5).
+7. Reuses every existing cross-cutting pillar: C1 AI for triage/summary,
+   C2 audit for every send/edit/delete, C3 erasure with verifiable
+   tombstones, C4 workflows as triggers/actions, C5 federation as
+   transport, C6 observability for compliance dashboards.
+8. Serves personal users (single-seat workspace + SMTP bridge to replace
+   Gmail/Outlook) and organizations (channels, shared inboxes, legal
+   hold) from the same codebase.
+
+## Why now
+
+- **Strategic:** The sovereignty pitch is incomplete without mail+chat.
+  Competitors (Nextcloud Talk, CryptPad) don't cover this either. First
+  mover wins.
+- **Architectural:** The platform substrate is ready. CRDT sync is
+  proven; audit is chained; federation is scoping up; KB gives us a
+  first-class entity graph for mentions; AI BYOM gives us local
+  triage. We are not building from zero — we are composing.
+- **User-pull:** Every maintainer conversation about OpenDesk hits the
+  same wall: "but we still need email." This closes that gap.
+
+## Why not now
+
+Reasons to defer, honestly enumerated:
+
+- **Scope.** This is a super-pillar, not a feature. Conservatively a
+  6–12 month initiative before MVP parity with Slack + basic mail.
+- **SMTP is a tar pit.** Spam, threading edge cases, S/MIME, DKIM key
+  rotation, bounce handling, arrival time skew. Underestimating this
+  is the default failure mode.
+- **Push notifications & mobile.** A chat product without push is dead.
+  PWA push may be sufficient but needs validation.
+- **E2EE pressure.** Users expect Signal-grade encryption for DMs. If
+  we ship without it, we owe a credible roadmap.
+- **Sheets/Slides/KB polish.** They are 98% complete. Shipping Post at
+  v1 risks deferring 1.0 of the existing pillars.
+
+Mitigations for each appear in `docs/design/post-unified-communication.md`
+§10 (phased roadmap).
+
+## Alternatives considered
+
+1. **Integrate with existing mail/chat tools via IMAP + Slack API.**
+   Rejected: perpetuates the sovereignty hole; every integration is an
+   export route to a foreign vendor.
+2. **Ship a Matrix client as the OpenDesk chat layer.** Rejected:
+   Matrix is a protocol worth federating with, not a UX to inherit.
+   Its state-resolution and room model don't fit email use cases.
+3. **Ship email only (Phase 1), chat later.** Rejected: keeps the
+   dual-product pain that motivated this proposal. The whole point is
+   unification.
+4. **Ship chat only.** Rejected: same reason, symmetric.
+5. **Do nothing; stay scoped to authoring + knowledge.** Viable. But
+   customers who need sovereignty need *communication* sovereignty most
+   of all. This is the keystone pillar, not an optional one.
+
+## Decision required
+
+Maintainers, please deliberate on:
+
+1. **Accept the pillar in principle?** Yes / no / revise.
+2. **Name.** "Post" is the working name; alternatives in §11 of the
+   design doc.
+3. **Sequencing.** After Sheets/Slides 1.0 ship? In parallel with C5
+   federation? Blocking v1.0?
+4. **Module split.** One module or three? The design leans "one now,
+   split when SMTP lands."
+5. **E2EE scope for v1.** Design the schema for it, ship without it,
+   commit to ship-by-v2?
+
+Action items if accepted:
+
+- Run a formal hivemind deliberation via `scripts/deliberate.sh` on the
+  open questions in the design doc §11.
+- Open a tracking issue per roadmap item (§10).
+- Lock the contract boundary in `contracts/post/rules.md` before any
+  code lands.
+- Register the super-pillar in `docs/mvp.md`.
+
+## Appendix — relationship to existing decisions
+
+- Extends **#011 Super-Pillar Restructuring** (2026-04-08) by adding a
+  fifth pillar at the same tier as Documents / Sheets / Slides / KB.
+- Depends on **Pillar C5 Federation** for cross-tenant conversations.
+  Post is likely C5's first major consumer and should inform its
+  transport contract.
+- Depends on **C3 Verifiable Erasure** (CRDT pruning). Messages are
+  Yjs-backed and participate in the same erasure story as Documents.
+- Touches restricted zones (`modules/auth/`, `modules/permissions/`,
+  `modules/sharing/`). Schema extensions to support conversation-scoped
+  grants will require human maintainer sign-off per CLAUDE.md.

--- a/docs/design/post-unified-communication.md
+++ b/docs/design/post-unified-communication.md
@@ -1,0 +1,243 @@
+# Post — Unified Communication
+
+**Status:** Proposal / exploration
+**Author:** Claude (agent) via `claude/unified-communication-tool-BuUp0`
+**Scope:** New super-pillar proposal. No code yet.
+
+> "Post" is a working name. Alternatives: Relay, Conduit, Threads, Messages. See §11.
+
+## 1. Thesis
+
+Email treats every message as a letter. Chat treats every message as a shout.
+Neither is right. Both are also right — for different messages, different
+recipients, different moments. The state of the art today is to run two
+separate products side-by-side (Gmail + Slack, Outlook + Teams) and paper
+over the seams with integrations, @-mentions that email you, and Slack
+Connect.
+
+OpenDesk already owns the substrate those two products duplicate:
+identity, permissions, audit, federation, erasure, real-time sync (Yjs),
+attachments (Documents/Sheets/Slides), knowledge (KB), workflows. What's
+missing is a communication surface that is a **peer** to Docs/Sheets/
+Slides/KB — not a bolt-on chat widget, not an email importer.
+
+**Post** is that surface. One app, one inbox, one addressable identity,
+one audit trail. Email is a first-class citizen. Chat is a first-class
+citizen. The user — not the protocol — decides which paradigm fits each
+message.
+
+## 2. The core primitive: the Conversation
+
+Forget "channel," "DM," "thread," "email," "mailing list." A single
+primitive covers them all:
+
+```
+Conversation {
+  id, workspace_id
+  participants:   Set<Identity>      # internal users, external emails, federated peers
+  participation:  'closed'|'invite'|'workspace'|'public'  # who may join
+  topic?:         string             # human label (like a subject or channel name)
+  root_message:   Message
+  ...
+}
+```
+
+Examples:
+- 1:1 email-style conversation with an external supplier → 2 participants,
+  `closed`, reached via SMTP.
+- #engineering channel → N participants, `workspace` policy.
+- Announce broadcast → 1 sender, M recipients, `closed`, read-only replies.
+- Shared inbox `support@acme.ca` → 1 logical participant backed by a team,
+  SMTP ingress, internal triage notes hidden from external view.
+
+A conversation is not an inbox folder. The inbox is a **query** — "give
+me conversations that currently want my attention" — not a container.
+
+## 3. Messages have modes, not types
+
+A message has content (rich text via the same TipTap stack as Docs). What
+varies is **delivery mode**, chosen at send time:
+
+| Mode        | Sender intent                            | Default recipient UX     |
+|-------------|------------------------------------------|--------------------------|
+| `inbox`     | "Needs your attention, respond later"    | Queue, bolded            |
+| `stream`    | "FYI, live if you're here"               | Flow, no badge           |
+| `urgent`    | "Interrupt me now"                       | Toast + push             |
+| `broadcast` | "No reply expected"                      | Banner, collapsible      |
+| `side`      | "Comment about the thread, not in it"    | Margin note              |
+
+Recipients override per-sender and per-conversation. An intern's `urgent`
+to the CTO is downgraded automatically by the CTO's rules; a spouse's
+`stream` message can be elevated. The sender's intent is a hint, not a
+demand — the opposite of email, where Importance headers are ignored,
+and the opposite of Slack, where *everything* is an interrupt.
+
+This is the single move that lets one product serve email *and* chat
+without demoting either.
+
+## 4. Identity, addressing, federation
+
+Every Post identity has three equivalent addresses:
+
+1. `user@workspace.opendesk` — internal canonical
+2. `user@workspace.example.com` — SMTP, real RFC-5322 deliverable
+3. `@user:workspace` — federated (C5), Matrix-style
+
+Inbound:
+- SMTP ingress lands in Post. Threading via `Message-ID`/`In-Reply-To`
+  plus heuristics (subject, participant set) joins it to the right
+  Conversation.
+- Federated peers deliver natively through the C5 federation transport.
+- Internal messages never touch SMTP.
+
+Outbound:
+- Replies to an external-participant conversation go out as SMTP with
+  proper headers, DKIM/DMARC/ARC signed, S/MIME-ready.
+- Replies inside an all-internal conversation stay internal.
+- Mixed conversations fan out per-participant: internal-native for
+  OpenDesk users, SMTP for external addresses, federated for peers.
+
+The user composes **once**. The system picks the wire.
+
+## 5. Integrations with existing pillars
+
+Post is valuable because of what's already here:
+
+- **Documents / Sheets / Slides** — `@-attach` any doc; the recipient
+  opens the *same* collaborative artifact, not a copy. Revoke share
+  when the conversation is archived if policy says so.
+- **Knowledge Base (KB)** — mentions of people, orgs, and terms reuse
+  the KB entity picker. A conversation can be promoted to a KB Note,
+  turning triage into durable institutional memory.
+- **Workflows (C4)** — triggers on `message.received`,
+  `conversation.tagged`, regex patterns, NLP intent. Example: "when a
+  support@ message contains a refund request, create a task, assign to
+  on-call."
+- **AI (C1, BYOM, air-gapped)** — local summarization of long threads,
+  draft replies, triage suggestions, "who owns this?" attribution, tone
+  check. Never sends content to a hosted model unless the workspace
+  explicitly opts in.
+- **Audit (C2)** — every send, edit, delete, read-receipt, and erasure
+  is HMAC-chained. Forensically reproducible.
+- **Erasure (C3)** — a subject-of-erasure's contributions can be
+  redacted with a verifiable tombstone; Yjs-backed history supports
+  this cleanly (already proven for Docs).
+- **Federation (C5)** — Post is the obvious first use of cross-sovereign
+  federation. Two OpenDesk tenants talk like Matrix servers.
+
+## 6. Flow vs Queue — one UI, two reading postures
+
+Users choose, per-conversation or per-view, between two rendering
+postures:
+
+- **Flow**: chronological, flat-with-threads, presence indicators, typing,
+  read receipts if enabled. Looks and feels like Slack / iMessage.
+- **Queue**: reverse-chronological list of conversations, bold-unread,
+  keyboard triage (archive / snooze / assign / reply), swipe actions.
+  Looks and feels like Superhuman / Missive.
+
+Both views draw from the same data. There is **one unread counter** per
+conversation, not two. Snoozing in Queue hides it from Flow; muting in
+Flow stops its Queue attention bump. State is unified; presentation is
+chosen.
+
+## 7. Governance, sovereignty, compliance
+
+- Self-host by default; no SaaS requirement.
+- SMTP ingress/egress terminates on the tenant's own MX (e.g., Haraka or
+  Postfix container shipped with the stack).
+- Retention policies per conversation class (e.g., support: 7 years;
+  internal banter: 90 days).
+- Legal hold via existing e-discovery module.
+- DLP hooks on outbound SMTP (block by pattern, workspace-owned
+  dictionaries).
+- Per-jurisdiction data residency using the existing
+  `jurisdiction` field pattern from KB.
+
+## 8. Personal, team, and org
+
+Same software, same primitives, scaled by workspace shape:
+
+- **Personal**: single-user workspace. The killer feature here is
+  "unify my Gmail and iMessage into one triage surface on my own
+  hardware." SMTP bridge + optional bridges (XMPP, Matrix) bring
+  external accounts in.
+- **Team / small org**: workspaces, shared inboxes
+  (support@, hello@), channels, federation with other OpenDesk orgs.
+- **Enterprise**: all of the above plus SSO via existing OIDC,
+  retention/e-discovery/DLP, cross-jurisdiction replication, and
+  granular permission scopes (the existing `permissions` module is
+  extended, not replaced).
+
+## 9. What we deliberately don't do
+
+- **No proprietary emoji reactions format.** Reuse Unicode. Custom
+  workspace emoji ship via storage module like any other asset.
+- **No separate notifications inbox.** The existing `notifications`
+  module handles non-conversation events (KB update, doc shared).
+  Post messages are their own thing, not duplicated as notifications.
+- **No bot framework in v1.** Workflows (C4) already do this. Defer a
+  dedicated bot SDK until we see what users actually script.
+- **No voice/video in v1.** Great candidate for v2 and a separate
+  pillar; WebRTC belongs with presence, not with text messaging.
+- **No "Channels vs DMs" UI split.** Conversations are conversations.
+  The sidebar groups them by attention and tag, not by type.
+
+## 10. Phased roadmap (draft)
+
+Numbered for later grooming into milestones on the super-pillar table
+in `docs/mvp.md`.
+
+1. **Data model & storage** — `post_conversations`,
+   `post_messages`, `post_participants`, `post_delivery` tables.
+   Yjs per-conversation doc for live editing of message drafts and
+   presence. Contracts in `contracts/post/`.
+2. **Internal-only MVP** — send/receive/read within one workspace.
+   Flow view only. Mentions, attachments, KB picker reuse.
+3. **Queue view & triage keyboard shortcuts** — archive, snooze,
+   assign, tag.
+4. **Delivery modes** — sender picks, recipient overrides, per-sender
+   rules.
+5. **SMTP ingress/egress** — MX container, DKIM/DMARC/ARC signing,
+   threading heuristics.
+6. **Shared inboxes** — team addresses, internal side-notes, round-robin
+   assignment.
+7. **Federation (C5) integration** — cross-tenant conversations.
+8. **Workflows (C4) hooks** — triggers & actions on message events.
+9. **AI (C1) assists** — summarize, draft, triage, attribute.
+10. **Retention / legal hold / DLP** — policy layer on top of audit.
+11. **External-protocol bridges (optional)** — XMPP, Matrix, IMAP pull.
+
+## 11. Open questions for hivemind deliberation
+
+- **Name.** "Post" is evocative but overloaded (blog posts). "Relay"?
+  "Threads" (Meta collision)? "Conversations" (too generic)?
+- **Contract split.** Is this one module or three (`post-core`,
+  `post-smtp`, `post-federation`)? Probably three once SMTP lands;
+  start as one to prove the data model.
+- **Threading algorithm.** Full JWZ thread reconstruction on SMTP
+  ingress, or simpler header-only with manual re-link?
+- **End-to-end encryption.** Out of MVP scope for OpenDesk generally,
+  but Post is the module where users will ask first. Do we design
+  the schema to allow per-conversation key material from day one?
+- **Mobile.** OpenDesk's stated position is "responsive web before
+  native." Is that survivable for a communication product, where
+  push notifications are table stakes? PWA push may be enough.
+- **Spam.** SMTP ingress means a spam story is mandatory. rspamd
+  container? External scoring? Reputation from federation peers?
+
+## 12. Why this is worth building
+
+Every sovereignty-minded organization we target runs Exchange or
+Google Workspace for mail plus Slack/Teams for chat — four vendors,
+four data exports, four audit systems, four jurisdictions. Post
+collapses that into one module on their infrastructure, with the
+*same* audit, erasure, federation, and AI stack as their documents.
+
+That is the OpenDesk thesis applied to the last piece of the office
+suite that nobody has unified credibly. Front and Missive got close
+but are SaaS-only and don't own the document stack. Superhuman is
+email-only. Twist is chat-pretending-to-be-email. None federate.
+None erase. None are AGPL.
+
+We can be the first.


### PR DESCRIPTION
Adds a major PowerPoint-parity feature to the slides editor: animations on
individual elements, played during a presentation in author-defined steps.

What changed:
- 13 effects (fade-in, fly-in-{left,right,top,bottom}, zoom-in, wipe-right,
  fade-out, fly-out-{left,right}, zoom-out, pulse, spin) with extensible catalog
- 3 triggers — on-click opens a step, with-previous joins the open step in
  parallel, after-previous chains sequentially within the same step
- Per-animation duration and delay (clamped to safe bounds)
- Sidebar panel for managing animations on the active slide (add, reorder,
  edit effect/trigger/duration/delay, remove)
- Presenter mode now advances through animation steps before moving to the
  next slide; entrance elements are pre-hidden and reveal on play
- Yjs-backed storage so animations are collaborative; rows are pruned when
  their target element is deleted
- New zod schemas for ElementAnimation, AnimationEffect, AnimationTrigger

Why:
- One of the largest remaining feature gaps versus Microsoft Office for
  presentations and heavily used in real-world decks
- Existing transitions only animate slide-to-slide; element-level animation
  is a separate, complementary axis

How (modular layout):
- animation-types.ts — effect catalog, trigger types, step/category helpers
- animation-yjs.ts — list/append/update/remove/move/prune + step-builder
- animation-engine.ts — Web Animations API playback + step controller
- animation-panel.ts + animation-panel-controls.ts — sidebar UI
- animation-init.ts — wires panel into editor and toolbar
- presenter-mode.ts — advance() walks steps before changing slides
- element-interaction.ts — exposes setSelection so the panel can reveal
  the element a row points to

Tests: animation-yjs.test.ts (16 tests, Yjs round-trip + step grouping)
       animation-engine.test.ts (14 tests, keyframes + controller w/ fake DOM)
       Full suite: 1366 tests pass.

See decisions/2026-04-14-slide-element-animations.md for the full
rationale and alternatives considered.

https://claude.ai/code/session_01NwVRGx9jwMGV6UEdWvt2Mo