### PR TITLE
fix(app-slides): correct animation step sequencing and plug destroy leak

### DIFF
--- a/modules/app-slides/internal/animation-engine.ts
+++ b/modules/app-slides/internal/animation-engine.ts
@@ -91,24 +91,20 @@ export function runAnimation(anim: ElementAnimation, resolve: ElementResolver): 
 }
 
 /**
- * Run a step. Items chained "after-previous" wait for the prior item; items
- * chained "with-previous" run in parallel. The first item in the step always
- * starts immediately (its trigger is the click that opened the step).
+ * Run a step. "with-previous" items join the current parallel group;
+ * "after-previous" items start a new group that waits for the prior group to finish.
+ * Groups execute sequentially; items within a group execute in parallel.
  */
 export async function runStep(step: AnimationStep, resolve: ElementResolver): Promise<void> {
-  // Group items into parallel lanes. A new lane begins on the first item or any after-previous.
-  const lanes: ElementAnimation[][] = [];
+  const groups: ElementAnimation[][] = [];
   for (let i = 0; i < step.items.length; i++) {
     const a = step.items[i];
-    if (i === 0 || a.trigger === 'after-previous') lanes.push([a]);
-    else lanes[lanes.length - 1].push(a);
+    if (i === 0 || a.trigger === 'after-previous') groups.push([a]);
+    else groups[groups.length - 1].push(a);
   }
-  const lanePromises = lanes.map(async (lane) => {
-    for (const item of lane) {
-      await runAnimation(item, resolve);
-    }
-  });
-  await Promise.all(lanePromises);
+  for (const group of groups) {
+    await Promise.all(group.map((item) => runAnimation(item, resolve)));
+  }
 }
 
 /**

--- a/modules/app-slides/internal/presentation-editor.ts
+++ b/modules/app-slides/internal/presentation-editor.ts
@@ -140,7 +140,7 @@ export function initSlides(documentId: string, els: SlidesElements): SlidesClean
   });
 
   // Animation panel — sidebar for managing element animations
-  initAnimations({
+  const animationInit = initAnimations({
     ydoc, yslides, canvasEl, toolbarRight,
     getActiveSlideIndex: () => activeSlideIndex,
     getInteractionController: () => interactionCtrl,
@@ -176,6 +176,7 @@ export function initSlides(documentId: string, els: SlidesElements): SlidesClean
 
   return {
     destroy() {
+      animationInit.destroy();
       interactionCtrl?.destroy();
       interactionCtrl = null;
       provider.destroy();


### PR DESCRIPTION
## Summary

- **#486** `runStep` had with-previous/after-previous semantics completely inverted. The old lane model ran `after-previous` items in parallel (new lane) and `with-previous` items sequentially (same lane) — the exact opposite of their meaning. Replaced with a sequential-groups model: `after-previous` starts a new group (groups execute sequentially); `with-previous` joins the current group (items within a group execute in parallel). This matches standard presentation software behaviour.
- **#487** `initAnimations()` return value was discarded at the call site in `presentation-editor.ts`. The `AnimationInitResult.destroy()` method was therefore never called on editor teardown, leaking both the Yjs deep observer inside the animation panel and the toggle button DOM node. Captured the return value and wired `animationInit.destroy()` into `SlidesCleanup.destroy()`.

## Test plan

- [ ] Create a slide with 3 elements, assign animations: A (on-click/first), B (with-previous), C (after-previous)
- [ ] In presenter mode, advance once — A and B should play simultaneously; C should play only after both finish
- [ ] Assign A (first), B (after-previous), C (with-previous) — A plays alone, then B and C play together
- [ ] Open and close the animation panel; navigate away (destroy) — no console errors about destroyed Yjs doc or orphaned DOM nodes

Closes #486
Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)