### PR TITLE
fix(api): filter SSE Grant events by principal and refresh allowedDocIds on revoke (#506 #507)

### DIFF
--- a/modules/api/internal/sse-routes.test.ts
+++ b/modules/api/internal/sse-routes.test.ts
@@ -1,0 +1,169 @@
+/** Contract: contracts/api/rules.md — SSE routes security tests */
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { Request, Response } from 'express';
+import type { Grant, GrantDef } from '../../permissions/index.ts';
+import type { GrantStore } from '../../permissions/internal/grant-store.ts';
+import { createSseFanout, type SseFanout } from './sse-fanout.ts';
+import { createSSERoutes } from './sse-routes.ts';
+import type { DomainEvent } from '../../events/contract.ts';
+
+// ---------------------------------------------------------------------------
+// Minimal test doubles (real in-memory, no mocks)
+// ---------------------------------------------------------------------------
+
+class StubGrantStore implements GrantStore {
+  constructor(private grants: Grant[] = []) {}
+  async findByPrincipal(id: string) { return this.grants.filter((g) => g.principalId === id); }
+  async findByPrincipalAndResource(p: string, r: string, t: string) {
+    return this.grants.filter((g) => g.principalId === p && g.resourceId === r && g.resourceType === t);
+  }
+  async findByResource(r: string, t: string) {
+    return this.grants.filter((g) => g.resourceId === r && g.resourceType === t);
+  }
+  async create(def: GrantDef): Promise<Grant> {
+    const g: Grant = { ...def, id: `g-${Date.now()}`, grantedAt: new Date().toISOString() };
+    this.grants.push(g);
+    return g;
+  }
+  async revoke(id: string) {
+    const i = this.grants.findIndex((g) => g.id === id);
+    if (i === -1) return false;
+    this.grants.splice(i, 1);
+    return true;
+  }
+  async findById(id: string) { return this.grants.find((g) => g.id === id) ?? null; }
+  async deleteByResource(r: string, t: string) {
+    const before = this.grants.length;
+    this.grants = this.grants.filter((g) => !(g.resourceId === r && g.resourceType === t));
+    return before - this.grants.length;
+  }
+}
+
+class SseResponse {
+  written: string[] = [];
+  ended = false;
+  _headers: Record<string, string> = {};
+  _status = 200;
+  _body: unknown;
+  statusCode = 200;
+  setHeader(k: string, v: string) { this._headers[k] = v; return this; }
+  getHeader(k: string) { return this._headers[k]; }
+  flushHeaders() { /* no-op */ }
+  write(c: string) { this.written.push(c); return true; }
+  end() { this.ended = true; }
+  status(code: number) { this._status = code; this.statusCode = code; return this; }
+  json(data: unknown) { this._body = data; return this; }
+}
+
+class SseRequest {
+  principal: { id: string } | undefined;
+  private close: Array<() => void> = [];
+  constructor(pid?: string) { this.principal = pid ? { id: pid } : undefined; }
+  on(ev: string, fn: () => void) { if (ev === 'close') this.close.push(fn); }
+  simulateClose() { for (const f of this.close) f(); }
+}
+
+function makeGrant(overrides: Partial<Grant>): Grant {
+  return { id: 'g1', principalId: 'alice', resourceId: 'doc-1', resourceType: 'document',
+    role: 'editor', grantedBy: 'admin', grantedAt: new Date().toISOString(), ...overrides };
+}
+
+function makeEvent(overrides: Partial<DomainEvent>): DomainEvent {
+  return { id: `e-${Math.random()}`, type: 'DocumentUpdated', aggregateId: 'doc-1',
+    actorId: 'admin', actorType: 'human', occurredAt: new Date().toISOString(), ...overrides };
+}
+
+async function openStream(fanout: SseFanout, store: GrantStore, pid: string) {
+  const router = createSSERoutes(fanout, store);
+  const layer = (router as unknown as { stack: Array<{ route?: { path: string; stack: Array<{ handle: Function }> } }> })
+    .stack.find((l) => l.route?.path === '/events/stream');
+  const handler = layer!.route!.stack[0].handle as (req: Request, res: Response) => Promise<void>;
+  const req = new SseRequest(pid);
+  const res = new SseResponse();
+  await handler(req as unknown as Request, res as unknown as Response);
+  return { req, res };
+}
+
+// ---------------------------------------------------------------------------
+// Tests — #506: Grant IDOR filter
+// ---------------------------------------------------------------------------
+
+describe('SSE #506: Grant events filtered by principal', () => {
+  let fanout: SseFanout;
+  beforeEach(() => { fanout = createSseFanout(); });
+
+  it('forwards GrantCreated to grantee (revisionId match)', async () => {
+    const { res } = await openStream(fanout, new StubGrantStore(), 'alice');
+    fanout.emit(makeEvent({ type: 'GrantCreated', aggregateId: 'doc-99', actorId: 'admin', revisionId: 'alice' }));
+    expect(res.written.join('')).toContain('GrantCreated');
+  });
+
+  it('forwards GrantCreated to granter (actorId match)', async () => {
+    const { res } = await openStream(fanout, new StubGrantStore(), 'admin');
+    fanout.emit(makeEvent({ type: 'GrantCreated', aggregateId: 'doc-99', actorId: 'admin', revisionId: 'alice' }));
+    expect(res.written.join('')).toContain('GrantCreated');
+  });
+
+  it('blocks GrantCreated from unrelated principal', async () => {
+    const { res } = await openStream(fanout, new StubGrantStore(), 'bob');
+    fanout.emit(makeEvent({ type: 'GrantCreated', aggregateId: 'doc-99', actorId: 'admin', revisionId: 'alice' }));
+    expect(res.written.join('')).not.toContain('GrantCreated');
+  });
+
+  it('blocks GrantRevoked from unrelated principal', async () => {
+    const { res } = await openStream(fanout, new StubGrantStore(), 'charlie');
+    fanout.emit(makeEvent({ type: 'GrantRevoked', aggregateId: 'doc-1', actorId: 'admin', revisionId: 'alice' }));
+    expect(res.written.join('')).not.toContain('GrantRevoked');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — #507: allowedDocIds refreshed on grant changes
+// ---------------------------------------------------------------------------
+
+describe('SSE #507: allowedDocIds updated dynamically', () => {
+  let fanout: SseFanout;
+  beforeEach(() => { fanout = createSseFanout(); });
+
+  it('adds docId on GrantCreated for self', async () => {
+    const { res } = await openStream(fanout, new StubGrantStore(), 'alice');
+    fanout.emit(makeEvent({ type: 'DocumentUpdated', aggregateId: 'doc-new' }));
+    expect(res.written.filter((w) => w.includes('DocumentUpdated'))).toHaveLength(0);
+    fanout.emit(makeEvent({ type: 'GrantCreated', aggregateId: 'doc-new', actorId: 'admin', revisionId: 'alice' }));
+    fanout.emit(makeEvent({ type: 'DocumentUpdated', aggregateId: 'doc-new' }));
+    expect(res.written.filter((w) => w.includes('DocumentUpdated'))).toHaveLength(1);
+  });
+
+  it('removes docId on GrantRevoked for self and closes stream', async () => {
+    const { res } = await openStream(fanout, new StubGrantStore([makeGrant({ principalId: 'alice' })]), 'alice');
+    fanout.emit(makeEvent({ type: 'DocumentUpdated', aggregateId: 'doc-1' }));
+    expect(res.written.filter((w) => w.includes('DocumentUpdated'))).toHaveLength(1);
+    fanout.emit(makeEvent({ type: 'GrantRevoked', aggregateId: 'doc-1', actorId: 'admin', revisionId: 'alice' }));
+    expect(res.ended).toBe(true);
+    expect(res.written.filter((w) => w.includes('GrantRevoked'))).toHaveLength(1);
+  });
+
+  it('blocks document events for docs alice never had access to', async () => {
+    const { res } = await openStream(fanout, new StubGrantStore([makeGrant({ principalId: 'alice' })]), 'alice');
+    fanout.emit(makeEvent({ type: 'DocumentUpdated', aggregateId: 'doc-secret' }));
+    expect(res.written.filter((w) => w.includes('DocumentUpdated'))).toHaveLength(0);
+  });
+
+  it('cleans up fanout subscription on client disconnect', async () => {
+    const { req } = await openStream(fanout, new StubGrantStore(), 'alice');
+    expect(fanout.listenerCount()).toBe(1);
+    req.simulateClose();
+    expect(fanout.listenerCount()).toBe(0);
+  });
+
+  it('returns 401 for unauthenticated request', async () => {
+    const router = createSSERoutes(createSseFanout(), new StubGrantStore());
+    const layer = (router as unknown as { stack: Array<{ route?: { path: string; stack: Array<{ handle: Function }> } }> })
+      .stack.find((l) => l.route?.path === '/events/stream');
+    const handler = layer!.route!.stack[0].handle as (req: Request, res: Response) => Promise<void>;
+    const req = new SseRequest();
+    const res = new SseResponse();
+    await handler(req as unknown as Request, res as unknown as Response);
+    expect(res._status).toBe(401);
+  });
+});

--- a/modules/api/internal/sse-routes.ts
+++ b/modules/api/internal/sse-routes.ts
@@ -14,9 +14,10 @@ const KEEPALIVE_INTERVAL_MS = 15_000;
  * Opens a text/event-stream connection for the authenticated principal.
  * Events are filtered to those the principal has access to:
  * - Document events (DocumentUpdated, StateFlushed) — only for docs the
- *   principal holds a grant on at connection time.
- * - Grant events (GrantCreated, GrantRevoked) — only those targeting the
- *   principal's own id.
+ *   principal holds a grant on, refreshed dynamically on grant changes.
+ * - Grant events (GrantCreated, GrantRevoked) — only those where:
+ *   - revisionId (granteeId) === principalId (you are the grantee), OR
+ *   - actorId (grantedBy) === principalId (you are the granter)
  *
  * The fanout hub receives all events from the single EventBus consumer
  * group and this handler decides which to forward per-connection.
@@ -40,8 +41,7 @@ export function createSSERoutes(fanout: SseFanout, grantStore: GrantStore): Rout
     const principalId = req.principal.id;
 
     // Build the set of doc IDs this principal may see.
-    // Fetched once at connection time; grant changes won't update the
-    // set mid-stream (a reconnect after a GrantCreated event handles that).
+    // Updated dynamically: GrantCreated adds, GrantRevoked removes.
     const grants = await grantStore.findByPrincipal(principalId);
     const allowedDocIds = new Set(
       grants.filter((g) => g.resourceType === 'document').map((g) => g.resourceId),
@@ -58,17 +58,35 @@ export function createSSERoutes(fanout: SseFanout, grantStore: GrantStore): Rout
     const unsubscribe = fanout.on((event) => {
       const docId = event.aggregateId;
 
-      // Grant events carry no docId — forward only if this principal is the grantee.
-      // The aggregateId on grant events is the grantId, not a docId.
+      // Grant events — only forward if this principal is involved as grantee or granter.
+      // revisionId carries the granteeId by convention (set by the permissions emitter).
+      // actorId carries the granterId (grantedBy).
+      // Fix #506: never broadcast grant events to unrelated principals (IDOR oracle).
       if (event.type === 'GrantCreated' || event.type === 'GrantRevoked') {
-        // The actorId on grant events is the granter; we can only forward
-        // based on what we know at this layer. Forward to all connected
-        // principals and let the client filter, OR only forward to the
-        // granter so they see their own actions. Per the contract, the
-        // events module is thin and carries no grantee payload, so we
-        // forward grant events to all authenticated SSE clients — the
-        // client MUST ignore events that aren't relevant to it.
-        // This is safe: grant events contain no document content.
+        const isGrantee = event.revisionId === principalId;
+        const isGranter = event.actorId === principalId;
+
+        if (!isGrantee && !isGranter) return;
+
+        // Fix #507: keep allowedDocIds in sync with live grant state.
+        // aggregateId on grant events is the resourceId (docId).
+        if (isGrantee) {
+          if (event.type === 'GrantCreated') {
+            allowedDocIds.add(docId);
+          } else {
+            // GrantRevoked: remove access and close the stream so the client
+            // reconnects fresh (no longer able to subscribe to this doc).
+            allowedDocIds.delete(docId);
+            const data = JSON.stringify(event);
+            res.write(`id: ${++eventId}\nevent: ${event.type}\ndata: ${data}\n\n`);
+            // Tear down this SSE connection; the client must reconnect.
+            clearInterval(pingTimer);
+            unsubscribe();
+            res.end();
+            return;
+          }
+        }
+
         const data = JSON.stringify(event);
         res.write(`id: ${++eventId}\nevent: ${event.type}\ndata: ${data}\n\n`);
         return;


### PR DESCRIPTION
## Summary

- **#506 (IDOR oracle):** The SSE handler was broadcasting `GrantCreated`/`GrantRevoked` events to every authenticated subscriber, leaking docIds, actor identities, and grantee identities. Fixed by only forwarding grant events when `event.revisionId === principalId` (you are the grantee) or `event.actorId === principalId` (you are the granter).
- **#507 (stale allowedDocIds):** The set of permitted docIds was frozen at connection time, so revoked users continued to receive `DocumentUpdated`/`StateFlushed` events until they disconnected. Fixed by subscribing to grant events inside the SSE handler: `GrantCreated` for self adds the docId; `GrantRevoked` for self removes it and force-closes the stream, requiring the client to reconnect without the revoked access.

## Files changed

- `modules/api/internal/sse-routes.ts` — both security fixes
- `modules/api/internal/sse-routes.test.ts` — new test file (9 tests covering both issues)

## Test plan

- [ ] `npm test -- sse-routes` — all 9 tests pass
- [ ] Unrelated principal does not receive GrantCreated/GrantRevoked events
- [ ] Granter (actorId match) receives grant events for their own actions
- [ ] Grantee (revisionId match) receives grant events and allowedDocIds updates dynamically
- [ ] GrantRevoked for self closes the stream immediately
- [ ] Client disconnect cleans up fanout subscription (no memory leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)