### PR TITLE
feat(slides): rich text formatting for text and shape elements

### DIFF
--- a/contracts/app/slides-element-types.md
+++ b/contracts/app/slides-element-types.md
@@ -6,15 +6,18 @@ Provide element type renderers, factories, and insert UI for the slide editor. S
 
 ## Inputs
 
-- `SlideElement` objects parsed from Yjs shared state, including type-specific fields (src, shapeType, fill, stroke, strokeWidth, tableData)
-- User interactions: toolbar clicks to insert elements, file picker / drag-and-drop for images, cell editing for tables
+- `SlideElement` objects parsed from Yjs shared state, including type-specific fields (src, shapeType, fill, stroke, strokeWidth, tableData, fontSize, fontColor, textAlign)
+- User interactions: toolbar clicks to insert elements, file picker / drag-and-drop for images, cell editing for tables, double-click for text editing mode
 - `documentId` for image upload API calls
+- Text formatting commands via TipTap mini-editors (bold, italic, underline, strikethrough)
 
 ## Outputs
 
 - DOM elements rendered into the slide viewport for each element type
 - New Yjs element maps inserted via the element factory + insert functions
-- Content/cell updates written back to Yjs on blur events
+- Content/cell updates written back to Yjs on editor update events
+- Text formatting changes (fontSize, fontColor, textAlign) written to Yjs
+- Formatting toolbar DOM element shown when text element is in edit mode
 - Insert toolbar DOM element attached to the presentation header
 
 ## Side Effects
@@ -43,6 +46,9 @@ Provide element type renderers, factories, and insert UI for the slide editor. S
 - `../image-upload.ts` (parent module) -- `uploadImage`, `validateImageFile`, `extractImageFiles`
 - `yjs` (runtime) -- Yjs shared types for element insertion and mutation
 - `./element-interaction.ts` (sibling) -- interaction controller consumes rendered elements
+- `@tiptap/core` (runtime) -- TipTap editor for rich text in text/shape elements
+- `@tiptap/starter-kit` (runtime) -- base editor extensions
+- `@tiptap/extension-underline` (runtime) -- underline mark support
 
 ## Boundary Rules
 
@@ -70,9 +76,13 @@ Provide element type renderers, factories, and insert UI for the slide editor. S
 modules/app/internal/slides/
   types.ts              -- Extended with ShapeType, TableData
   element-renderer.ts   -- Dispatcher: routes element to type-specific renderer
-  render-text.ts        -- Text element renderer (contentEditable)
+  render-text.ts        -- Text element renderer (TipTap mini-editor)
   render-image.ts       -- Image element renderer (img tag)
-  render-shape.ts       -- Shape element renderer (SVG + text overlay)
+  render-shape.ts       -- Shape element renderer (SVG + TipTap text overlay)
+  tiptap-mini-editor.ts -- Lightweight TipTap editor factory for slide elements
+  text-edit-controller.ts -- Manages text editing mode (double-click enter, Escape exit)
+  text-format-toolbar.ts -- Formatting toolbar (bold, italic, underline, strikethrough, font size, color, alignment)
+  text-format.css       -- Styles for TipTap editors and formatting toolbar
   render-table.ts       -- Table element renderer (HTML table with editable cells)
   element-factory.ts    -- Factory functions for creating new elements
   insert-toolbar.ts     -- Insert toolbar UI with shape submenu and table grid picker
@@ -90,3 +100,6 @@ modules/app/internal/slides/
 4. **Table grid** -- Table renders correct number of rows and columns. Cell edits write to Yjs.
 5. **Insert toolbar** -- Each button inserts the correct element type into Yjs.
 6. **Interaction compatibility** -- Inserted elements can be dragged, resized, rotated, selected.
+7. **Text editing mode** -- Double-click activates TipTap editor; single click selects for move/resize.
+8. **Format toolbar** -- Toolbar appears when text element enters edit mode; all formatting changes sync via Yjs.
+9. **Rich text persistence** -- Content stored as HTML in Yjs content field; formatting marks (bold, italic, etc.) survive round-trips.

--- a/modules/app/internal/css/presentation.css
+++ b/modules/app/internal/css/presentation.css
@@ -3,3 +3,4 @@
 @import "../public/presentation.css";
 @import "../slides/interaction.css";
 @import "../slides/element-types.css";
+@import "../slides/text-format.css";

--- a/modules/app/internal/presentation-editor.ts
+++ b/modules/app/internal/presentation-editor.ts
@@ -8,6 +8,7 @@ import type { SlideElement } from './slides/types.ts';
 import { renderElement } from './slides/element-renderer.ts';
 import { createInsertToolbar, type InsertAction } from './slides/insert-toolbar.ts';
 import { insertElement, updateTableCell } from './slides/yjs-element-insert.ts';
+import { applyFieldUpdate } from './slides/yjs-mutations.ts';
 import { createTextElement, createImageElement, createShapeElement, createTableElement } from './slides/element-factory.ts';
 import { openSlideImagePicker, setupSlideDragDrop } from './slides/slide-image-upload.ts';
 import { parseSlideElements } from './slides/parse-elements.ts';
@@ -47,7 +48,8 @@ function init() {
       const titleEl = new Y.Map<unknown>();
       const defaults: Record<string, unknown> = {
         id: crypto.randomUUID(), type: 'text', x: 10, y: 10, width: 80, height: 20,
-        rotation: 0, content: 'Click to add title',
+        rotation: 0, content: '<p>Click to add title</p>',
+        fontSize: 36, fontColor: '#000000', textAlign: 'center',
       };
       for (const [k, v] of Object.entries(defaults)) titleEl.set(k, v);
       elements.insert(0, [titleEl]);
@@ -82,6 +84,10 @@ function init() {
     });
   }
 
+  function handleStyleUpdate(elementId: string, field: string, value: unknown) {
+    applyFieldUpdate(ydoc, { yElements: getActiveYElements() }, elementId, field, value);
+  }
+
   function handleCellUpdate(elementId: string, row: number, col: number, value: string) {
     updateTableCell(ydoc, getActiveYElements(), elementId, row, col, value);
   }
@@ -109,8 +115,8 @@ function init() {
     viewportEl.innerHTML = '';
     const elements = getSlideElements(activeSlideIndex);
     for (const el of elements) {
-      const domEl = renderElement(el, handleContentUpdate, handleCellUpdate);
-      viewportEl.appendChild(domEl);
+      const result = renderElement(el, handleContentUpdate, handleStyleUpdate, handleCellUpdate);
+      viewportEl.appendChild(result.dom);
     }
   }
 
@@ -127,6 +133,7 @@ function init() {
       getActiveSlideElements() {
         return { yElements: getActiveYElements(), elements: getSlideElements(activeSlideIndex) };
       },
+      onStyleUpdate: handleStyleUpdate,
     });
   }
   initInteraction();
@@ -148,35 +155,25 @@ function init() {
   }
 
   const insertToolbar = createInsertToolbar(handleInsertAction);
-  if (toolbarRight) {
-    toolbarRight.insertBefore(insertToolbar, toolbarRight.firstChild);
-  }
+  if (toolbarRight) toolbarRight.insertBefore(insertToolbar, toolbarRight.firstChild);
 
-  // Image drag-and-drop on viewport
   setupSlideDragDrop(viewportEl, documentId, (url) => {
     insertElement(ydoc, getActiveYElements(), createImageElement(url));
   });
 
-  // Add slide button
-  if (addSlideBtn) {
-    addSlideBtn.addEventListener('click', () => {
-      ydoc.transact(() => {
-        const slide = new Y.Map<unknown>();
-        slide.set('layout', 'blank');
-        slide.set('elements', new Y.Array<Y.Map<unknown>>());
-        yslides.insert(yslides.length, [slide]);
-      });
-      activeSlideIndex = yslides.length - 1;
-      renderSlideList();
-      renderActiveSlide();
+  addSlideBtn?.addEventListener('click', () => {
+    ydoc.transact(() => {
+      const slide = new Y.Map<unknown>();
+      slide.set('layout', 'blank');
+      slide.set('elements', new Y.Array<Y.Map<unknown>>());
+      yslides.insert(yslides.length, [slide]);
     });
-  }
-
-  // Re-render on remote changes
-  yslides.observeDeep(() => {
+    activeSlideIndex = yslides.length - 1;
     renderSlideList();
     renderActiveSlide();
   });
+
+  yslides.observeDeep(() => { renderSlideList(); renderActiveSlide(); });
 
   // Presence
   function updateUsers() {

--- a/modules/app/internal/slides/element-factory.test.ts
+++ b/modules/app/internal/slides/element-factory.test.ts
@@ -13,9 +13,12 @@ describe('createTextElement', () => {
     const el = createTextElement();
     expect(el.type).toBe('text');
     expect(el.id).toMatch(/^[0-9a-f]{8}-/);
-    expect(el.content).toBe('Click to edit text');
+    expect(el.content).toBe('<p>Click to edit text</p>');
     expect(el.width).toBeGreaterThan(0);
     expect(el.height).toBeGreaterThan(0);
+    expect(el.fontSize).toBe(24);
+    expect(el.fontColor).toBe('#000000');
+    expect(el.textAlign).toBe('left');
   });
 
   it('produces unique IDs on each call', () => {
@@ -34,13 +37,16 @@ describe('createImageElement', () => {
 });
 
 describe('createShapeElement', () => {
-  it('creates a rectangle shape', () => {
+  it('creates a rectangle shape with text defaults', () => {
     const el = createShapeElement('rectangle');
     expect(el.type).toBe('shape');
     expect(el.shapeType).toBe('rectangle');
     expect(el.fill).toBeTruthy();
     expect(el.stroke).toBeTruthy();
     expect(el.strokeWidth).toBeGreaterThan(0);
+    expect(el.fontSize).toBe(24);
+    expect(el.fontColor).toBe('#000000');
+    expect(el.textAlign).toBe('center');
   });
 
   it('creates a line with different default dimensions', () => {

--- a/modules/app/internal/slides/element-factory.ts
+++ b/modules/app/internal/slides/element-factory.ts
@@ -1,7 +1,8 @@
 /** Contract: contracts/app/slides-element-types.md */
 
-import type { ShapeType, TableData } from './types.ts';
+import type { ShapeType, TableData, TextAlign } from './types.ts';
 import { createDefaultTableData } from './render-table.ts';
+import { TEXT_DEFAULTS } from './tiptap-mini-editor.ts';
 
 type NewElementBase = {
   id: string;
@@ -15,6 +16,9 @@ type NewElementBase = {
 export type NewTextElement = NewElementBase & {
   type: 'text';
   content: string;
+  fontSize: number;
+  fontColor: string;
+  textAlign: TextAlign;
 };
 
 export type NewImageElement = NewElementBase & {
@@ -26,6 +30,9 @@ export type NewImageElement = NewElementBase & {
 export type NewShapeElement = NewElementBase & {
   type: 'shape';
   content: string;
+  fontSize: number;
+  fontColor: string;
+  textAlign: TextAlign;
   shapeType: ShapeType;
   fill: string;
   stroke: string;
@@ -54,7 +61,10 @@ export function createTextElement(): NewTextElement {
     width: 60,
     height: 15,
     rotation: 0,
-    content: 'Click to edit text',
+    content: '<p>Click to edit text</p>',
+    fontSize: TEXT_DEFAULTS.fontSize,
+    fontColor: TEXT_DEFAULTS.fontColor,
+    textAlign: TEXT_DEFAULTS.textAlign,
   };
 }
 
@@ -85,6 +95,9 @@ export function createShapeElement(shapeType: ShapeType): NewShapeElement {
     height: isLine ? 5 : 30,
     rotation: 0,
     content: '',
+    fontSize: TEXT_DEFAULTS.fontSize,
+    fontColor: TEXT_DEFAULTS.fontColor,
+    textAlign: 'center',
     shapeType,
     fill: isLine ? 'none' : '#4f87e0',
     stroke: '#2563eb',

--- a/modules/app/internal/slides/element-interaction.ts
+++ b/modules/app/internal/slides/element-interaction.ts
@@ -14,17 +14,20 @@ import {
   applyPositionUpdates, applyBoundsUpdate, applyRotationUpdate,
   deleteElements, applyZOrderToYjs,
 } from './yjs-mutations.ts';
+import { createTextEditController, type TextEditController } from './text-edit-controller.ts';
 
 export type InteractionController = {
   destroy: () => void;
   getSelection: () => SelectionState;
   applyZOrder: (reorderedElements: SlideElement[]) => void;
+  getTextEditController: () => import('./text-edit-controller.ts').TextEditController | null;
 };
 
 type InteractionContext = {
   ydoc: Y.Doc;
   viewport: HTMLElement;
   getActiveSlideElements: () => { yElements: Y.Array<Y.Map<unknown>>; elements: SlideElement[] };
+  onStyleUpdate?: (elementId: string, field: string, value: unknown) => void;
 };
 
 /** Convert a mouse event's pixel position to percentage coordinates within the viewport */
@@ -44,45 +47,54 @@ export function createInteractionController(ctx: InteractionContext): Interactio
   let rotateState: RotateState | null = null;
   let marqueeStart: Point | null = null;
 
+  const textEditCtrl: TextEditController | null = ctx.onStyleUpdate
+    ? createTextEditController(ctx.viewport, ctx.onStyleUpdate)
+    : null;
+
   function onSelectionChange() {
     const { elements } = ctx.getActiveSlideElements();
     const selected = elements.filter((el) => selection.selectedIds.has(el.id));
     renderHandles(ctx.viewport, selected);
   }
 
+  function handleDblClick(e: MouseEvent) {
+    if (!textEditCtrl) return;
+    const { elements } = ctx.getActiveSlideElements();
+    const hit = elementAtPoint(elements, mouseToPercent(e, ctx.viewport));
+    if (!hit || (hit.type !== 'text' && hit.type !== 'shape')) return;
+    const dom = ctx.viewport.querySelector(`[data-element-id="${hit.id}"]`);
+    if (dom instanceof HTMLElement) {
+      textEditCtrl.enterEditMode(hit.id, dom);
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  }
+
   function handleMouseDown(e: MouseEvent) {
     if (e.button !== 0) return;
+    if (textEditCtrl?.isEditing()) {
+      const target = e.target as HTMLElement;
+      const editingId = textEditCtrl.getEditingId();
+      const el = editingId ? ctx.viewport.querySelector(`[data-element-id="${editingId}"]`) : null;
+      if (el && !el.contains(target)) textEditCtrl.exitEditMode();
+      else if (el?.contains(target)) return; // let TipTap handle
+    }
     const percent = mouseToPercent(e, ctx.viewport);
     const target = e.target as HTMLElement;
 
-    // Resize handle click
     const handleAttr = target.dataset.resizeHandle as HandlePosition | undefined;
-    if (handleAttr && selection.selectedIds.size === 1) {
-      const { elements } = ctx.getActiveSlideElements();
-      const selId = [...selection.selectedIds][0];
-      const el = elements.find((el) => el.id === selId);
-      if (el) {
+    const singleSel = selection.selectedIds.size === 1 ? [...selection.selectedIds][0] : null;
+    if (singleSel && (handleAttr || target.dataset.rotateHandle)) {
+      const el = ctx.getActiveSlideElements().elements.find((el) => el.id === singleSel);
+      if (el && handleAttr) {
         mode = 'resizing';
-        resizeState = {
-          ...startResize({ x: el.x, y: el.y, width: el.width, height: el.height }, handleAttr, percent, e.shiftKey),
-          elementId: selId,
-        };
-        e.preventDefault();
-        return;
+        resizeState = { ...startResize({ x: el.x, y: el.y, width: el.width, height: el.height }, handleAttr, percent, e.shiftKey), elementId: singleSel };
+        e.preventDefault(); return;
       }
-    }
-
-    // Rotation handle click
-    if (target.dataset.rotateHandle && selection.selectedIds.size === 1) {
-      const { elements } = ctx.getActiveSlideElements();
-      const selId = [...selection.selectedIds][0];
-      const el = elements.find((el) => el.id === selId);
-      if (el) {
+      if (el && target.dataset.rotateHandle) {
         mode = 'rotating';
-        const center = getElementCenter(el.x, el.y, el.width, el.height);
-        rotateState = { ...startRotate(center, percent, el.rotation || 0), elementId: selId };
-        e.preventDefault();
-        return;
+        rotateState = { ...startRotate(getElementCenter(el.x, el.y, el.width, el.height), percent, el.rotation || 0), elementId: singleSel };
+        e.preventDefault(); return;
       }
     }
 
@@ -129,14 +141,16 @@ export function createInteractionController(ctx: InteractionContext): Interactio
 
   function handleMouseUp() {
     mode = 'idle';
-    dragState = null;
-    resizeState = null;
-    rotateState = null;
+    dragState = resizeState = rotateState = null;
     marqueeStart = null;
     clearOverlays(ctx.viewport, 'snap-guides');
   }
 
   function handleKeyDown(e: KeyboardEvent) {
+    if (textEditCtrl?.isEditing()) {
+      if (e.key === 'Escape') { e.preventDefault(); textEditCtrl.exitEditMode(); }
+      return;
+    }
     if (selection.selectedIds.size === 0) return;
     const dirs: Record<string, 'up' | 'down' | 'left' | 'right'> = {
       ArrowUp: 'up', ArrowDown: 'down', ArrowLeft: 'left', ArrowRight: 'right',
@@ -145,8 +159,7 @@ export function createInteractionController(ctx: InteractionContext): Interactio
     if (dir) {
       e.preventDefault();
       const amount = e.shiftKey ? NUDGE_LARGE : NUDGE_SMALL;
-      const { elements } = ctx.getActiveSlideElements();
-      const updates = nudgeElements(elements, [...selection.selectedIds], dir, amount);
+      const updates = nudgeElements(ctx.getActiveSlideElements().elements, [...selection.selectedIds], dir, amount);
       applyPositionUpdates(ctx.ydoc, ctx.getActiveSlideElements(), updates);
     }
     if (e.key === 'Delete' || e.key === 'Backspace') {
@@ -157,23 +170,26 @@ export function createInteractionController(ctx: InteractionContext): Interactio
     }
   }
 
-  ctx.viewport.addEventListener('mousedown', handleMouseDown);
+  const vp = ctx.viewport;
+  vp.addEventListener('mousedown', handleMouseDown);
+  vp.addEventListener('dblclick', handleDblClick);
+  vp.addEventListener('keydown', handleKeyDown);
+  vp.setAttribute('tabindex', '0');
   document.addEventListener('mousemove', handleMouseMove);
   document.addEventListener('mouseup', handleMouseUp);
-  ctx.viewport.addEventListener('keydown', handleKeyDown);
-  ctx.viewport.setAttribute('tabindex', '0');
 
   return {
     destroy() {
-      ctx.viewport.removeEventListener('mousedown', handleMouseDown);
+      vp.removeEventListener('mousedown', handleMouseDown);
+      vp.removeEventListener('dblclick', handleDblClick);
+      vp.removeEventListener('keydown', handleKeyDown);
       document.removeEventListener('mousemove', handleMouseMove);
       document.removeEventListener('mouseup', handleMouseUp);
-      ctx.viewport.removeEventListener('keydown', handleKeyDown);
-      clearOverlays(ctx.viewport, 'all');
+      textEditCtrl?.destroy();
+      clearOverlays(vp, 'all');
     },
     getSelection: () => selection,
-    applyZOrder(reorderedElements: SlideElement[]) {
-      applyZOrderToYjs(ctx.ydoc, ctx.getActiveSlideElements(), reorderedElements);
-    },
+    applyZOrder: (els: SlideElement[]) => applyZOrderToYjs(ctx.ydoc, ctx.getActiveSlideElements(), els),
+    getTextEditController: () => textEditCtrl,
   };
 }

--- a/modules/app/internal/slides/element-renderer.ts
+++ b/modules/app/internal/slides/element-renderer.ts
@@ -1,34 +1,61 @@
 /** Contract: contracts/app/slides-element-types.md */
 
 import type { SlideElement } from './types.ts';
-import { renderTextElement } from './render-text.ts';
+import { renderTextElement, type TextElementResult } from './render-text.ts';
 import { renderImageElement } from './render-image.ts';
-import { renderShapeElement } from './render-shape.ts';
+import { renderShapeElement, type ShapeElementResult } from './render-shape.ts';
 import { renderTableElement } from './render-table.ts';
+import type { MiniEditor } from './tiptap-mini-editor.ts';
 
 export type ContentUpdateHandler = (elementId: string, content: string) => void;
+export type StyleUpdateHandler = (elementId: string, field: string, value: unknown) => void;
 export type CellUpdateHandler = (elementId: string, row: number, col: number, value: string) => void;
+
+export type RenderResult = {
+  dom: HTMLElement;
+  miniEditor?: MiniEditor;
+};
 
 /** Render a slide element to a DOM node based on its type */
 export function renderElement(
   el: SlideElement,
   onContentUpdate: ContentUpdateHandler,
+  onStyleUpdate: StyleUpdateHandler,
   onCellUpdate: CellUpdateHandler,
-): HTMLElement {
+): RenderResult {
   switch (el.type) {
-    case 'text':
-      return renderTextElement(el, (content) => onContentUpdate(el.id, content));
+    case 'text': {
+      const result: TextElementResult = renderTextElement(
+        el,
+        (content) => onContentUpdate(el.id, content),
+        (field, value) => onStyleUpdate(el.id, field, value),
+      );
+      return { dom: result.dom, miniEditor: result.miniEditor };
+    }
 
     case 'image':
-      return renderImageElement(el);
+      return { dom: renderImageElement(el) };
 
-    case 'shape':
-      return renderShapeElement(el, (content) => onContentUpdate(el.id, content));
+    case 'shape': {
+      const result: ShapeElementResult = renderShapeElement(
+        el,
+        (content) => onContentUpdate(el.id, content),
+        (field, value) => onStyleUpdate(el.id, field, value),
+      );
+      return { dom: result.dom, miniEditor: result.miniEditor };
+    }
 
     case 'table':
-      return renderTableElement(el, (row, col, value) => onCellUpdate(el.id, row, col, value));
+      return {
+        dom: renderTableElement(el, (row, col, value) => onCellUpdate(el.id, row, col, value)),
+      };
 
     default:
-      return renderTextElement(el, (content) => onContentUpdate(el.id, content));
+      return renderElement(
+        { ...el, type: 'text' },
+        onContentUpdate,
+        onStyleUpdate,
+        onCellUpdate,
+      );
   }
 }

--- a/modules/app/internal/slides/parse-elements.ts
+++ b/modules/app/internal/slides/parse-elements.ts
@@ -19,6 +19,9 @@ export function parseSlideElements(yElements: Y.Array<Y.Map<unknown>>): SlideEle
       height: (el.get('height') as number) || 20,
       rotation: (el.get('rotation') as number) || 0,
       content: (el.get('content') as string) || '',
+      fontSize: el.get('fontSize') as number | undefined,
+      fontColor: el.get('fontColor') as string | undefined,
+      textAlign: el.get('textAlign') as SlideElement['textAlign'],
     };
 
     if (type === 'image') {

--- a/modules/app/internal/slides/render-shape.ts
+++ b/modules/app/internal/slides/render-shape.ts
@@ -1,12 +1,20 @@
 /** Contract: contracts/app/slides-element-types.md */
 
 import type { ShapeType, SlideElement } from './types.ts';
+import { createMiniEditor, applyTextStyles, TEXT_DEFAULTS, type MiniEditor } from './tiptap-mini-editor.ts';
+import type { TextElementDom } from './render-text.ts';
 
-/** Render a shape element using inline SVG */
+export type ShapeElementResult = {
+  dom: HTMLElement;
+  miniEditor: MiniEditor;
+};
+
+/** Render a shape element using inline SVG with TipTap text overlay */
 export function renderShapeElement(
   el: SlideElement,
-  onTextBlur: (content: string) => void,
-): HTMLElement {
+  onTextUpdate: (content: string) => void,
+  onStyleUpdate: (field: string, value: unknown) => void,
+): ShapeElementResult {
   const div = document.createElement('div');
   div.className = 'slide-element slide-element--shape';
   div.dataset.type = 'shape';
@@ -21,17 +29,28 @@ export function renderShapeElement(
   );
   div.appendChild(svg);
 
-  // Text overlay on shape
-  const textOverlay = document.createElement('div');
-  textOverlay.className = 'slide-shape-text';
-  textOverlay.contentEditable = 'true';
-  textOverlay.textContent = el.content || '';
-  textOverlay.addEventListener('blur', () => {
-    onTextBlur(textOverlay.textContent || '');
-  });
-  div.appendChild(textOverlay);
+  // TipTap text overlay on shape
+  const fontSize = el.fontSize ?? TEXT_DEFAULTS.fontSize;
+  const fontColor = el.fontColor ?? TEXT_DEFAULTS.fontColor;
+  const textAlign = el.textAlign ?? 'center'; // shapes default center
 
-  return div;
+  const miniEditor = createMiniEditor({
+    content: el.content || '',
+    fontSize,
+    fontColor,
+    textAlign,
+    onUpdate: (html) => onTextUpdate(html),
+  });
+
+  miniEditor.element.classList.add('slide-shape-text');
+
+  div.appendChild(miniEditor.element);
+
+  // Expose for interaction controller
+  (div as TextElementDom).__styleUpdate = onStyleUpdate;
+  (div as TextElementDom).__miniEditor = miniEditor;
+
+  return { dom: div, miniEditor };
 }
 
 function createShapeSvg(
@@ -54,7 +73,7 @@ function createShapeSvg(
   return svg;
 }
 
-function createShapePath(shapeType: ShapeType, svg: SVGSVGElement): SVGElement {
+function createShapePath(shapeType: ShapeType, _svg: SVGSVGElement): SVGElement {
   const ns = 'http://www.w3.org/2000/svg';
 
   switch (shapeType) {

--- a/modules/app/internal/slides/render-text.ts
+++ b/modules/app/internal/slides/render-text.ts
@@ -1,23 +1,55 @@
 /** Contract: contracts/app/slides-element-types.md */
 
 import type { SlideElement } from './types.ts';
+import { createMiniEditor, applyTextStyles, TEXT_DEFAULTS, type MiniEditor } from './tiptap-mini-editor.ts';
 
-/** Render a text element as a contentEditable div */
-export function renderTextElement(el: SlideElement, onBlur: (content: string) => void): HTMLElement {
+export type TextElementResult = {
+  dom: HTMLElement;
+  miniEditor: MiniEditor;
+};
+
+/** Render a text element with an embedded TipTap mini-editor */
+export function renderTextElement(
+  el: SlideElement,
+  onContentUpdate: (content: string) => void,
+  onStyleUpdate: (field: string, value: unknown) => void,
+): TextElementResult {
   const div = document.createElement('div');
-  div.className = 'slide-element';
+  div.className = 'slide-element slide-element--text';
   div.dataset.type = 'text';
   div.dataset.elementId = el.id;
   applyTransform(div, el);
-  div.contentEditable = 'true';
-  div.textContent = el.content;
 
-  div.addEventListener('blur', () => {
-    onBlur(div.textContent || '');
+  const fontSize = el.fontSize ?? TEXT_DEFAULTS.fontSize;
+  const fontColor = el.fontColor ?? TEXT_DEFAULTS.fontColor;
+  const textAlign = el.textAlign ?? TEXT_DEFAULTS.textAlign;
+
+  const miniEditor = createMiniEditor({
+    content: el.content,
+    fontSize,
+    fontColor,
+    textAlign,
+    onUpdate: (html) => onContentUpdate(html),
   });
 
-  return div;
+  div.appendChild(miniEditor.element);
+
+  // Store style update handler for toolbar use
+  div.dataset.fontSize = String(fontSize);
+  div.dataset.fontColor = fontColor;
+  div.dataset.textAlign = textAlign;
+
+  // Expose style updater via custom property
+  (div as TextElementDom).__styleUpdate = onStyleUpdate;
+  (div as TextElementDom).__miniEditor = miniEditor;
+
+  return { dom: div, miniEditor };
 }
+
+export type TextElementDom = HTMLElement & {
+  __styleUpdate?: (field: string, value: unknown) => void;
+  __miniEditor?: MiniEditor;
+};
 
 function applyTransform(div: HTMLElement, el: SlideElement): void {
   div.style.left = `${el.x}%`;
@@ -26,5 +58,22 @@ function applyTransform(div: HTMLElement, el: SlideElement): void {
   div.style.height = `${el.height}%`;
   if (el.rotation) {
     div.style.transform = `rotate(${el.rotation}deg)`;
+  }
+}
+
+/** Update text styles on an existing text element DOM */
+export function updateTextElementStyles(
+  dom: HTMLElement,
+  fontSize: number,
+  fontColor: string,
+  textAlign: string,
+): void {
+  const container = dom.querySelector('.slide-tiptap-container');
+  if (container instanceof HTMLElement) {
+    applyTextStyles(container, {
+      fontSize,
+      fontColor,
+      textAlign: textAlign as 'left' | 'center' | 'right',
+    });
   }
 }

--- a/modules/app/internal/slides/text-edit-controller.ts
+++ b/modules/app/internal/slides/text-edit-controller.ts
@@ -1,0 +1,100 @@
+/** Contract: contracts/app/slides-element-types.md */
+
+import type { MiniEditor } from './tiptap-mini-editor.ts';
+import { createFormatToolbar, type FormatToolbar } from './text-format-toolbar.ts';
+import { applyTextStyles } from './tiptap-mini-editor.ts';
+import type { TextAlign } from './types.ts';
+import type { TextElementDom } from './render-text.ts';
+
+export type TextEditState = {
+  elementId: string;
+  miniEditor: MiniEditor;
+  toolbar: FormatToolbar;
+};
+
+export type TextEditController = {
+  enterEditMode: (elementId: string, dom: HTMLElement) => void;
+  exitEditMode: () => void;
+  isEditing: () => boolean;
+  getEditingId: () => string | null;
+  destroy: () => void;
+};
+
+type StyleUpdateFn = (elementId: string, field: string, value: unknown) => void;
+
+/** Create a controller that manages text editing mode for slide elements */
+export function createTextEditController(
+  viewport: HTMLElement,
+  onStyleUpdate: StyleUpdateFn,
+): TextEditController {
+  let state: TextEditState | null = null;
+
+  function enterEditMode(elementId: string, dom: HTMLElement) {
+    // Exit any current edit first
+    exitEditMode();
+
+    const typedDom = dom as TextElementDom;
+    const miniEditor = typedDom.__miniEditor;
+    if (!miniEditor) return;
+
+    miniEditor.activate();
+    dom.classList.add('slide-element--editing');
+
+    const fontSize = Number(dom.dataset.fontSize) || 24;
+    const fontColor = dom.dataset.fontColor || '#000000';
+    const textAlign = (dom.dataset.textAlign || 'left') as TextAlign;
+
+    const toolbar = createFormatToolbar(miniEditor.editor, {
+      fontSize,
+      fontColor,
+      textAlign,
+      onFontSizeChange: (size) => {
+        onStyleUpdate(elementId, 'fontSize', size);
+        applyTextStyles(miniEditor.element, { fontSize: size, fontColor, textAlign });
+        dom.dataset.fontSize = String(size);
+      },
+      onFontColorChange: (color) => {
+        onStyleUpdate(elementId, 'fontColor', color);
+        applyTextStyles(miniEditor.element, { fontSize, fontColor: color, textAlign });
+        dom.dataset.fontColor = color;
+      },
+      onTextAlignChange: (align) => {
+        onStyleUpdate(elementId, 'textAlign', align);
+        applyTextStyles(miniEditor.element, { fontSize, fontColor, textAlign: align });
+        dom.dataset.textAlign = align;
+      },
+    });
+
+    viewport.parentElement?.insertBefore(toolbar.element, viewport);
+
+    // Update toolbar state when editor selection changes
+    miniEditor.editor.on('selectionUpdate', () => {
+      toolbar.update(miniEditor.editor);
+    });
+    miniEditor.editor.on('transaction', () => {
+      toolbar.update(miniEditor.editor);
+    });
+
+    state = { elementId, miniEditor, toolbar };
+  }
+
+  function exitEditMode() {
+    if (!state) return;
+    state.miniEditor.deactivate();
+    state.toolbar.destroy();
+
+    // Remove editing class from DOM
+    const editingEl = viewport.querySelector(`[data-element-id="${state.elementId}"]`);
+    if (editingEl) editingEl.classList.remove('slide-element--editing');
+
+    state = null;
+  }
+
+  return {
+    enterEditMode,
+    exitEditMode,
+    isEditing: () => state !== null,
+    getEditingId: () => state?.elementId ?? null,
+    destroy: () => exitEditMode(),
+  };
+}

--- a/modules/app/internal/slides/text-format-toolbar.ts
+++ b/modules/app/internal/slides/text-format-toolbar.ts
@@ -1,0 +1,170 @@
+/** Contract: contracts/app/slides-element-types.md */
+
+import type { Editor } from '@tiptap/core';
+import type { TextAlign } from './types.ts';
+
+export type FormatToolbarConfig = {
+  fontSize: number;
+  fontColor: string;
+  textAlign: TextAlign;
+  onFontSizeChange: (size: number) => void;
+  onFontColorChange: (color: string) => void;
+  onTextAlignChange: (align: TextAlign) => void;
+};
+
+export type FormatToolbar = {
+  element: HTMLElement;
+  update: (editor: Editor) => void;
+  destroy: () => void;
+};
+
+const FONT_SIZES = [12, 14, 16, 18, 20, 24, 28, 32, 36, 42, 48, 60, 72];
+
+/** Create a formatting toolbar for a text element in edit mode */
+export function createFormatToolbar(
+  editor: Editor,
+  config: FormatToolbarConfig,
+): FormatToolbar {
+  const bar = document.createElement('div');
+  bar.className = 'slide-format-toolbar';
+
+  // Bold
+  const boldBtn = createMarkButton(bar, 'B', 'bold', editor);
+  boldBtn.style.fontWeight = 'bold';
+
+  // Italic
+  const italicBtn = createMarkButton(bar, 'I', 'italic', editor);
+  italicBtn.style.fontStyle = 'italic';
+
+  // Underline
+  const underlineBtn = createMarkButton(bar, 'U', 'underline', editor);
+  underlineBtn.style.textDecoration = 'underline';
+
+  // Strikethrough
+  const strikeBtn = createMarkButton(bar, 'S', 'strike', editor);
+  strikeBtn.style.textDecoration = 'line-through';
+
+  addSeparator(bar);
+
+  // Font size dropdown
+  const fontSelect = createFontSizeSelect(config.fontSize, (size) => {
+    config.onFontSizeChange(size);
+  });
+  bar.appendChild(fontSelect);
+
+  // Color picker
+  const colorPicker = createColorPicker(config.fontColor, (color) => {
+    config.onFontColorChange(color);
+  });
+  bar.appendChild(colorPicker);
+
+  addSeparator(bar);
+
+  // Alignment buttons
+  const alignGroup = document.createElement('div');
+  alignGroup.className = 'slide-format-align-group';
+  createAlignButton(alignGroup, 'left', config, editor);
+  createAlignButton(alignGroup, 'center', config, editor);
+  createAlignButton(alignGroup, 'right', config, editor);
+  bar.appendChild(alignGroup);
+
+  function update(ed: Editor) {
+    boldBtn.classList.toggle('active', ed.isActive('bold'));
+    italicBtn.classList.toggle('active', ed.isActive('italic'));
+    underlineBtn.classList.toggle('active', ed.isActive('underline'));
+    strikeBtn.classList.toggle('active', ed.isActive('strike'));
+  }
+
+  update(editor);
+
+  return { element: bar, update, destroy: () => bar.remove() };
+}
+
+function createMarkButton(
+  parent: HTMLElement,
+  label: string,
+  mark: string,
+  editor: Editor,
+): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.className = 'slide-format-btn';
+  btn.type = 'button';
+  btn.textContent = label;
+  btn.addEventListener('mousedown', (e) => {
+    e.preventDefault(); // prevent blur
+    editor.chain().focus().toggleMark(mark).run();
+    btn.classList.toggle('active', editor.isActive(mark));
+  });
+  parent.appendChild(btn);
+  return btn;
+}
+
+function createFontSizeSelect(
+  current: number,
+  onChange: (size: number) => void,
+): HTMLSelectElement {
+  const select = document.createElement('select');
+  select.className = 'slide-format-font-size';
+  for (const size of FONT_SIZES) {
+    const opt = document.createElement('option');
+    opt.value = String(size);
+    opt.textContent = `${size}px`;
+    if (size === current) opt.selected = true;
+    select.appendChild(opt);
+  }
+  select.addEventListener('change', () => {
+    onChange(Number(select.value));
+  });
+  return select;
+}
+
+function createColorPicker(
+  current: string,
+  onChange: (color: string) => void,
+): HTMLInputElement {
+  const input = document.createElement('input');
+  input.type = 'color';
+  input.className = 'slide-format-color';
+  input.value = current;
+  input.addEventListener('input', () => {
+    onChange(input.value);
+  });
+  return input;
+}
+
+function createAlignButton(
+  parent: HTMLElement,
+  align: TextAlign,
+  config: FormatToolbarConfig,
+  _editor: Editor,
+): void {
+  const btn = document.createElement('button');
+  btn.className = 'slide-format-btn slide-format-align-btn';
+  btn.type = 'button';
+  btn.dataset.align = align;
+  if (config.textAlign === align) btn.classList.add('active');
+
+  const icons: Record<TextAlign, string> = {
+    left: '\u2261',    // hamburger-left
+    center: '\u2550',  // center lines
+    right: '\u2261',   // hamburger-right (mirrored via CSS)
+  };
+  btn.textContent = icons[align];
+  btn.title = `Align ${align}`;
+
+  btn.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    config.onTextAlignChange(align);
+    const siblings = parent.querySelectorAll('.slide-format-align-btn');
+    siblings.forEach((s) => s.classList.remove('active'));
+    btn.classList.add('active');
+  });
+
+  parent.appendChild(btn);
+}
+
+function addSeparator(parent: HTMLElement): void {
+  const sep = document.createElement('div');
+  sep.className = 'slide-format-separator';
+  parent.appendChild(sep);
+}

--- a/modules/app/internal/slides/text-format.css
+++ b/modules/app/internal/slides/text-format.css
@@ -1,0 +1,138 @@
+/* Text formatting toolbar and TipTap mini-editor styles */
+
+/* --- TipTap mini-editor container --- */
+.slide-tiptap-container {
+  width: 100%;
+  height: 100%;
+  outline: none;
+  overflow: hidden;
+  word-break: break-word;
+  cursor: default;
+}
+
+.slide-tiptap-container .tiptap {
+  width: 100%;
+  height: 100%;
+  outline: none;
+  padding: 0.25rem 0.5rem;
+}
+
+.slide-tiptap-container .tiptap p {
+  margin: 0;
+}
+
+.slide-tiptap-active {
+  cursor: text;
+}
+
+.slide-element--editing {
+  z-index: 100;
+}
+
+/* Shape text overlay with TipTap */
+.slide-shape-text.slide-tiptap-container {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+  padding: 0.5rem;
+}
+
+.slide-shape-text .tiptap {
+  padding: 0;
+}
+
+/* Text element default styling */
+.slide-element--text {
+  padding: 0;
+  overflow: hidden;
+}
+
+/* --- Format toolbar --- */
+.slide-format-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.375rem 0.5rem;
+  background: var(--surface, #fff);
+  border: 1px solid var(--border, #d1d5db);
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  margin-bottom: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.slide-format-btn {
+  width: 1.75rem;
+  height: 1.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  color: var(--text, #1f2937);
+  font-family: serif;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.slide-format-btn:hover {
+  background: var(--bg, #f3f4f6);
+  border-color: var(--border, #d1d5db);
+}
+
+.slide-format-btn.active {
+  background: var(--accent-light, #dbeafe);
+  border-color: var(--accent, #2563eb);
+  color: var(--accent, #2563eb);
+}
+
+.slide-format-separator {
+  width: 1px;
+  height: 1.25rem;
+  background: var(--border, #d1d5db);
+  margin: 0 0.125rem;
+}
+
+.slide-format-font-size {
+  height: 1.75rem;
+  padding: 0 0.25rem;
+  border: 1px solid var(--border, #d1d5db);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  background: var(--surface, #fff);
+  color: var(--text, #1f2937);
+  cursor: pointer;
+}
+
+.slide-format-color {
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  border: 1px solid var(--border, #d1d5db);
+  border-radius: 4px;
+  cursor: pointer;
+  background: transparent;
+}
+
+.slide-format-color::-webkit-color-swatch-wrapper {
+  padding: 2px;
+}
+
+.slide-format-color::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.slide-format-align-group {
+  display: flex;
+  gap: 0.125rem;
+}
+
+.slide-format-align-btn[data-align="right"] {
+  transform: scaleX(-1);
+}

--- a/modules/app/internal/slides/tiptap-mini-editor.ts
+++ b/modules/app/internal/slides/tiptap-mini-editor.ts
@@ -1,0 +1,95 @@
+/** Contract: contracts/app/slides-element-types.md */
+
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import Underline from '@tiptap/extension-underline';
+import type { TextAlign } from './types.ts';
+
+export type MiniEditorConfig = {
+  content: string;
+  fontSize: number;
+  fontColor: string;
+  textAlign: TextAlign;
+  onUpdate: (html: string) => void;
+};
+
+export type MiniEditor = {
+  editor: Editor;
+  element: HTMLElement;
+  destroy: () => void;
+  activate: () => void;
+  deactivate: () => void;
+  isActive: () => boolean;
+};
+
+/** Create a lightweight TipTap editor for a slide text element */
+export function createMiniEditor(config: MiniEditorConfig): MiniEditor {
+  const container = document.createElement('div');
+  container.className = 'slide-tiptap-container';
+  let active = false;
+
+  const editor = new Editor({
+    element: container,
+    extensions: [
+      StarterKit.configure({
+        // Disable features not needed in slides
+        heading: false,
+        blockquote: false,
+        bulletList: false,
+        orderedList: false,
+        codeBlock: false,
+        code: false,
+        horizontalRule: false,
+        dropcursor: false,
+        gapcursor: false,
+      }),
+      Underline,
+    ],
+    content: config.content || '',
+    editable: false,
+    onUpdate: ({ editor: ed }) => {
+      config.onUpdate(ed.getHTML());
+    },
+  });
+
+  applyTextStyles(container, config);
+
+  return {
+    editor,
+    element: container,
+    destroy: () => editor.destroy(),
+    activate: () => {
+      active = true;
+      editor.setEditable(true);
+      container.classList.add('slide-tiptap-active');
+      editor.commands.focus('end');
+    },
+    deactivate: () => {
+      active = false;
+      editor.setEditable(false);
+      container.classList.remove('slide-tiptap-active');
+    },
+    isActive: () => active,
+  };
+}
+
+/** Apply element-level text styles to the container */
+export function applyTextStyles(container: HTMLElement, config: Pick<MiniEditorConfig, 'fontSize' | 'fontColor' | 'textAlign'>): void {
+  container.style.fontSize = `${config.fontSize}px`;
+  container.style.color = config.fontColor;
+  container.style.textAlign = config.textAlign;
+}
+
+/** Default text formatting values */
+export const TEXT_DEFAULTS = {
+  fontSize: 24,
+  fontColor: '#000000',
+  textAlign: 'left' as TextAlign,
+};
+
+/** Default title formatting values */
+export const TITLE_DEFAULTS = {
+  fontSize: 36,
+  fontColor: '#000000',
+  textAlign: 'center' as TextAlign,
+};

--- a/modules/app/internal/slides/types.ts
+++ b/modules/app/internal/slides/types.ts
@@ -8,6 +8,8 @@ export type TableData = {
   cells: string[][];
 };
 
+export type TextAlign = 'left' | 'center' | 'right';
+
 export type SlideElement = {
   id: string;
   type: 'text' | 'shape' | 'image' | 'table';
@@ -17,6 +19,10 @@ export type SlideElement = {
   height: number;
   rotation: number;
   content: string;
+  // Text formatting (text + shape elements)
+  fontSize?: number;
+  fontColor?: string;
+  textAlign?: TextAlign;
   // Image elements
   src?: string;
   // Shape elements

--- a/modules/app/internal/slides/yjs-element-insert.ts
+++ b/modules/app/internal/slides/yjs-element-insert.ts
@@ -21,9 +21,16 @@ export function insertElement(
     yel.set('rotation', element.rotation);
     yel.set('content', element.content);
 
-    if (element.type === 'image') {
+    if (element.type === 'text') {
+      yel.set('fontSize', element.fontSize);
+      yel.set('fontColor', element.fontColor);
+      yel.set('textAlign', element.textAlign);
+    } else if (element.type === 'image') {
       yel.set('src', element.src);
     } else if (element.type === 'shape') {
+      yel.set('fontSize', element.fontSize);
+      yel.set('fontColor', element.fontColor);
+      yel.set('textAlign', element.textAlign);
       yel.set('shapeType', element.shapeType);
       yel.set('fill', element.fill);
       yel.set('stroke', element.stroke);

--- a/modules/app/internal/slides/yjs-mutations.ts
+++ b/modules/app/internal/slides/yjs-mutations.ts
@@ -85,6 +85,26 @@ export function deleteElements(
   });
 }
 
+/** Update a single field on a Yjs element */
+export function applyFieldUpdate(
+  ydoc: Y.Doc,
+  accessor: YjsElementAccessor,
+  elementId: string,
+  field: string,
+  value: unknown,
+): void {
+  const { yElements } = accessor;
+  ydoc.transact(() => {
+    for (let i = 0; i < yElements.length; i++) {
+      const yel = yElements.get(i);
+      if (yel.get('id') === elementId) {
+        yel.set(field, value);
+        break;
+      }
+    }
+  });
+}
+
 /** Reorder Yjs elements to match a new ordering */
 export function applyZOrderToYjs(
   ydoc: Y.Doc,


### PR DESCRIPTION
## Summary
- Adds rich text formatting (bold, italic, underline, font size, colour) inside slides text and shape elements
- Builds on the element-types and element-interaction work already in dev

## Test plan
- [ ] Select text inside a slide text element, apply bold/italic
- [ ] Change font size on a shape text element
- [ ] Verify colour picker works for text
- [ ] No regressions on non-text elements (image, table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)